### PR TITLE
Exclude Any Function for Resulting Type

### DIFF
--- a/types/ExcludeMethods.ts
+++ b/types/ExcludeMethods.ts
@@ -1,4 +1,4 @@
 /**
  * Allows to create a type with all the same properties as `T`, excluding methods.
  */
-export type ExcludeMethods<T> = Pick<T, { [K in keyof T]: T[K] extends (_: unknown) => unknown ? never : K }[keyof T]>
+export type ExcludeMethods<T> = Pick<T, { [K in keyof T]: T[K] extends Function ? never : K }[keyof T]>


### PR DESCRIPTION
Resolves #156 

## How has this been tested?

Only ExperimentFull is using the ExcludeMethods type. All its code still TS compiles and the associated unit tests succeed.
