### PR TITLE
Fix hook conventions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -108,6 +108,9 @@ module.exports = {
     // Off because we are using TypeScript which expects us to declare the props.
     'react/prop-types': 'off',
 
+    'react-hooks/rules-of-hooks': 'error', // Checks rules of Hooks
+    'react-hooks/exhaustive-deps': 'warn', // Checks effect dependencies
+
     'simple-import-sort/sort': 'error',
 
     // Off because it is deprecated and favoring @typescript-eslint/naming-convention

--- a/pages/experiments/[id].tsx
+++ b/pages/experiments/[id].tsx
@@ -56,7 +56,8 @@ function ExperimentDetails({ experiment }: { experiment: ExperimentFull }) {
 }
 
 export default function ExperimentPage() {
-  const experimentId = toIntOrNull(useRouter().query.id)
+  const router = useRouter()
+  const experimentId = toIntOrNull(router.query.id)
   debug(`ExperimentPage#render ${experimentId}`)
 
   const [fetchError, setFetchError] = useState<Error | null>(null)


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
This PR:
- Fixes a specific mis-usage of Hooks: Hook use-functions should be seperate from other lines.
- Adds `eslint` rules to enforce proper usage.



Hooks are magical due to being order-dependant and they are
side-effectful, so they shouldn't be hidden away within an expression.

Adding in the `eslint` rules adds additional checking such as ensuring dependancies are added to hooks.

https://reactjs.org/docs/hooks-rules.html
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
- Passes existing automated tests.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
