### PR TITLE
Fix E2E Tests

### DIFF
--- a/e2e/navigation.test.tsx
+++ b/e2e/navigation.test.tsx
@@ -6,8 +6,12 @@ jest.setTimeout(30000)
 
 describe('Dashboard', () => {
   it('should redirect to /experiments', async () => {
-    // This helps prevent race conditions around waitForNavigation and the redirect.
-    await Promise.all([page.goto('http://a8c-abacus-local:3000'), page.waitForNavigation({ timeout: 2000 })])
+    await page.goto('http://a8c-abacus-local:3000')
+
+    // Sometimes the redirect has not occurred yet. So, we need to wait.
+    if (new URL(page.url()).pathname === '/') {
+      await page.waitForNavigation({ timeout: 2000 })
+    }
 
     expect(new URL(page.url()).pathname).toBe('/experiments')
   })

--- a/e2e/smoke.test.tsx
+++ b/e2e/smoke.test.tsx
@@ -18,12 +18,13 @@ describe('Experiments', () => {
   it('should skip authentication and show the main page.', async () => {
     await page.goto('http://a8c-abacus-local:3000')
 
-    // Wait for the redirect
-    await page.waitForNavigation({
-      timeout: 0, // Sometimes the navigation has already occured, this stops the test from waiting indefinitely
-    })
+    // Sometimes the redirect has not occurred yet. So, we need to wait.
+    if (new URL(page.url()).pathname === '/') {
+      await page.waitForNavigation({ timeout: 2000 })
+    }
 
     // We should arrive at the '/experiments' list
+    expect(new URL(page.url()).pathname).toBe('/experiments')
     await expect(page.title()).resolves.toMatch('Experiments | Abacus')
     // TODO: make more interesting assertions once there is more content to display
   })


### PR DESCRIPTION
Fix e2e tests by checking first the URL before determining whether we need to wait for a navigation.

Fixes #154.

## How has this been tested?

Ran tests locally. The tests pass. Hopefully, they will pass everywhere too with this change.