### PR TITLE
Move processing logic from AnalysisSummary to AnalysisProcessor

### DIFF
--- a/utils/AnalysisProcessor.ts
+++ b/utils/AnalysisProcessor.ts
@@ -1,0 +1,51 @@
+import _ from 'lodash'
+
+import { Analysis, AttributionWindowSeconds, ExperimentFull, MetricBare } from '@/models'
+
+// TODO: document and test
+interface ResultSummary {
+  metricAssignmentId: number
+  attributionWindowSeconds: AttributionWindowSeconds
+  metricName: string
+  latestAnalyses: Analysis[]
+}
+
+export default class AnalysisProcessor {
+  public readonly metricAssignmentIdToLatestAnalyses: { [key: number]: Analysis[] }
+  public readonly resultSummaries: ResultSummary[]
+
+  constructor(
+    public readonly analyses: Analysis[],
+    public readonly experiment: ExperimentFull,
+    public readonly metrics: MetricBare[],
+  ) {
+    this.metricAssignmentIdToLatestAnalyses = _.mapValues(
+      _.groupBy(analyses, 'metricAssignmentId'),
+      (metricAnalyses) => {
+        metricAnalyses = _.orderBy(metricAnalyses, ['analysisDatetime'], ['desc'])
+        return _.sortBy(
+          _.filter(metricAnalyses, ['analysisDatetime', metricAnalyses[0].analysisDatetime]),
+          'analysisStrategy',
+        )
+      },
+    )
+
+    const metricsById = _.zipObject(_.map(metrics, 'metricId'), metrics)
+    this.resultSummaries = _.orderBy(
+      experiment.metricAssignments,
+      ['isPrimary', 'metricAssignmentId'],
+      ['desc', 'asc'],
+    ).map(({ metricAssignmentId, attributionWindowSeconds, metricId }) => {
+      return {
+        metricAssignmentId: metricAssignmentId as number,
+        attributionWindowSeconds,
+        metricName: metricsById[metricId].name,
+        latestAnalyses: this.metricAssignmentIdToLatestAnalyses[metricAssignmentId as number],
+      }
+    })
+  }
+
+  getLatestPrimaryMetricAnalyses() {
+    return this.metricAssignmentIdToLatestAnalyses[this.experiment.getPrimaryMetricAssignmentId() as number]
+  }
+}

--- a/utils/AnalysisProcessor.ts
+++ b/utils/AnalysisProcessor.ts
@@ -2,7 +2,10 @@ import _ from 'lodash'
 
 import { Analysis, AttributionWindowSeconds, ExperimentFull, MetricBare } from '@/models'
 
-// TODO: document and test
+/**
+ * A summary of the latest analysis results for a specific metric assignment, containing the information we need to
+ * show the results to the user.
+ */
 interface ResultSummary {
   metricAssignmentId: number
   attributionWindowSeconds: AttributionWindowSeconds
@@ -10,15 +13,33 @@ interface ResultSummary {
   latestAnalyses: Analysis[]
 }
 
+/**
+ * A helper class to handle the processing of an experiment's analyses.
+ */
 export default class AnalysisProcessor {
+  /**
+   * The analyzed experiment.
+   */
+  public readonly experiment: ExperimentFull
+
+  /**
+   * A mapping from each of the experiment's metric assignments to its latest analyses.
+   *
+   * The mapped analyses are guaranteed to be ordered deterministically by analysisStrategy. Determinism is based on the
+   * assumption that there's a single analysis per analysisStrategy for a given analysisDatetime.
+   */
   public readonly metricAssignmentIdToLatestAnalyses: { [key: number]: Analysis[] }
+
+  /**
+   * A flat summary of the latest experiment results for display purposes. See ResultSummary for details.
+   *
+   * This array is guaranteed to have a deterministic order with the primary metric as the first element and the
+   * remaining elements in ascending order by metricAssignmentId.
+   */
   public readonly resultSummaries: ResultSummary[]
 
-  constructor(
-    public readonly analyses: Analysis[],
-    public readonly experiment: ExperimentFull,
-    public readonly metrics: MetricBare[],
-  ) {
+  constructor(analyses: Analysis[], experiment: ExperimentFull, metrics: MetricBare[]) {
+    this.experiment = experiment
     this.metricAssignmentIdToLatestAnalyses = _.mapValues(
       _.groupBy(analyses, 'metricAssignmentId'),
       (metricAnalyses) => {
@@ -45,6 +66,9 @@ export default class AnalysisProcessor {
     })
   }
 
+  /**
+   * Return the latest analyses for the primary metric assignment from metricAssignmentIdToLatestAnalyses.
+   */
   getLatestPrimaryMetricAnalyses() {
     return this.metricAssignmentIdToLatestAnalyses[this.experiment.getPrimaryMetricAssignmentId() as number]
   }


### PR DESCRIPTION
In preparation to addressing #96 and #98, this change moves some of the logic from the `AnalysisSummary` components to a standalone `AnalysisProcessor` helper class, making the components more focused on rendering the processed results.

## How has this been tested?

Technically, it's now possible to test `AnalysisProcessor` in isolation, but for this change I'm relying on the existing tests that still give us full coverage.

<strike>I also had some weird unrelated test failures that seem to be due to SwaggerHub failures. Hopefully it'll be fine on CircleCI.</strike> Yep, looks fine.