### PR TITLE
Fix Pre-Commit Hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,11 @@
     "ts-jest": "^25.4.0",
     "typescript": "^3.8.3"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
   "lint-staged": {
     "*.*": "prettier --write",
     "*.{css,scss}": "stylelint --fix",
@@ -65,7 +70,6 @@
   "scripts": {
     "analyze": "cross-env ANALYZE=true next build",
     "build": "next build",
-    "precommit": "lint-staged",
     "dev": "next",
     "format": "prettier --write .",
     "format:check": "prettier --check .",


### PR DESCRIPTION
It didn't seem like the pre-commit hook was actually running although I was using the same configuration on other projects I use it with.

I found out that we can see the calls to the lint-staged commands by looking at the Git console in VS Code.

## How has this been tested?

After committing, I can see in the Git console that the calls to the lint-staged commands were being made.