### PR TITLE
Update Jest Coverage Configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,13 +38,13 @@ jobs:
                 command: npm run lint
             - run:
                 name: Unit Testing
-                command: npm run test:unit -- --ci --coverage --maxWorkers 2
+                command: npm run test:unit -- --ci --maxWorkers 2
             - run:
                 name: Integration Testing
-                command: npm run test:integration -- --ci --coverage
+                command: npm run test:integration -- --ci
             - run:
                 name: End-to-End Testing
-                command: npm run test:e2e -- --ci --coverage
+                command: npm run test:e2e -- --ci
 
 workflows:
   build-and-verify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,10 +41,10 @@ jobs:
                 command: npm run test:unit -- --ci --coverage --maxWorkers 2
             - run:
                 name: Integration Testing
-                command: npm run test:integration -- --ci
+                command: npm run test:integration -- --ci --coverage
             - run:
                 name: End-to-End Testing
-                command: npm run test:e2e -- --ci
+                command: npm run test:e2e -- --ci --coverage
 
 workflows:
   build-and-verify:

--- a/README.md
+++ b/README.md
@@ -111,23 +111,37 @@ This will open a browser window of the Storybook webapp.
 
 Runs the unit tests with Jest.
 
-The unit tests are found throughout the project excluding tests in the `__tests__` directory which is being reserved for integration tests.
+The unit tests are found throughout the project excluding tests in the `__tests__` directory which is being reserved for integration tests and the `e2e` directory which is being reserved for e2e tests.
 
 ```sh
 npm run test:unit
 npm run test:unit -- --coverage
 npm run test:unit -- --watch
+npm run test:unit -- --coverage --watch
+```
+
+**test:integration**
+
+Runs the integration tests with Jest. These are in the `__tests__` directory.
+
+```sh
+npm run test:integration
+npm run test:integration -- --coverage
+npm run test:integration -- --watch
+npm run test:integration -- --coverage --watch
 ```
 
 **test:e2e**
 
-Runs the end-to-end tests with Jest and Puppeteer in a headless Chrome browser.
+Runs the end-to-end tests with Jest and Puppeteer in a headless Chrome browser. These are in the `e2e` directory.
 
 ```sh
 # Run all the E2E tests
 npm run test:e2e
+npm run test:e2e -- --coverage
 # Run just the E2E smoke tests (intended to be used in development for quick iterations)
 npm run test:e2e:smoke
+npm run test:e2e:smoke -- --coverage
 ```
 
 For debugging, you'll likely want to run with a full visual browser. To do that:

--- a/README.md
+++ b/README.md
@@ -115,9 +115,7 @@ The unit tests are found throughout the project excluding tests in the `__tests_
 
 ```sh
 npm run test:unit
-npm run test:unit -- --coverage
 npm run test:unit -- --watch
-npm run test:unit -- --coverage --watch
 ```
 
 **test:integration**
@@ -126,9 +124,7 @@ Runs the integration tests with Jest. These are in the `__tests__` directory.
 
 ```sh
 npm run test:integration
-npm run test:integration -- --coverage
 npm run test:integration -- --watch
-npm run test:integration -- --coverage --watch
 ```
 
 **test:e2e**
@@ -138,10 +134,8 @@ Runs the end-to-end tests with Jest and Puppeteer in a headless Chrome browser. 
 ```sh
 # Run all the E2E tests
 npm run test:e2e
-npm run test:e2e -- --coverage
 # Run just the E2E smoke tests (intended to be used in development for quick iterations)
 npm run test:e2e:smoke
-npm run test:e2e:smoke -- --coverage
 ```
 
 For debugging, you'll likely want to run with a full visual browser. To do that:

--- a/api/utils.ts
+++ b/api/utils.ts
@@ -16,9 +16,11 @@ const PRODUCTION_API_URL_ROOT = 'https://public-api.wordpress.com/wpcom/v2/exper
  * @throws UnauthorizedError
  */
 async function fetchApi(method: string, path: string, body: ApiDataSource | null = null) {
+  /* istanbul ignore next; code branch not reachable in integration tests -- we don't hit production */
   const apiUrlRoot = window.location.host === 'experiments.a8c.com' ? PRODUCTION_API_URL_ROOT : DEVELOPMENT_API_URL_ROOT
 
   const headers = new Headers()
+  /* istanbul ignore next; code branch not reachable in integration tests -- we don't hit production */
   if (apiUrlRoot === PRODUCTION_API_URL_ROOT) {
     const accessToken = getExperimentsAuthInfo()?.accessToken
     if (!accessToken) {

--- a/components/ExperimentTabs.test.tsx
+++ b/components/ExperimentTabs.test.tsx
@@ -1,0 +1,49 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+
+import { ExperimentFull, Platform, Status, Variation } from '@/models'
+
+import ExperimentTabs from './ExperimentTabs'
+
+test('renders nothing when experiment prop is `null`', () => {
+  const { container } = render(<ExperimentTabs experiment={null} />)
+
+  expect(container.hasChildNodes()).toBe(false)
+})
+
+test('renders expected links', () => {
+  // TODO: Get from fixtures.
+  const experiment = new ExperimentFull({
+    experimentId: 1,
+    name: 'experiment_1',
+    startDatetime: new Date(Date.UTC(2020, 5, 4)),
+    endDatetime: new Date(Date.UTC(2020, 6, 4)),
+    status: Status.Completed,
+    platform: Platform.Calypso,
+    ownerLogin: 'test_a11n',
+    description: 'Experiment with things. Change stuff. Profit.',
+    existingUsersAllowed: false,
+    p2Url: 'https://wordpress.com/experiment_1',
+    exposureEvents: null,
+    variations: [
+      new Variation({
+        variationId: 2,
+        name: 'test',
+        isDefault: false,
+        allocatedPercentage: 40,
+      }),
+      new Variation({
+        variationId: 1,
+        name: 'control',
+        isDefault: true,
+        allocatedPercentage: 60,
+      }),
+    ],
+    metricAssignments: [],
+    segmentAssignments: [],
+  })
+  const { getByText } = render(<ExperimentTabs experiment={experiment} />)
+
+  expect(getByText('Details', { selector: 'a' })).toBeInTheDocument()
+  expect(getByText('Results', { selector: 'a' })).toBeInTheDocument()
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,17 @@
 module.exports = {
+  collectCoverageFrom: [
+    // Note: Dot directories (e.g., .storybook) are also excluded automatically.
+    '**/*.{ts,tsx}',
+    '!**/*stories.tsx',
+    '!**/node_modules/**',
+    '!<rootDir>/api/**', // We tests these with integration tests.
+    '!<rootDir>/coverage/**',
+    '!<rootDir>/e2e/**',
+    '!<rootDir>/pages/**', // We plan to test these with e2e tests.
+    '!<rootDir>/public/**',
+    '!<rootDir>/styles/**',
+    '!<rootDir>/__tests__/**',
+  ],
   coverageThreshold: {
     global: {
       branches: 100,

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,10 +4,10 @@ module.exports = {
     '**/*.{ts,tsx}',
     '!**/*stories.tsx',
     '!**/node_modules/**',
-    '!<rootDir>/api/**', // We tests these with integration tests.
+    '!<rootDir>/api/**', // We test these with integration tests.
     '!<rootDir>/coverage/**',
     '!<rootDir>/e2e/**',
-    '!<rootDir>/pages/**', // We plan to test these with e2e tests.
+    '!<rootDir>/pages/**', // We test these with e2e tests.
     '!<rootDir>/public/**',
     '!<rootDir>/styles/**',
     '!<rootDir>/__tests__/**',

--- a/jest.e2e.config.js
+++ b/jest.e2e.config.js
@@ -2,7 +2,7 @@ module.exports = {
   collectCoverageFrom: [
     '<rootDir>/pages/**/*.{ts,tsx}',
     '!**/node_modules/**',
-    // FIXME: TODO: Get tests on the following.
+    // FIXME: TODO: Get tests on the following. Issue #114.
     '!<rootDir>/pages/_app.tsx',
     '!<rootDir>/pages/auth.tsx',
     '!<rootDir>/pages/index.tsx',

--- a/jest.e2e.config.js
+++ b/jest.e2e.config.js
@@ -1,4 +1,23 @@
 module.exports = {
+  collectCoverageFrom: [
+    '<rootDir>/pages/**/*.{ts,tsx}',
+    '!**/node_modules/**',
+    // FIXME: TODO: Get tests on the following.
+    '!<rootDir>/pages/_app.tsx',
+    '!<rootDir>/pages/auth.tsx',
+    '!<rootDir>/pages/index.tsx',
+    '!<rootDir>/pages/experiments/[id].tsx',
+    '!<rootDir>/pages/experiments/[id]/results.tsx',
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
+
   preset: 'jest-puppeteer',
   testMatch: ['**/e2e/**/?(*.)+(spec|test).ts?(x)'],
   transform: {

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -2,7 +2,10 @@ module.exports = {
   collectCoverageFrom: [
     '<rootDir>/api/**/*.ts',
     '!**/node_modules/**',
-    // FIXME: TODO: Get tests on the following.
+    // FIXME: TODO: Get tests on the following. This is related to issues 52 and 64.
+    // Currently we are unable to test the following because the code won't hit the
+    // code branch that leads to this error being thrown. If we test against the
+    // production API or a more sophisticated mock, then we may be able.
     '!<rootDir>/api/UnauthorizedError.ts',
   ],
   coverageThreshold: {

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -1,4 +1,19 @@
 module.exports = {
+  collectCoverageFrom: [
+    '<rootDir>/api/**/*.ts',
+    '!**/node_modules/**',
+    // FIXME: TODO: Get tests on the following.
+    '!<rootDir>/api/UnauthorizedError.ts',
+    '!<rootDir>/api/utils.ts',
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
   globals: {
     // Must specify a custom tsconfig for tests because we need the TypeScript
     // transform to transform JSX into js rather than leaving it as JSX which the

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -4,7 +4,6 @@ module.exports = {
     '!**/node_modules/**',
     // FIXME: TODO: Get tests on the following.
     '!<rootDir>/api/UnauthorizedError.ts',
-    '!<rootDir>/api/utils.ts',
   ],
   coverageThreshold: {
     global: {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "lint:ts:fix": "eslint . --ext .ts,.tsx --fix",
     "start": "next start",
     "storybook": "start-storybook",
-    "test:all": "npm run test:unit -- --coverage && npm run test:integration && npm run test:e2e -- --coverage",
+    "test:all": "npm run test:unit -- --coverage && npm run test:integration -- --coverage && npm run test:e2e -- --coverage",
     "@comment test:e2e": "Runs the e2e tests. It will spawn Chromium to run the tests.",
     "test:e2e": "jest --config=jest.e2e.config.js --runInBand",
     "test:e2e:smoke": "jest --config=jest.e2e.config.js --runInBand e2e/smoke.test.tsx",

--- a/package.json
+++ b/package.json
@@ -100,12 +100,12 @@
     "lint:ts:fix": "eslint . --ext .ts,.tsx --fix",
     "start": "next start",
     "storybook": "start-storybook",
-    "test:all": "npm run test:unit -- --coverage && npm run test:integration -- --coverage && npm run test:e2e -- --coverage",
+    "test:all": "npm run test:unit && npm run test:integration && npm run test:e2e",
     "@comment test:e2e": "Runs the e2e tests. It will spawn Chromium to run the tests.",
-    "test:e2e": "jest --config=jest.e2e.config.js --runInBand",
-    "test:e2e:smoke": "jest --config=jest.e2e.config.js --runInBand e2e/smoke.test.tsx",
-    "test:integration": "jest --config=jest.integration.config.js --runInBand",
-    "test:unit": "jest",
+    "test:e2e": "jest --config=jest.e2e.config.js --coverage --runInBand",
+    "test:e2e:smoke": "jest --config=jest.e2e.config.js --coverage --runInBand e2e/smoke.test.tsx",
+    "test:integration": "jest --config=jest.integration.config.js --coverage --runInBand",
+    "test:unit": "jest --coverage",
     "type-check": "tsc",
     "verify": "npm run format:check && npm run lint && npm run test:all"
   }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "lint:ts:fix": "eslint . --ext .ts,.tsx --fix",
     "start": "next start",
     "storybook": "start-storybook",
-    "test:all": "npm run test:unit -- --coverage && npm run test:integration && npm run test:e2e",
+    "test:all": "npm run test:unit -- --coverage && npm run test:integration && npm run test:e2e -- --coverage",
     "@comment test:e2e": "Runs the e2e tests. It will spawn Chromium to run the tests.",
     "test:e2e": "jest --config=jest.e2e.config.js --runInBand",
     "test:e2e:smoke": "jest --config=jest.e2e.config.js --runInBand e2e/smoke.test.tsx",


### PR DESCRIPTION
Update Jest coverage configuration to catch new files. Added coverage reporting to integration and e2e tests.

New tests added to complete unit test coverage.

Ignored some files for integration and e2e to get coverage at 100% for the files being tested.

Resolves #108 

## How has this been tested?

Ran `npm run verify`. Can still new coverage reports for integration and e2e tests. All three test types have 100% coverage due to some files being ignored.