### PR TITLE
Disable Coverage Via Jest for E2E Tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  collectCoverage: true,
   collectCoverageFrom: [
     // Note: Dot directories (e.g., .storybook) are also excluded automatically.
     '**/*.{ts,tsx}',

--- a/jest.e2e.config.js
+++ b/jest.e2e.config.js
@@ -1,24 +1,4 @@
 module.exports = {
-  collectCoverageFrom: [
-    '<rootDir>/pages/**/*.{ts,tsx}',
-    '!**/node_modules/**',
-    // FIXME: TODO: Get tests on the following. Issue #114.
-    '!<rootDir>/pages/_app.tsx',
-    '!<rootDir>/pages/_document.tsx',
-    '!<rootDir>/pages/auth.tsx',
-    '!<rootDir>/pages/index.tsx',
-    '!<rootDir>/pages/experiments/[id].tsx',
-    '!<rootDir>/pages/experiments/[id]/results.tsx',
-  ],
-  coverageThreshold: {
-    global: {
-      branches: 100,
-      functions: 100,
-      lines: 100,
-      statements: 100,
-    },
-  },
-
   preset: 'jest-puppeteer',
   testMatch: ['**/e2e/**/?(*.)+(spec|test).ts?(x)'],
   transform: {

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  collectCoverage: true,
   collectCoverageFrom: [
     '<rootDir>/api/**/*.ts',
     '!**/node_modules/**',
@@ -16,6 +17,7 @@ module.exports = {
       statements: 100,
     },
   },
+
   globals: {
     // Must specify a custom tsconfig for tests because we need the TypeScript
     // transform to transform JSX into js rather than leaving it as JSX which the

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "@comment jest": "Run jest with consistent TZ and LANG",
-    "jest": "cross-env NODE_ICU_DATA=node_modules/full-icu TZ=America/New_York LANG=en-GB jest --coverage",
+    "jest": "cross-env NODE_ICU_DATA=node_modules/full-icu TZ=America/New_York LANG=en-GB jest",
     "lint": "npm run lint:ts",
     "lint:ts": "eslint . --ext .ts,.tsx",
     "lint:ts:fix": "eslint . --ext .ts,.tsx --fix",


### PR DESCRIPTION
Coverage isn't actually working correctly for the E2E tests with Puppeteer.

Tried to install https://www.npmjs.com/package/jest-puppeteer-istanbul but was unable to get it to work correctly. It behaved like two coverage reports were being generated. One report would always report that there was no coverage, the other report which seemed to be coming from `jest-puppeteer-istanbul` would report as expected.

We can revisit this in the future. For now, I think we should just disable the coverage reports since we are ignoring everything anyway.

Resolves #152.

## How has this been tested?

Automated tests still work but no attempt to generate coverage is done for e2e tests.