### PR TITLE
Change Jest-Puppeteers default port to 3001

### DIFF
--- a/e2e/navigation.test.tsx
+++ b/e2e/navigation.test.tsx
@@ -6,7 +6,7 @@ jest.setTimeout(30000)
 
 describe('Dashboard', () => {
   it('should redirect to /experiments', async () => {
-    await page.goto('http://a8c-abacus-local:3000')
+    await page.goto('http://a8c-abacus-local:3001')
 
     // Sometimes the redirect has not occurred yet. So, we need to wait.
     if (new URL(page.url()).pathname === '/') {
@@ -19,7 +19,7 @@ describe('Dashboard', () => {
 
 describe('Experiments', () => {
   beforeAll(async () => {
-    await page.goto('http://a8c-abacus-local:3000/experiments')
+    await page.goto('http://a8c-abacus-local:3001/experiments')
   })
 
   describe('from experiments table', () => {
@@ -35,7 +35,7 @@ describe('Experiments', () => {
       await Promise.all([page.waitForNavigation(), $tableRows[0].click()])
 
       // Assert clicking a row navigated to the details page of that experiment.
-      expect(page.url()).toMatch(/^http:\/\/a8c-abacus-local:3000\/experiments\/\d+/)
+      expect(page.url()).toMatch(/^http:\/\/a8c-abacus-local:3001\/experiments\/\d+/)
     })
   })
 })

--- a/e2e/smoke.test.tsx
+++ b/e2e/smoke.test.tsx
@@ -7,7 +7,7 @@ jest.setTimeout(90000)
 describe('Experiments', () => {
   // Temporarily disabled until we decide how to test the full auth flow.
   xit('should display "Abacus - Testing" text on page from WordPress.com.', async () => {
-    await page.goto('http://a8c-abacus-local:3000')
+    await page.goto('http://a8c-abacus-local:3001')
     // This is because we expect that the user has not authenticated yet and they
     // should be redirected to the WP.com log-in page.
     expect(page.url()).toMatch(/^https:\/\/wordpress.com\/log-in/)
@@ -16,7 +16,7 @@ describe('Experiments', () => {
 
   // In non-production contexts, we should see the main page immediately.
   it('should skip authentication and show the main page.', async () => {
-    await page.goto('http://a8c-abacus-local:3000')
+    await page.goto('http://a8c-abacus-local:3001')
 
     // Sometimes the redirect has not occurred yet. So, we need to wait.
     if (new URL(page.url()).pathname === '/') {

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -6,9 +6,9 @@ module.exports = {
     headless: toBool(process.env.PUPPETEER_HEADLESS, true),
   },
   server: {
-    command: 'echo "Building app..." && npm run build && echo "Starting app..." && npm run start',
+    command: 'echo "Building app..." && npm run build && echo "Starting app..." && npm run start -- -p 3001',
     debug: true, // Allows us to see the output of the above commands.
     launchTimeout: 60 * 1000,
-    port: 3000,
+    port: 3001,
   },
 }

--- a/utils/auth.test.ts
+++ b/utils/auth.test.ts
@@ -10,10 +10,10 @@ describe('utils/auth.ts module', () => {
   describe('getAuthClientId', () => {
     it('should return 68795 for host experiments.a8c.com but 68797 for all other host', () => {
       expect(getAuthClientId('experiments.a8c.com')).toBe(68795)
-      expect(getAuthClientId('http://a8c-abacus-local:3000')).toBe(68797)
-      expect(getAuthClientId('https://a8c-abacus-local:3000')).toBe(68797)
+      expect(getAuthClientId('http://a8c-abacus-local:3001')).toBe(68797)
+      expect(getAuthClientId('https://a8c-abacus-local:3001')).toBe(68797)
       expect(getAuthClientId('http://localhost')).toBe(68797)
-      expect(getAuthClientId('http://localhost:3000')).toBe(68797)
+      expect(getAuthClientId('http://localhost:3001')).toBe(68797)
       expect(getAuthClientId('https://localhost')).toBe(68797)
     })
   })


### PR DESCRIPTION
Currently the port conflicts with `npm run dev`, and stops to ask if we want to kill it. 
<img width="896" alt="Screen Shot 2020-06-28 at 11 37 20 pm" src="https://user-images.githubusercontent.com/971886/85952601-10bc4780-b99d-11ea-8d60-3701b563a042.png">

This is incredibly annoying. 

This PR moves the default puppeteer port to `3001`.

<!-- Describe your changes in detail. -->
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
- Manually tested
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
