### PR TITLE
Add simple-import-sort ESlint Plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,7 +52,7 @@ module.exports = {
 
     'plugin:react-hooks/recommended',
   ],
-  plugins: ['@typescript-eslint', 'jsx-a11y', 'promise', 'react-hooks'],
+  plugins: ['@typescript-eslint', 'jsx-a11y', 'promise', 'react-hooks', 'simple-import-sort'],
   rules: {
     // Off because favoring @typescript-eslint/naming-convention instead.
     camelcase: 'off',
@@ -74,6 +74,12 @@ module.exports = {
     'no-unused-vars': 'off',
 
     'padded-blocks': 'off',
+
+    // Off because we are using `simple-import-sort` instead.
+    'sort-imports': 'off',
+
+    // Off because we are using `simple-import-sort` instead.
+    'import/order': 'off',
 
     // Allows to use an `a` element without an `href` attribute inside a `Link`
     // component which in our case is a Next.js Link component.
@@ -100,6 +106,8 @@ module.exports = {
 
     // Off because we are using TypeScript which expects us to declare the props.
     'react/prop-types': 'off',
+
+    'simple-import-sort/sort': 'error',
 
     // Off because it is deprecated and favoring @typescript-eslint/naming-convention
     // instead.

--- a/__tests__/api/ExperimentsApi.test.ts
+++ b/__tests__/api/ExperimentsApi.test.ts
@@ -1,5 +1,4 @@
 import ExperimentsApi from '@/api/ExperimentsApi'
-
 import { ExperimentFull, Platform, Status } from '@/models'
 
 const PLATFORMS = Object.values(Platform)

--- a/__tests__/api/SegmentsApi.test.ts
+++ b/__tests__/api/SegmentsApi.test.ts
@@ -1,5 +1,4 @@
 import SegmentsApi from '@/api/SegmentsApi'
-
 import { SegmentType } from '@/models'
 
 const SEGMENT_TYPES = Object.values(SegmentType)

--- a/components/AnalysisSummary.test.tsx
+++ b/components/AnalysisSummary.test.tsx
@@ -1,7 +1,6 @@
 import { render } from '@testing-library/react'
 import React from 'react'
 
-import AnalysisSummary from './AnalysisSummary'
 import {
   Analysis,
   AnalysisStrategy,
@@ -13,6 +12,8 @@ import {
   Status,
   Variation,
 } from '@/models'
+
+import AnalysisSummary from './AnalysisSummary'
 
 const experiment: ExperimentFull = new ExperimentFull({
   experimentId: 1,

--- a/components/AnalysisSummary.tsx
+++ b/components/AnalysisSummary.tsx
@@ -1,5 +1,6 @@
-import { Analysis, ExperimentFull, MetricBare } from '@/models'
 import React from 'react'
+
+import { Analysis, ExperimentFull, MetricBare } from '@/models'
 
 /**
  * Main component for summarizing experiment analyses.

--- a/components/ExperimentTabs.tsx
+++ b/components/ExperimentTabs.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import React from 'react'
+
 import { ExperimentFull } from '@/models'
 
 /**

--- a/components/Layout.stories.tsx
+++ b/components/Layout.stories.tsx
@@ -1,7 +1,7 @@
 import '@/styles/main.scss'
 
-import React from 'react'
 import { withRouter } from 'next/router'
+import React from 'react'
 
 import Layout from './Layout'
 

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,13 +1,13 @@
 import Container from '@material-ui/core/Container'
-import Link from 'next/link'
 import Head from 'next/head'
+import Link from 'next/link'
 import React, { ReactNode } from 'react'
 
+import ErrorsBox from '@/components/ErrorsBox'
 import { onRenderError } from '@/event-handlers'
 
 import RenderErrorBoundary from './RenderErrorBoundary'
 import RenderErrorView from './RenderErrorView'
-import ErrorsBox from '@/components/ErrorsBox'
 
 const Layout = ({ title, error, children }: { title: string; error?: Error | null; children?: ReactNode }) => (
   <RenderErrorBoundary onError={onRenderError}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8972,6 +8972,12 @@
       "integrity": "sha512-kAMRjNztrLW1rK+81X1NwMB2LqG+nc7Q8AibnG8/VyWhQK8SP6JotCFG+HL4u1EjziplxVz4jARdR8gGk8pLDA==",
       "dev": true
     },
+    "eslint-plugin-simple-import-sort": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-5.0.3.tgz",
+      "integrity": "sha512-1rf3AWiHeWNCQdAq0iXNnlccnH1UDnelGgrPbjBBHE8d2hXVtOudcmy0vTF4hri3iJ0MKz8jBhmH6lJ0ZWZLHQ==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^4.0.2",
+    "eslint-plugin-simple-import-sort": "^5.0.3",
     "husky": "^4.2.5",
     "isomorphic-fetch": "^2.2.1",
     "jest": "^25.4.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,9 +8,7 @@ import React from 'react'
 
 import RenderErrorBoundary from '@/components/RenderErrorBoundary'
 import RenderErrorView from '@/components/RenderErrorView'
-
 import { onRenderError } from '@/event-handlers/index'
-
 import { getAuthClientId, getExperimentsAuthInfo, saveExperimentsAuthInfo } from '@/utils/auth'
 
 const debug = debugFactory('abacus:pages/_app.tsx')

--- a/pages/experiments/[id].tsx
+++ b/pages/experiments/[id].tsx
@@ -1,13 +1,13 @@
 import debugFactory from 'debug'
 import { useRouter } from 'next/router'
-import React, { useEffect, useState } from 'react'
 import { toIntOrNull } from 'qc-to_int'
+import React, { useEffect, useState } from 'react'
 
 import ExperimentsApi from '@/api/ExperimentsApi'
+import ExperimentTabs from '@/components/ExperimentTabs'
 import Layout from '@/components/Layout'
 import { ExperimentFull } from '@/models'
 import { formatIsoUtcOffset } from '@/utils/date'
-import ExperimentTabs from '@/components/ExperimentTabs'
 
 const debug = debugFactory('abacus:pages/experiments/[id].tsx')
 

--- a/pages/experiments/[id]/results.tsx
+++ b/pages/experiments/[id]/results.tsx
@@ -1,15 +1,15 @@
 import debugFactory from 'debug'
 import { useRouter } from 'next/router'
-import React, { useEffect, useState } from 'react'
 import { toIntOrNull } from 'qc-to_int'
+import React, { useEffect, useState } from 'react'
 
 import AnalysesApi from '@/api/AnalysesApi'
 import ExperimentsApi from '@/api/ExperimentsApi'
+import MetricsApi from '@/api/MetricsApi'
+import AnalysisSummary from '@/components/AnalysisSummary'
+import ExperimentTabs from '@/components/ExperimentTabs'
 import Layout from '@/components/Layout'
 import { Analysis, ExperimentFull, MetricBare } from '@/models'
-import AnalysisSummary from '@/components/AnalysisSummary'
-import MetricsApi from '@/api/MetricsApi'
-import ExperimentTabs from '@/components/ExperimentTabs'
 
 const debug = debugFactory('abacus:pages/experiments/[id]/results.tsx')
 


### PR DESCRIPTION
Add simple-import-sort ESlint Plugin to keep the imports nicely ordered.

Resolves #102 

## How has this been tested?

Lint tests failed before fixing the import order. They pass after fixing the import order.