### PR TITLE
Update metric and segment assignment models to match API

### DIFF
--- a/models/MetricAssignment.ts
+++ b/models/MetricAssignment.ts
@@ -1,5 +1,3 @@
-import { Metric } from './index'
-
 /**
  * An assignment of a metric to an experiment.
  */
@@ -18,8 +16,6 @@ export interface MetricAssignment {
    * ID of the metric assigned to the experiment.
    */
   metricId: number
-
-  metric: Metric
 
   /**
    * `true` if this metric is the primary metric for `experiment_id`. An experiment

--- a/models/SegmentAssignment.ts
+++ b/models/SegmentAssignment.ts
@@ -1,5 +1,3 @@
-import { Segment } from './index'
-
 /**
  * An assignment of a segment to an experiment.
  */
@@ -18,8 +16,6 @@ export interface SegmentAssignment {
    * ID of the segment assigned to the experiment.
    */
   segmentId: number
-
-  segment: Segment
 
   /**
    * If `true`, users in this segment should be excluded from the experiment.


### PR DESCRIPTION
The API doesn't actually return the metric and segment objects with their assignments. This PR changes the models accordingly.

## How has this been tested?

`npm install && npm run verify`