### PR TITLE
Add ExperimentStatus Component

### DIFF
--- a/components/ExperimentStatus.test.tsx
+++ b/components/ExperimentStatus.test.tsx
@@ -1,0 +1,62 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+
+import { Status } from '@/models'
+
+import ExperimentStatus from './ExperimentStatus'
+
+test('renders as completed', () => {
+  const { container } = render(<ExperimentStatus status={Status.Completed} />)
+
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      <span
+        class="makeStyles-root-1 makeStyles-completed-2"
+      >
+        completed
+      </span>
+    </div>
+  `)
+})
+
+test('renders as disabled', () => {
+  const { container } = render(<ExperimentStatus status={Status.Disabled} />)
+
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      <span
+        class="makeStyles-root-6 makeStyles-disabled-8"
+      >
+        disabled
+      </span>
+    </div>
+  `)
+})
+
+test('renders as running', () => {
+  const { container } = render(<ExperimentStatus status={Status.Running} />)
+
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      <span
+        class="makeStyles-root-11 makeStyles-running-14"
+      >
+        running
+      </span>
+    </div>
+  `)
+})
+
+test('renders as staging', () => {
+  const { container } = render(<ExperimentStatus status={Status.Staging} />)
+
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      <span
+        class="makeStyles-root-16 makeStyles-staging-20"
+      >
+        staging
+      </span>
+    </div>
+  `)
+})

--- a/components/ExperimentStatus.tsx
+++ b/components/ExperimentStatus.tsx
@@ -1,0 +1,35 @@
+import { makeStyles } from '@material-ui/core/styles'
+import clsx from 'clsx'
+import React from 'react'
+
+import { Status } from '@/models'
+
+const useStatusStyles = makeStyles({
+  root: {
+    borderRadius: 1,
+    padding: '0.5rem',
+  },
+  completed: {
+    background: '#4caf5014',
+    color: '#4caf50',
+  },
+  disabled: {
+    background: '#82828214',
+    color: '#828282',
+  },
+  running: {
+    background: '#ff980014',
+    color: '#ff9800',
+  },
+  staging: {
+    background: '#82828214',
+    color: '#828282',
+  },
+})
+
+function ExperimentStatus({ status }: { status: Status }) {
+  const classes = useStatusStyles()
+  return <span className={clsx(classes.root, classes[status])}>{status}</span>
+}
+
+export default ExperimentStatus


### PR DESCRIPTION
Add a reusable ExperimentStatus component. Plan to use in the experiments table and experiment details.

## How has this been tested?

Added new unit test.

Automated test continue to pass at 100% coverage.