### PR TITLE
Add Experiment Creation page

### DIFF
--- a/components/Layout.test.tsx
+++ b/components/Layout.test.tsx
@@ -56,6 +56,11 @@ test('renders layout with declared title and children', () => {
               Experiments
             </a>
             <a
+              href="/experiments/new"
+            >
+              Create Experiment
+            </a>
+            <a
               href="/metrics"
             >
               Metrics

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -96,6 +96,9 @@ const Layout = ({ title, error, children }: { title: string; error?: Error | nul
                     <Link href='/experiments'>
                       <a>Experiments</a>
                     </Link>
+                    <Link href='/experiments/new'>
+                      <a>Create Experiment</a>
+                    </Link>
                     <Link href='/metrics'>
                       <a>Metrics</a>
                     </Link>

--- a/models/ExperimentFull.test.ts
+++ b/models/ExperimentFull.test.ts
@@ -1,7 +1,7 @@
 import Fixtures from '@/helpers/fixtures'
 import { AttributionWindowSeconds, Platform, Status } from '@/models'
 
-import { ExperimentFull } from './ExperimentFull'
+import { createNewExperiment, ExperimentFull } from './ExperimentFull'
 
 describe('models/ExperimentFull.ts module', () => {
   describe('ExperimentFull', () => {
@@ -371,6 +371,29 @@ describe('models/ExperimentFull.ts module', () => {
 
       it('should return false if no conclusion data is set', () => {
         expect(Fixtures.createExperimentFull().hasConclusionData()).toBe(false)
+      })
+    })
+  })
+
+  describe('createNewExperiment', () => {
+    it('should return a new experiment', () => {
+      expect(createNewExperiment()).toEqual({
+        experimentId: null,
+        name: null,
+        description: null,
+        startDatetime: null,
+        endDatetime: null,
+        status: null,
+        platform: null,
+        ownerLogin: null,
+        conclusionUrl: null,
+        deployedVariationId: null,
+        endReason: null,
+        existingUsersAllowed: null,
+        p2Url: null,
+        metricAssignments: [],
+        segmentAssignments: [],
+        variations: [],
       })
     })
   })

--- a/models/ExperimentFull.ts
+++ b/models/ExperimentFull.ts
@@ -218,3 +218,22 @@ export class ExperimentFull implements ApiDataSource {
     return !!this.endReason || !!this.conclusionUrl || typeof this.deployedVariationId === 'number'
   }
 }
+
+export const newExperimentTemplate = {
+  experimentId: null,
+  name: null,
+  description: null,
+  startDatetime: null,
+  endDatetime: null,
+  status: null,
+  platform: null,
+  ownerLogin: null,
+  conclusionUrl: null,
+  deployedVariationId: null,
+  endReason: null,
+  existingUsersAllowed: null,
+  p2Url: null,
+  metricAssignments: [],
+  segmentAssignments: [],
+  variations: [],
+}

--- a/models/ExperimentFull.ts
+++ b/models/ExperimentFull.ts
@@ -219,21 +219,23 @@ export class ExperimentFull implements ApiDataSource {
   }
 }
 
-export const newExperimentTemplate = {
-  experimentId: null,
-  name: null,
-  description: null,
-  startDatetime: null,
-  endDatetime: null,
-  status: null,
-  platform: null,
-  ownerLogin: null,
-  conclusionUrl: null,
-  deployedVariationId: null,
-  endReason: null,
-  existingUsersAllowed: null,
-  p2Url: null,
-  metricAssignments: [],
-  segmentAssignments: [],
-  variations: [],
+export function createNewExperiment() {
+  return {
+    experimentId: null,
+    name: null,
+    description: null,
+    startDatetime: null,
+    endDatetime: null,
+    status: null,
+    platform: null,
+    ownerLogin: null,
+    conclusionUrl: null,
+    deployedVariationId: null,
+    endReason: null,
+    existingUsersAllowed: null,
+    p2Url: null,
+    metricAssignments: [],
+    segmentAssignments: [],
+    variations: [],
+  }
 }

--- a/pages/experiments/new.tsx
+++ b/pages/experiments/new.tsx
@@ -1,0 +1,55 @@
+import { LinearProgress, Paper, Typography } from '@material-ui/core'
+import debugFactory from 'debug'
+import React, { useEffect, useState } from 'react'
+
+import MetricsApi from '@/api/MetricsApi'
+import SegmentsApi from '@/api/SegmentsApi'
+import Layout from '@/components/Layout'
+import { MetricBare, Segment } from '@/models'
+
+const debug = debugFactory('abacus:pages/experiments/new.tsx')
+
+const ExperimentsNewPage = function () {
+  debug('ExperimentsNewPage#render')
+  const initialExperiment = {}
+
+  // TODO: Create a component from this point to allow editing as
+  //       well as creation.
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+  const [error, setError] = useState<Error | null>(null)
+  const [metrics, setMetrics] = useState<MetricBare[] | null>(null)
+  const [segments, setSegments] = useState<Segment[] | null>(null)
+
+  useEffect(() => {
+    setIsLoading(true)
+    Promise.all([MetricsApi.findAll(), SegmentsApi.findAll()])
+      .then(([metrics, segments]) => {
+        setMetrics(metrics)
+        setSegments(segments)
+        return
+      })
+      .catch(setError)
+      .finally(() => setIsLoading(false))
+  }, [])
+
+  return (
+    <Layout title='Create an Experiment' error={error}>
+      <Paper>
+        <Typography variant='h5'>initialExperiment</Typography>
+        <pre>{JSON.stringify(initialExperiment, null, 2)}</pre>
+        {isLoading ? (
+          <LinearProgress />
+        ) : (
+          <>
+            <Typography variant='h5'>metrics</Typography>
+            <pre>{JSON.stringify(metrics, null, 2)}</pre>
+            <Typography variant='h5'>segments</Typography>
+            <pre>{JSON.stringify(segments, null, 2)}</pre>
+          </>
+        )}
+      </Paper>
+    </Layout>
+  )
+}
+
+export default ExperimentsNewPage

--- a/pages/experiments/new.tsx
+++ b/pages/experiments/new.tsx
@@ -5,13 +5,13 @@ import React, { useEffect, useState } from 'react'
 import MetricsApi from '@/api/MetricsApi'
 import SegmentsApi from '@/api/SegmentsApi'
 import Layout from '@/components/Layout'
-import { MetricBare, newExperimentTemplate, Segment } from '@/models'
+import { createNewExperiment, MetricBare, Segment } from '@/models'
 
 const debug = debugFactory('abacus:pages/experiments/new.tsx')
 
 const ExperimentsNewPage = function () {
   debug('ExperimentsNewPage#render')
-  const initialExperiment = newExperimentTemplate
+  const initialExperiment = createNewExperiment()
 
   // TODO: Create a component from this point to allow editing as
   //       well as creation.

--- a/pages/experiments/new.tsx
+++ b/pages/experiments/new.tsx
@@ -5,13 +5,13 @@ import React, { useEffect, useState } from 'react'
 import MetricsApi from '@/api/MetricsApi'
 import SegmentsApi from '@/api/SegmentsApi'
 import Layout from '@/components/Layout'
-import { MetricBare, Segment } from '@/models'
+import { MetricBare, newExperimentTemplate, Segment } from '@/models'
 
 const debug = debugFactory('abacus:pages/experiments/new.tsx')
 
 const ExperimentsNewPage = function () {
   debug('ExperimentsNewPage#render')
-  const initialExperiment = {}
+  const initialExperiment = newExperimentTemplate
 
   // TODO: Create a component from this point to allow editing as
   //       well as creation.


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
Adds experiment creation page.
- Loads necessary initial data: metrics, segments
- Adds `newExperimentTemplate` for new experiments
- Adds "for now" link in the top nav

Part of a series on #9 

## How has this been tested?
- MT
- e2e tests to come later
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

