### PR TITLE
Adjust to Use Client-side Routing

### DIFF
--- a/components/ExperimentTabs.tsx
+++ b/components/ExperimentTabs.tsx
@@ -12,11 +12,11 @@ export default function ExperimentTabs({ experiment }: { experiment: ExperimentF
   }
   return (
     <nav>
-      <Link href={`/experiments/${experiment.experimentId}`}>
+      <Link as={`/experiments/${experiment.experimentId}`} href='/experiments/[id]'>
         <a>Details</a>
       </Link>
       <span>|</span>
-      <Link href={`/experiments/${experiment.experimentId}/results`}>
+      <Link as={`/experiments/${experiment.experimentId}/results`} href='/experiments/[id]/results'>
         <a>Results</a>
       </Link>
     </nav>


### PR DESCRIPTION
The dynamic URL require extra prop to use client-side routing.

## How has this been tested?

No page network requests when switching tabs -- just API requests.