### PR TITLE
Add jest:clear NPM Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "docker-start": "docker run -p 8888:3000 abacus:latest",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "jest:clear": "jest --clearCache",
     "lint": "npm run lint:ts && npm run lint:css",
     "lint:css": "stylelint **/*.{css,scss}",
     "lint:css:fix": "stylelint **/*.{css,scss} --fix",


### PR DESCRIPTION
The need to clear the Jest cache happens once in awhile but frequently enough that it would be nice to have a convenience script to handle it instead of looking up the command each time.(Someday I might have `./node_modules/.bin/jest --clearCache` memorized, but I'd still rather type `npm run jest:clear`.)

## How has this been tested?

Ran the script, get a message saying what directory was cleared. Then running the tests again makes them succeed again.