### PR TITLE
Skip auth in non-production environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,9 @@ jobs:
                   libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
                   fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
             - run:
+                name: Configure local host mapping
+                command: echo 127.0.0.1 a8c-abacus-local | sudo tee -a /etc/hosts
+            - run:
                 name: Format Checking
                 command: npm run format:check
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,10 +36,9 @@ jobs:
             - run:
                 name: Unit Testing
                 command: npm run test:unit -- --ci --coverage
-            # Temporarily disabled until we figure out how to test authorisation on CircleCI
-            # - run:
-            #    name: End-to-End Testing
-            #    command: npm run test:e2e -- --ci
+            - run:
+                name: End-to-End Testing
+                command: npm run test:e2e -- --ci
 
 workflows:
   build-and-verify:

--- a/e2e/smoke.test.tsx
+++ b/e2e/smoke.test.tsx
@@ -9,10 +9,18 @@ describe('Experiments', () => {
     await page.goto('http://a8c-abacus-local:3000')
   })
 
-  it('should display "Abacus - Testing" text on page from WordPress.com.', async () => {
+  // Temporarily disabled until we decide how to test the full auth flow.
+  xit('should display "Abacus - Testing" text on page from WordPress.com.', async () => {
     // This is because we expect that the user has not authenticated yet and they
     // should be redirected to the WP.com log-in page.
     expect(page.url()).toMatch(/^https:\/\/wordpress.com\/log-in/)
     await expect(page).toMatch('Abacus - Testing')
+  })
+
+  // In non-production contexts, we should see the main page immediately.
+  it('should skip authentication and show the main page.', async () => {
+    await expect(page.title()).resolves.toMatch('Experiments | Abacus')
+
+    // TODO: make more interesting assertions once there is more content to display
   })
 })

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,7 +3,7 @@ import { AppProps } from 'next/app'
 import qs from 'querystring'
 import React from 'react'
 
-import { getAuthClientId, getExperimentsAuthInfo } from '@/utils/auth'
+import { getAuthClientId, getExperimentsAuthInfo, saveExperimentsAuthInfo } from '@/utils/auth'
 
 const debug = debugFactory('abacus:pages/_app.tsx')
 
@@ -12,6 +12,17 @@ const App = React.memo(function App(props: AppProps) {
   const { Component: Route, pageProps: routeProps } = props
 
   if (typeof window !== 'undefined') {
+    // Inject a fake auth token to skip authentication in non-production contexts.
+    // This is a temporary solution. Ideally, we should test the full authentication flow in every environment.
+    if (window.location.host !== 'experiments.a8c.com') {
+      saveExperimentsAuthInfo({
+        accessToken: 'fake_token',
+        expiresAt: Date.parse('2100-01-01'),
+        scope: 'global',
+        type: 'bearer',
+      })
+    }
+
     // Prompt user for authorization if we don't have auth info.
     const experimentsAuthInfo = getExperimentsAuthInfo()
     if (!experimentsAuthInfo) {

--- a/pages/auth.tsx
+++ b/pages/auth.tsx
@@ -37,7 +37,7 @@ const AuthPage = function AuthPage() {
           }
           saveExperimentsAuthInfo(experimentsAuthInfo)
 
-          window.location.assign(window.location.origin)
+          window.location.replace(window.location.origin)
         } else if (authInfo.error === 'access_denied') {
           setError('Please log into WordPress.com and authorize Abacus - Testing to have access.')
 


### PR DESCRIPTION
Fix #55 and resolve #56 by injecting a fake auth token in non-production environments. This also includes re-enabling e2e tests on CircleCI.

## How has this been tested?

* Locally: `npm run verify`
* Manual check that there is no redirect to authenticate when running locally
* Manual check that the Vercel deployment works
* Manual check that the CircleCI build passes