### PR TITLE
Add result page and update navigation and layout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     executor:
       name: node/default
       tag: '10.18.1'
-      size: large
+    resource_class: large
     steps:
       - checkout
       - node/with-cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ jobs:
     executor:
       name: node/default
       tag: '10.18.1'
-    resource_class: large
     steps:
       - checkout
       - node/with-cache:
@@ -39,7 +38,7 @@ jobs:
                 command: npm run lint
             - run:
                 name: Unit Testing
-                command: npm run test:unit -- --ci --coverage
+                command: npm run test:unit -- --ci --coverage --maxWorkers 2
             - run:
                 name: Integration Testing
                 command: npm run test:integration -- --ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
     executor:
       name: node/default
       tag: '10.18.1'
+      size: large
     steps:
       - checkout
       - node/with-cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,10 +41,10 @@ jobs:
                 command: npm run test:unit -- --ci --coverage --maxWorkers 2
             - run:
                 name: Integration Testing
-                command: npm run test:integration -- --ci --maxWorkers 2
+                command: npm run test:integration -- --ci
             - run:
                 name: End-to-End Testing
-                command: npm run test:e2e -- --ci --maxWorkers 2
+                command: npm run test:e2e -- --ci
 
 workflows:
   build-and-verify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,10 +41,10 @@ jobs:
                 command: npm run test:unit -- --ci --coverage --maxWorkers 2
             - run:
                 name: Integration Testing
-                command: npm run test:integration -- --ci
+                command: npm run test:integration -- --ci --maxWorkers 2
             - run:
                 name: End-to-End Testing
-                command: npm run test:e2e -- --ci
+                command: npm run test:e2e -- --ci --maxWorkers 2
 
 workflows:
   build-and-verify:

--- a/components/AnalysisSummary.test.tsx
+++ b/components/AnalysisSummary.test.tsx
@@ -182,18 +182,3 @@ test('shows the analyses JSON in debug mode', () => {
   )
   expect(container.querySelector('pre')).not.toBeNull()
 })
-
-// if (analyses.length === 0) {
-//   return <h2>No analyses yet for {experiment.name}.</h2>
-// }
-//
-// return (
-//   <>
-//     <h2>Analysis summary</h2>
-//     <p>
-//       Found {analyses.length} analysis objects in total. There are {metrics.length} metrics in the system.
-//     </p>
-//
-//     {debugMode ? <pre>{JSON.stringify(analyses, null, 2)}</pre> : ''}
-//   </>
-// )

--- a/components/AnalysisSummary.test.tsx
+++ b/components/AnalysisSummary.test.tsx
@@ -1,0 +1,199 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+
+import AnalysisSummary from './AnalysisSummary'
+import {
+  Analysis,
+  AnalysisStrategy,
+  AttributionWindowSeconds,
+  ExperimentFull,
+  MetricAssignment,
+  Platform,
+  RecommendationReason,
+  Status,
+  Variation,
+} from '@/models'
+
+const experiment: ExperimentFull = new ExperimentFull({
+  experimentId: 1,
+  name: 'experiment_1',
+  startDatetime: new Date(2020, 5, 4),
+  endDatetime: new Date(2020, 6, 4),
+  status: Status.Completed,
+  platform: Platform.Calypso,
+  ownerLogin: 'test_a11n',
+  description: 'Experiment with things. Change stuff. Profit.',
+  existingUsersAllowed: false,
+  p2Url: 'https://wordpress.com/experiment_1',
+  exposureEvents: null,
+  variations: [
+    new Variation({
+      variationId: 2,
+      name: 'test',
+      isDefault: false,
+      allocatedPercentage: 40,
+    }),
+    new Variation({
+      variationId: 1,
+      name: 'control',
+      isDefault: true,
+      allocatedPercentage: 60,
+    }),
+  ],
+  metricAssignments: [
+    new MetricAssignment({
+      metricAssignmentId: 123,
+      metricId: 1,
+      experimentId: 1,
+      attributionWindowSeconds: AttributionWindowSeconds.OneWeek,
+      changeExpected: true,
+      isPrimary: true,
+      minDifference: 0.1,
+    }),
+  ],
+  segmentAssignments: [],
+})
+const analyses: Analysis[] = [
+  new Analysis({
+    metricAssignmentId: 123,
+    analysisStrategy: AnalysisStrategy.IttPure,
+    participantStats: {
+      total: 1000,
+      not_final: 100,
+      variation_1: 600,
+      variation_2: 400,
+    },
+    metricEstimates: {
+      diff: { estimate: 0.0, bottom: -0.01, top: 0.01 },
+      variation_1: { estimate: 0.12, bottom: 0, top: 10.0 },
+      variation_2: { estimate: -0.12, bottom: -1.123, top: 1.0 },
+    },
+    recommendation: {
+      endExperiment: true,
+      chosenVariationId: 2,
+      reason: RecommendationReason.CiInRope,
+      warnings: [],
+    },
+    analysisDatetime: new Date(2020, 4, 10),
+  }),
+  new Analysis({
+    metricAssignmentId: 123,
+    analysisStrategy: AnalysisStrategy.MittNoCrossovers,
+    participantStats: {
+      total: 900,
+      not_final: 90,
+      variation_1: 540,
+      variation_2: 360,
+    },
+    metricEstimates: {
+      diff: { estimate: 0.0, bottom: -0.01, top: 0.01 },
+      variation_1: { estimate: 0.12, bottom: 0, top: 10.0 },
+      variation_2: { estimate: -0.12, bottom: -1.123, top: 1.0 },
+    },
+    recommendation: {
+      endExperiment: true,
+      chosenVariationId: 2,
+      reason: RecommendationReason.CiInRope,
+      warnings: [],
+    },
+    analysisDatetime: new Date(2020, 4, 10),
+  }),
+  new Analysis({
+    metricAssignmentId: 123,
+    analysisStrategy: AnalysisStrategy.MittNoSpammers,
+    participantStats: {
+      total: 850,
+      not_final: 85,
+      variation_1: 510,
+      variation_2: 340,
+    },
+    metricEstimates: {
+      diff: { estimate: 0.0, bottom: -0.01, top: 0.01 },
+      variation_1: { estimate: 0.12, bottom: 0, top: 10.0 },
+      variation_2: { estimate: -0.12, bottom: -1.123, top: 1.0 },
+    },
+    recommendation: {
+      endExperiment: true,
+      chosenVariationId: 2,
+      reason: RecommendationReason.CiInRope,
+      warnings: [],
+    },
+    analysisDatetime: new Date(2020, 4, 10),
+  }),
+  new Analysis({
+    metricAssignmentId: 123,
+    analysisStrategy: AnalysisStrategy.MittNoSpammersNoCrossovers,
+    participantStats: {
+      total: 800,
+      not_final: 80,
+      variation_1: 480,
+      variation_2: 320,
+    },
+    metricEstimates: {
+      diff: { estimate: 0.0, bottom: -0.01, top: 0.01 },
+      variation_1: { estimate: 0.12, bottom: 0, top: 10.0 },
+      variation_2: { estimate: -0.12, bottom: -1.123, top: 1.0 },
+    },
+    recommendation: {
+      endExperiment: true,
+      chosenVariationId: 2,
+      reason: RecommendationReason.CiInRope,
+      warnings: [],
+    },
+    analysisDatetime: new Date(2020, 4, 10),
+  }),
+  new Analysis({
+    metricAssignmentId: 123,
+    analysisStrategy: AnalysisStrategy.PpNaive,
+    participantStats: {
+      total: 700,
+      not_final: 70,
+      variation_1: 420,
+      variation_2: 280,
+    },
+    metricEstimates: {
+      diff: { estimate: 0.0, bottom: -0.01, top: 0.01 },
+      variation_1: { estimate: 0.12, bottom: 0, top: 10.0 },
+      variation_2: { estimate: -0.12, bottom: -1.123, top: 1.0 },
+    },
+    recommendation: {
+      endExperiment: true,
+      chosenVariationId: 2,
+      reason: RecommendationReason.CiInRope,
+      warnings: [],
+    },
+    analysisDatetime: new Date(2020, 4, 10),
+  }),
+]
+
+test('renders an appropriate message with no analyses', () => {
+  const { container } = render(<AnalysisSummary analyses={[]} experiment={experiment} metrics={[]} />)
+  expect(container).toHaveTextContent('No analyses yet for experiment_1.')
+})
+
+test('renders an appropriate message with some analyses', () => {
+  const { container } = render(<AnalysisSummary analyses={analyses} experiment={experiment} metrics={[]} />)
+  expect(container).toHaveTextContent('Found 5 analysis objects in total. There are 0 metrics in the system.')
+})
+
+test('shows the analyses JSON in debug mode', () => {
+  const { container } = render(
+    <AnalysisSummary analyses={analyses} experiment={experiment} metrics={[]} debugMode={true} />,
+  )
+  expect(container.querySelector('pre')).not.toBeNull()
+})
+
+// if (analyses.length === 0) {
+//   return <h2>No analyses yet for {experiment.name}.</h2>
+// }
+//
+// return (
+//   <>
+//     <h2>Analysis summary</h2>
+//     <p>
+//       Found {analyses.length} analysis objects in total. There are {metrics.length} metrics in the system.
+//     </p>
+//
+//     {debugMode ? <pre>{JSON.stringify(analyses, null, 2)}</pre> : ''}
+//   </>
+// )

--- a/components/AnalysisSummary.tsx
+++ b/components/AnalysisSummary.tsx
@@ -1,0 +1,32 @@
+import { Analysis, ExperimentFull, MetricBare } from '@/models'
+import React from 'react'
+
+/**
+ * Main component for summarizing experiment analyses.
+ */
+export default function AnalysisSummary({
+  analyses,
+  experiment,
+  metrics,
+  debugMode,
+}: {
+  analyses: Analysis[]
+  experiment: ExperimentFull
+  metrics: MetricBare[]
+  debugMode?: boolean
+}) {
+  if (analyses.length === 0) {
+    return <h2>No analyses yet for {experiment.name}.</h2>
+  }
+
+  return (
+    <>
+      <h2>Analysis summary</h2>
+      <p>
+        Found {analyses.length} analysis objects in total. There are {metrics.length} metrics in the system.
+      </p>
+
+      {debugMode ? <pre>{JSON.stringify(analyses, null, 2)}</pre> : ''}
+    </>
+  )
+}

--- a/components/ExperimentTabs.tsx
+++ b/components/ExperimentTabs.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link'
+import React from 'react'
+import { ExperimentFull } from '@/models'
+
+/**
+ * Experiment tab component. Used to switch between experiment details and results.
+ */
+export default function ExperimentTabs({ experiment }: { experiment: ExperimentFull | null }) {
+  // TODO: Render using Material UI tabs and add tests
+  if (!experiment) {
+    return <></>
+  }
+  return (
+    <nav>
+      <Link href={`/experiments/${experiment.experimentId}`}>
+        <a>Details</a>
+      </Link>
+      <span>|</span>
+      <Link href={`/experiments/${experiment.experimentId}/results`}>
+        <a>Results</a>
+      </Link>
+    </nav>
+  )
+}

--- a/components/ExperimentsTable.tsx
+++ b/components/ExperimentsTable.tsx
@@ -18,21 +18,20 @@ const isoDateRenderer = (date: Date) => (
 
 const debug = debugFactory('abacus:components/ExperimentsTable.tsx')
 
-interface Props {
-  experiments: ExperimentBare[]
-}
-
 /**
  * Renders a table of "bare" experiment information.
  */
-const ExperimentsTable = (props: Props) => {
+const ExperimentsTable = ({ experiments }: { experiments: ExperimentBare[] }) => {
   debug('ExperimentsTable#render')
-  const { experiments } = props
   const router = useRouter()
 
   /* istanbul ignore next; to be handled by an e2e test */
   const handleRowClick = (event?: React.MouseEvent, rowData?: ExperimentBare) => {
-    router.push('/experiments/[id]', `/experiments/${rowData?.experimentId}`)
+    if (rowData?.status === 'staging') {
+      router.push('/experiments/[id]', `/experiments/${rowData?.experimentId}`)
+    } else {
+      router.push('/experiments/[id]/results', `/experiments/${rowData?.experimentId}/results`)
+    }
   }
 
   return (

--- a/components/Layout.test.tsx
+++ b/components/Layout.test.tsx
@@ -79,3 +79,14 @@ test('renders RenderErrorView when has bad children', () => {
     ;(console.error as jest.Mock).mockRestore()
   }
 })
+
+test('renders an error when it is passed in', () => {
+  const err: Error = { name: 'testError', message: 'An error occurred' }
+  const { container } = render(
+    <Layout title='Some Title' error={err}>
+      A child.
+    </Layout>,
+  )
+
+  expect(container.querySelector('.error-box')).toHaveTextContent('An error occurred')
+})

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -3,17 +3,13 @@ import Link from 'next/link'
 import Head from 'next/head'
 import React, { ReactNode } from 'react'
 
-import { onRenderError } from '@/event-handlers/index'
+import { onRenderError } from '@/event-handlers'
 
 import RenderErrorBoundary from './RenderErrorBoundary'
 import RenderErrorView from './RenderErrorView'
+import ErrorsBox from '@/components/ErrorsBox'
 
-type Props = {
-  children?: ReactNode
-  title: string
-}
-
-const Layout = ({ children, title }: Props) => (
+const Layout = ({ title, error, children }: { title: string; error?: Error | null; children?: ReactNode }) => (
   <RenderErrorBoundary onError={onRenderError}>
     {({ renderError }) => {
       return renderError ? (
@@ -38,7 +34,11 @@ const Layout = ({ children, title }: Props) => (
               </nav>
             </Container>
           </header>
-          {children}
+          <Container>
+            <h1>{title}</h1>
+            {error && <ErrorsBox errors={[error]} />}
+            {children}
+          </Container>
           <footer>
             <hr />
             <Container>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13841,9 +13841,9 @@
       }
     },
     "markdown-to-jsx": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.11.1.tgz",
-      "integrity": "sha512-FdtDAv8d9/tjyHxdCvWZxxOgK2icwzBkTq/dPk+XlQ2B+DYDcwE89FWGzT92erXQ0CQR/bQbpNK3loNYhYL70g==",
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz",
+      "integrity": "sha512-3lRCD5Sh+tfA52iGgfs/XZiw33f7fFX9Bn55aNnVNUd2GzLDkOWyKYYD8Yju2B1Vn+feiEdgJs8T6Tg0xNokPw==",
       "dev": true,
       "requires": {
         "prop-types": "^15.6.2",

--- a/pages/experiments/[id].tsx
+++ b/pages/experiments/[id].tsx
@@ -1,55 +1,55 @@
-import Container from '@material-ui/core/Container'
 import debugFactory from 'debug'
 import { useRouter } from 'next/router'
 import React, { useEffect, useState } from 'react'
 import { toIntOrNull } from 'qc-to_int'
 
-import AnalysesApi from '@/api/AnalysesApi'
 import ExperimentsApi from '@/api/ExperimentsApi'
-import ErrorsBox from '@/components/ErrorsBox'
 import Layout from '@/components/Layout'
-import { Analysis, ExperimentFull } from '@/models'
+import { ExperimentFull } from '@/models'
 import { formatIsoUtcOffset } from '@/utils/date'
+import ExperimentTabs from '@/components/ExperimentTabs'
 
 const debug = debugFactory('abacus:pages/experiments/[id].tsx')
 
-function ExperimentDetails(props: { experiment: ExperimentFull }) {
-  const { experiment } = props
+function ExperimentDetails({ experiment }: { experiment: ExperimentFull }) {
   return (
     <div>
+      <h2>Experiment details</h2>
       <table>
-        <tr>
-          <td>Name</td>
-          <td>{experiment.name}</td>
-        </tr>
-        <tr>
-          <td>P2 Link</td>
-          <td>
-            <a href={experiment.p2Url} rel='noopener noreferrer' target='_blank'>
-              P2
-            </a>
-          </td>
-        </tr>
-        <tr>
-          <td>Description</td>
-          <td>{experiment.description}</td>
-        </tr>
-        <tr>
-          <td>Start</td>
-          <td>{formatIsoUtcOffset(experiment.startDatetime)}</td>
-        </tr>
-        <tr>
-          <td>End</td>
-          <td>{formatIsoUtcOffset(experiment.endDatetime)}</td>
-        </tr>
-        <tr>
-          <td>Status</td>
-          <td>{experiment.status}</td>
-        </tr>
-        <tr>
-          <td>Platform</td>
-          <td>{experiment.platform}</td>
-        </tr>
+        <tbody>
+          <tr>
+            <td>Name</td>
+            <td>{experiment.name}</td>
+          </tr>
+          <tr>
+            <td>P2 Link</td>
+            <td>
+              <a href={experiment.p2Url} rel='noopener noreferrer' target='_blank'>
+                P2
+              </a>
+            </td>
+          </tr>
+          <tr>
+            <td>Description</td>
+            <td>{experiment.description}</td>
+          </tr>
+          <tr>
+            <td>Start</td>
+            <td>{formatIsoUtcOffset(experiment.startDatetime)}</td>
+          </tr>
+          <tr>
+            <td>End</td>
+            <td>{formatIsoUtcOffset(experiment.endDatetime)}</td>
+          </tr>
+          <tr>
+            <td>Status</td>
+            <td>{experiment.status}</td>
+          </tr>
+          <tr>
+            <td>Platform</td>
+            <td>{experiment.platform}</td>
+          </tr>
+        </tbody>
       </table>
     </div>
   )
@@ -60,7 +60,6 @@ export default function ExperimentPage() {
   debug(`ExperimentPage#render ${experimentId}`)
 
   const [fetchError, setFetchError] = useState<Error | null>(null)
-  const [analyses, setAnalyses] = useState<Analysis[] | null>(null)
   const [experiment, setExperiment] = useState<ExperimentFull | null>(null)
 
   useEffect(() => {
@@ -70,30 +69,15 @@ export default function ExperimentPage() {
     }
 
     setFetchError(null)
-    setAnalyses(null)
     setExperiment(null)
 
-    Promise.all([AnalysesApi.findByExperimentId(experimentId), ExperimentsApi.findById(experimentId)])
-      .then(([analyses, experiment]) => {
-        setAnalyses(analyses)
-        setExperiment(experiment)
-        return
-      })
-      .catch(setFetchError)
+    ExperimentsApi.findById(experimentId).then(setExperiment).catch(setFetchError)
   }, [experimentId])
 
   return (
-    <Layout title='Experiment: insert_name_here'>
-      <Container>
-        <h1>Experiment insert_name_here</h1>
-        {fetchError && <ErrorsBox errors={[fetchError]} />}
-        {experiment && <ExperimentDetails experiment={experiment} />}
-        {analyses && (analyses.length === 0 ? <p>No analyses yet.</p> : <pre>{JSON.stringify(analyses, null, 2)}</pre>)}
-        <p>
-          TODO: Fix the flash-of-error-before-data-load. That is, the `ErrorsBox` initially renders because
-          `experimentId` is initially `null`.
-        </p>
-      </Container>
+    <Layout title={`Experiment: ${experiment ? experiment.name : 'Not Found'}`} error={fetchError}>
+      <ExperimentTabs experiment={experiment} />
+      {experiment && <ExperimentDetails experiment={experiment} />}
     </Layout>
   )
 }

--- a/pages/experiments/[id]/results.tsx
+++ b/pages/experiments/[id]/results.tsx
@@ -13,7 +13,7 @@ import ExperimentTabs from '@/components/ExperimentTabs'
 
 const debug = debugFactory('abacus:pages/experiments/[id]/results.tsx')
 
-export default function ResultPage() {
+export default function ResultsPage() {
   const router = useRouter()
   const experimentId = toIntOrNull(router.query.id)
   debug(`ResultPage#render ${experimentId}`)

--- a/pages/experiments/[id]/results.tsx
+++ b/pages/experiments/[id]/results.tsx
@@ -1,0 +1,64 @@
+import debugFactory from 'debug'
+import { useRouter } from 'next/router'
+import React, { useEffect, useState } from 'react'
+import { toIntOrNull } from 'qc-to_int'
+
+import AnalysesApi from '@/api/AnalysesApi'
+import ExperimentsApi from '@/api/ExperimentsApi'
+import Layout from '@/components/Layout'
+import { Analysis, ExperimentFull, MetricBare } from '@/models'
+import AnalysisSummary from '@/components/AnalysisSummary'
+import MetricsApi from '@/api/MetricsApi'
+import ExperimentTabs from '@/components/ExperimentTabs'
+
+const debug = debugFactory('abacus:pages/experiments/[id]/results.tsx')
+
+export default function ResultPage() {
+  const router = useRouter()
+  const experimentId = toIntOrNull(router.query.id)
+  debug(`ResultPage#render ${experimentId}`)
+
+  const [fetchError, setFetchError] = useState<Error | null>(null)
+  const [analyses, setAnalyses] = useState<Analysis[] | null>(null)
+  const [experiment, setExperiment] = useState<ExperimentFull | null>(null)
+  const [metrics, setMetrics] = useState<MetricBare[] | null>(null)
+
+  useEffect(() => {
+    if (experimentId === null) {
+      setFetchError({ name: 'nullExperimentId', message: 'Experiment not found' })
+      return
+    }
+
+    setFetchError(null)
+    setAnalyses(null)
+    setExperiment(null)
+    setMetrics(null)
+
+    Promise.all([
+      AnalysesApi.findByExperimentId(experimentId),
+      ExperimentsApi.findById(experimentId),
+      MetricsApi.findAll(),
+    ])
+      .then(([analyses, experiment, metrics]) => {
+        setAnalyses(analyses)
+        setExperiment(experiment)
+        setMetrics(metrics)
+        return
+      })
+      .catch(setFetchError)
+  }, [experimentId])
+
+  return (
+    <Layout title={`Experiment results: ${experiment ? experiment.name : 'Not Found'}`} error={fetchError}>
+      <ExperimentTabs experiment={experiment} />
+      {experiment && analyses && metrics && (
+        <AnalysisSummary
+          analyses={analyses}
+          experiment={experiment}
+          metrics={metrics}
+          debugMode={router.query.debug === 'true'}
+        />
+      )}
+    </Layout>
+  )
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,13 +1,9 @@
-import Container from '@material-ui/core/Container'
 import debugFactory from 'debug'
 import React, { useEffect, useState } from 'react'
 
 import ExperimentsApi from '@/api/ExperimentsApi'
-
-import ErrorsBox from '@/components/ErrorsBox'
 import ExperimentsTable from '@/components/ExperimentsTable'
 import Layout from '@/components/Layout'
-
 import { ExperimentBare } from '@/models'
 
 const debug = debugFactory('abacus:pages/index.tsx')
@@ -24,14 +20,10 @@ const IndexPage = function IndexPage() {
   }, [])
 
   return (
-    <Layout title='Experiments'>
-      <Container>
-        <img alt='logo' src='/img/logo.png' width='100' />
-        <h1>Experiments</h1>
-        {error && <ErrorsBox errors={[error]} />}
-        {experiments &&
-          (experiments.length === 0 ? <p>No experiments yet.</p> : <ExperimentsTable experiments={experiments} />)}
-      </Container>
+    <Layout title='Experiments' error={error}>
+      <img alt='logo' src='/img/logo.png' width='100' />
+      {experiments &&
+        (experiments.length === 0 ? <p>No experiments yet.</p> : <ExperimentsTable experiments={experiments} />)}
     </Layout>
   )
 }


### PR DESCRIPTION
Another part of addressing #95: 
* Add `AnalysisSummary` as a standalone component (more exciting content to come in #99)
* Split the experiment details page to `/experiments/<id>` and `/experiments/<id>/results`
* Move some common code to the `Layout` component.

## How has this been tested?
* Added some tests
* Manually clicked through the changed pages to verify they're not broken:
  * Homepage: https://abacus-git-add-result-page.a8c.now.sh/
  * Detail page: https://abacus-git-add-result-page.a8c.now.sh/experiments/112
  * Result page: https://abacus-git-add-result-page.a8c.now.sh/experiments/112/results
  * Result page in debug mode: https://abacus-git-add-result-page.a8c.now.sh/experiments/112/results?debug=true (intentionally not linked from anywhere)