### PR TITLE
Collapse Imports

### DIFF
--- a/components/ExperimentsTable.test.tsx
+++ b/components/ExperimentsTable.test.tsx
@@ -2,9 +2,7 @@ import { fireEvent, getAllByText, getByText, getByTitle, render } from '@testing
 import addToDate from 'date-fns/add'
 import React from 'react'
 
-import { ExperimentBare } from '@/models/ExperimentBare'
-import { Platform } from '@/models/Platform'
-import { Status } from '@/models/Status'
+import { ExperimentBare, Platform, Status } from '@/models'
 
 import ExperimentsTable from './ExperimentsTable'
 

--- a/models/ExperimentBare.test.ts
+++ b/models/ExperimentBare.test.ts
@@ -1,5 +1,4 @@
-import { Platform } from '@/models/Platform'
-import { Status } from '@/models/Status'
+import { Platform, Status } from '@/models'
 
 import { ExperimentBare } from './ExperimentBare'
 

--- a/models/ExperimentFull.test.ts
+++ b/models/ExperimentFull.test.ts
@@ -1,6 +1,5 @@
 import Fixtures from '@/helpers/fixtures'
-import { Platform } from '@/models/Platform'
-import { Status } from '@/models/Status'
+import { Platform, Status } from '@/models'
 
 import { ExperimentFull } from './ExperimentFull'
 import { AttributionWindowSeconds } from './MetricAssignment'


### PR DESCRIPTION
A quick cleanup PR. Collapses some imports. Less verbose, less to maintain.

## How has this been tested?

Automated tests still passed.
