### PR TITLE
Fix/double border

### DIFF
--- a/components/AnalysisSummary.test.tsx
+++ b/components/AnalysisSummary.test.tsx
@@ -31,172 +31,227 @@ test('renders the full tables with some analyses', () => {
         Participant counts for the primary metric
       </h3>
       <div
-        class="MuiPaper-root MuiTableContainer-root MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+        style="position: relative;"
       >
-        <table
-          class="MuiTable-root"
+        <div
+          class="Component-horizontalScrollContainer-5"
+          style="overflow-x: auto; position: relative;"
         >
-          <thead
-            class="MuiTableHead-root"
-          >
-            <tr
-              class="MuiTableRow-root MuiTableRow-head"
+          <div>
+            <div
+              style="overflow-y: auto;"
             >
-              <th
-                class="MuiTableCell-root MuiTableCell-head"
-                scope="col"
-              >
-                Strategy
-              </th>
-              <th
-                class="MuiTableCell-root MuiTableCell-head"
-                scope="col"
-              >
-                Total
-              </th>
-              <th
-                class="MuiTableCell-root MuiTableCell-head"
-                scope="col"
-              >
-                <code>
-                  control
-                </code>
-              </th>
-              <th
-                class="MuiTableCell-root MuiTableCell-head"
-                scope="col"
-              >
-                <code>
-                  test
-                </code>
-              </th>
-            </tr>
-          </thead>
-          <tbody
-            class="MuiTableBody-root"
-          >
-            <tr
-              class="MuiTableRow-root"
-            >
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                All participants
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                1000
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                600
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                400
-              </td>
-            </tr>
-            <tr
-              class="MuiTableRow-root"
-            >
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                Without crossovers
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                900
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                540
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                360
-              </td>
-            </tr>
-            <tr
-              class="MuiTableRow-root"
-            >
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                Without spammers
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                850
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                510
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                340
-              </td>
-            </tr>
-            <tr
-              class="MuiTableRow-root"
-            >
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                Without crossovers and spammers
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                800
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                480
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                320
-              </td>
-            </tr>
-            <tr
-              class="MuiTableRow-root"
-            >
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                Exposed without crossovers and spammers
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                700
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                420
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                280
-              </td>
-            </tr>
-          </tbody>
-        </table>
+              <div>
+                <table
+                  class="MuiTable-root"
+                  style="table-layout: auto;"
+                >
+                  <thead
+                    class="MuiTableHead-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root MuiTableRow-head"
+                    >
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                        scope="col"
+                        style="font-weight: 700; box-sizing: border-box;"
+                      >
+                        Strategy
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                        scope="col"
+                        style="font-weight: 700; box-sizing: border-box;"
+                      >
+                        Total
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                        scope="col"
+                        style="font-weight: 700; box-sizing: border-box;"
+                      >
+                        control
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                        scope="col"
+                        style="font-weight: 700; box-sizing: border-box;"
+                      >
+                        test
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    class="MuiTableBody-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root"
+                      index="0"
+                      level="0"
+                      path="0"
+                      style="transition: all ease 300ms; opacity: 0.8;"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        All participants
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        1000
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        600
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        400
+                      </td>
+                    </tr>
+                    <tr
+                      class="MuiTableRow-root"
+                      index="1"
+                      level="0"
+                      path="1"
+                      style="transition: all ease 300ms; opacity: 0.8;"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        Without crossovers
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        900
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        540
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        360
+                      </td>
+                    </tr>
+                    <tr
+                      class="MuiTableRow-root"
+                      index="2"
+                      level="0"
+                      path="2"
+                      style="transition: all ease 300ms; opacity: 0.8;"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        Without spammers
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        850
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        510
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        340
+                      </td>
+                    </tr>
+                    <tr
+                      class="MuiTableRow-root"
+                      index="3"
+                      level="0"
+                      path="3"
+                      style="transition: all ease 300ms; opacity: 0.8;"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        Without crossovers and spammers
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        800
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        480
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        320
+                      </td>
+                    </tr>
+                    <tr
+                      class="MuiTableRow-root"
+                      index="4"
+                      level="0"
+                      path="4"
+                      style="transition: all ease 300ms; opacity: 0.8;"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        Exposed without crossovers and spammers
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        700
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        420
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        280
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   `)
@@ -209,390 +264,436 @@ test('renders the full tables with some analyses', () => {
         Latest results by metric
       </h3>
       <div>
-        <div>
+        <h6
+          class="MuiTypography-root MuiTypography-subtitle1"
+        >
           <strong>
-            Metric: 
+            <code>
+              metric_1
+            </code>
           </strong>
-          <code>
-            metric_1
-          </code>
-        </div>
-        <div>
-          <strong>
-            Attribution window: 
-          </strong>
+           
+          with 
           1 week
-        </div>
-        <div>
-          <strong>
-            Last analyzed: 
-          </strong>
+           attribution, last analyzed on
+           
           <span
-            class="makeStyles-root-1"
+            class="makeStyles-root-7"
             title="09/05/2020, 20:00:00"
           >
             2020-05-10
           </span>
-        </div>
+        </h6>
         <div
-          class="MuiPaper-root MuiTableContainer-root MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+          style="position: relative;"
         >
-          <table
-            class="MuiTable-root"
+          <div
+            class="Component-horizontalScrollContainer-5"
+            style="overflow-x: auto; position: relative;"
           >
-            <thead
-              class="MuiTableHead-root"
-            >
-              <tr
-                class="MuiTableRow-root MuiTableRow-head"
+            <div>
+              <div
+                style="overflow-y: auto;"
               >
-                <th
-                  class="MuiTableCell-root MuiTableCell-head"
-                  scope="col"
-                >
-                  Strategy
-                </th>
-                <th
-                  class="MuiTableCell-root MuiTableCell-head"
-                  scope="col"
-                >
-                  Participants (not final)
-                </th>
-                <th
-                  class="MuiTableCell-root MuiTableCell-head"
-                  scope="col"
-                >
-                  Difference interval
-                </th>
-                <th
-                  class="MuiTableCell-root MuiTableCell-head"
-                  scope="col"
-                >
-                  Recommendation
-                </th>
-                <th
-                  class="MuiTableCell-root MuiTableCell-head"
-                  scope="col"
-                >
-                  Warnings
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              class="MuiTableBody-root"
-            >
-              <tr
-                class="MuiTableRow-root"
-              >
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  All participants
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  1000
-                   (
-                  100
-                  )
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  [
-                  -0.01
-                  , 
-                  0.01
-                  ]
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  End experiment; deploy 
-                  <code>
-                    test
-                  </code>
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  <div>
-                    Experiment period is too short. Wait a few days to be safer.
-                  </div>
-                  <div>
-                    The CI is too wide in comparison to the ROPE. Collect more data to be safer.
-                  </div>
-                </td>
-              </tr>
-              <tr
-                class="MuiTableRow-root"
-              >
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  Without crossovers
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  900
-                   (
-                  90
-                  )
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  [
-                  -0.01
-                  , 
-                  0.01
-                  ]
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  Keep running
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                />
-              </tr>
-              <tr
-                class="MuiTableRow-root"
-              >
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  Without spammers
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  850
-                   (
-                  85
-                  )
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  [
-                  -0.01
-                  , 
-                  0.01
-                  ]
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  End experiment; deploy either variation
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                />
-              </tr>
-              <tr
-                class="MuiTableRow-root"
-              >
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  Without crossovers and spammers
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  800
-                   (
-                  80
-                  )
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  [
-                  -0.01
-                  , 
-                  0.01
-                  ]
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  End experiment; deploy 
-                  <code>
-                    test
-                  </code>
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  <div>
-                    Experiment period is too short. Wait a few days to be safer.
-                  </div>
-                  <div>
-                    The CI is too wide in comparison to the ROPE. Collect more data to be safer.
-                  </div>
-                </td>
-              </tr>
-              <tr
-                class="MuiTableRow-root"
-              >
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  Exposed without crossovers and spammers
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  700
-                   (
-                  70
-                  )
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  [
-                  -0.01
-                  , 
-                  0.01
-                  ]
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  End experiment; deploy 
-                  <code>
-                    test
-                  </code>
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  <div>
-                    Experiment period is too short. Wait a few days to be safer.
-                  </div>
-                  <div>
-                    The CI is too wide in comparison to the ROPE. Collect more data to be safer.
-                  </div>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                <div>
+                  <table
+                    class="MuiTable-root"
+                    style="table-layout: auto;"
+                  >
+                    <thead
+                      class="MuiTableHead-root"
+                    >
+                      <tr
+                        class="MuiTableRow-root MuiTableRow-head"
+                      >
+                        <th
+                          class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                          scope="col"
+                          style="font-weight: 700; box-sizing: border-box;"
+                        >
+                          Strategy
+                        </th>
+                        <th
+                          class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                          scope="col"
+                          style="font-weight: 700; box-sizing: border-box;"
+                        >
+                          Participants (not final)
+                        </th>
+                        <th
+                          class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                          scope="col"
+                          style="font-weight: 700; box-sizing: border-box;"
+                        >
+                          Difference interval
+                        </th>
+                        <th
+                          class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                          scope="col"
+                          style="font-weight: 700; box-sizing: border-box;"
+                        >
+                          Recommendation
+                        </th>
+                        <th
+                          class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                          scope="col"
+                          style="font-weight: 700; box-sizing: border-box;"
+                        >
+                          Warnings
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody
+                      class="MuiTableBody-root"
+                    >
+                      <tr
+                        class="MuiTableRow-root"
+                        index="0"
+                        level="0"
+                        path="0"
+                        style="transition: all ease 300ms; opacity: 0.8;"
+                      >
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          All participants
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          1000 (100)
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          [-0.01, 0.01]
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          End experiment; deploy 
+                          <code>
+                            test
+                          </code>
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          <div>
+                            Experiment period is too short. Wait a few days to be safer.
+                          </div>
+                          <div>
+                            The CI is too wide in comparison to the ROPE. Collect more data to be safer.
+                          </div>
+                        </td>
+                      </tr>
+                      <tr
+                        class="MuiTableRow-root"
+                        index="1"
+                        level="0"
+                        path="1"
+                        style="transition: all ease 300ms; opacity: 0.8;"
+                      >
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          Without crossovers
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          900 (90)
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          [-0.01, 0.01]
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          Keep running
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        />
+                      </tr>
+                      <tr
+                        class="MuiTableRow-root"
+                        index="2"
+                        level="0"
+                        path="2"
+                        style="transition: all ease 300ms; opacity: 0.8;"
+                      >
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          Without spammers
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          850 (85)
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          [-0.01, 0.01]
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          End experiment; deploy either variation
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        />
+                      </tr>
+                      <tr
+                        class="MuiTableRow-root"
+                        index="3"
+                        level="0"
+                        path="3"
+                        style="transition: all ease 300ms; opacity: 0.8;"
+                      >
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          Without crossovers and spammers
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          800 (80)
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          [-0.01, 0.01]
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          End experiment; deploy 
+                          <code>
+                            test
+                          </code>
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          <div>
+                            Experiment period is too short. Wait a few days to be safer.
+                          </div>
+                          <div>
+                            The CI is too wide in comparison to the ROPE. Collect more data to be safer.
+                          </div>
+                        </td>
+                      </tr>
+                      <tr
+                        class="MuiTableRow-root"
+                        index="4"
+                        level="0"
+                        path="4"
+                        style="transition: all ease 300ms; opacity: 0.8;"
+                      >
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          Exposed without crossovers and spammers
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          700 (70)
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          [-0.01, 0.01]
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          End experiment; deploy 
+                          <code>
+                            test
+                          </code>
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          <div>
+                            Experiment period is too short. Wait a few days to be safer.
+                          </div>
+                          <div>
+                            The CI is too wide in comparison to the ROPE. Collect more data to be safer.
+                          </div>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
+        <br />
       </div>
       <div>
-        <div>
+        <h6
+          class="MuiTypography-root MuiTypography-subtitle1"
+        >
           <strong>
-            Metric: 
+            <code>
+              metric_2
+            </code>
           </strong>
-          <code>
-            metric_2
-          </code>
-        </div>
-        <div>
-          <strong>
-            Attribution window: 
-          </strong>
+           
+          with 
           4 weeks
-        </div>
-        <div>
-          <strong>
-            Last analyzed: 
-          </strong>
+           attribution, last analyzed on
+           
           <span
-            class="makeStyles-root-1"
+            class="makeStyles-root-7"
             title="09/05/2020, 20:00:00"
           >
             2020-05-10
           </span>
-        </div>
+        </h6>
         <div
-          class="MuiPaper-root MuiTableContainer-root MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+          style="position: relative;"
         >
-          <table
-            class="MuiTable-root"
+          <div
+            class="Component-horizontalScrollContainer-5"
+            style="overflow-x: auto; position: relative;"
           >
-            <thead
-              class="MuiTableHead-root"
-            >
-              <tr
-                class="MuiTableRow-root MuiTableRow-head"
+            <div>
+              <div
+                style="overflow-y: auto;"
               >
-                <th
-                  class="MuiTableCell-root MuiTableCell-head"
-                  scope="col"
-                >
-                  Strategy
-                </th>
-                <th
-                  class="MuiTableCell-root MuiTableCell-head"
-                  scope="col"
-                >
-                  Participants (not final)
-                </th>
-                <th
-                  class="MuiTableCell-root MuiTableCell-head"
-                  scope="col"
-                >
-                  Difference interval
-                </th>
-                <th
-                  class="MuiTableCell-root MuiTableCell-head"
-                  scope="col"
-                >
-                  Recommendation
-                </th>
-                <th
-                  class="MuiTableCell-root MuiTableCell-head"
-                  scope="col"
-                >
-                  Warnings
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              class="MuiTableBody-root"
-            >
-              <tr
-                class="MuiTableRow-root"
-              >
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  All participants
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  10
-                   (
-                  10
-                  )
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  N/A
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  N/A
-                </td>
-                <td
-                  class="MuiTableCell-root MuiTableCell-body"
-                >
-                  Not analyzed yet
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                <div>
+                  <table
+                    class="MuiTable-root"
+                    style="table-layout: auto;"
+                  >
+                    <thead
+                      class="MuiTableHead-root"
+                    >
+                      <tr
+                        class="MuiTableRow-root MuiTableRow-head"
+                      >
+                        <th
+                          class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                          scope="col"
+                          style="font-weight: 700; box-sizing: border-box;"
+                        >
+                          Strategy
+                        </th>
+                        <th
+                          class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                          scope="col"
+                          style="font-weight: 700; box-sizing: border-box;"
+                        >
+                          Participants (not final)
+                        </th>
+                        <th
+                          class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                          scope="col"
+                          style="font-weight: 700; box-sizing: border-box;"
+                        >
+                          Difference interval
+                        </th>
+                        <th
+                          class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                          scope="col"
+                          style="font-weight: 700; box-sizing: border-box;"
+                        >
+                          Recommendation
+                        </th>
+                        <th
+                          class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                          scope="col"
+                          style="font-weight: 700; box-sizing: border-box;"
+                        >
+                          Warnings
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody
+                      class="MuiTableBody-root"
+                    >
+                      <tr
+                        class="MuiTableRow-root"
+                        index="0"
+                        level="0"
+                        path="0"
+                        style="transition: all ease 300ms; opacity: 0.8;"
+                      >
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          All participants
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          10 (10)
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          N/A
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        />
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
+        <br />
       </div>
     </div>
   `)
@@ -619,76 +720,99 @@ test('renders the full tables with some analyses and a different primary metric'
         Participant counts for the primary metric
       </h3>
       <div
-        class="MuiPaper-root MuiTableContainer-root MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+        style="position: relative;"
       >
-        <table
-          class="MuiTable-root"
+        <div
+          class="Component-horizontalScrollContainer-12"
+          style="overflow-x: auto; position: relative;"
         >
-          <thead
-            class="MuiTableHead-root"
-          >
-            <tr
-              class="MuiTableRow-root MuiTableRow-head"
+          <div>
+            <div
+              style="overflow-y: auto;"
             >
-              <th
-                class="MuiTableCell-root MuiTableCell-head"
-                scope="col"
-              >
-                Strategy
-              </th>
-              <th
-                class="MuiTableCell-root MuiTableCell-head"
-                scope="col"
-              >
-                Total
-              </th>
-              <th
-                class="MuiTableCell-root MuiTableCell-head"
-                scope="col"
-              >
-                <code>
-                  control
-                </code>
-              </th>
-              <th
-                class="MuiTableCell-root MuiTableCell-head"
-                scope="col"
-              >
-                <code>
-                  test
-                </code>
-              </th>
-            </tr>
-          </thead>
-          <tbody
-            class="MuiTableBody-root"
-          >
-            <tr
-              class="MuiTableRow-root"
-            >
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                All participants
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                10
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                10
-              </td>
-              <td
-                class="MuiTableCell-root MuiTableCell-body"
-              >
-                0
-              </td>
-            </tr>
-          </tbody>
-        </table>
+              <div>
+                <table
+                  class="MuiTable-root"
+                  style="table-layout: auto;"
+                >
+                  <thead
+                    class="MuiTableHead-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root MuiTableRow-head"
+                    >
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-13 MuiTableCell-alignLeft"
+                        scope="col"
+                        style="font-weight: 700; box-sizing: border-box;"
+                      >
+                        Strategy
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-13 MuiTableCell-alignLeft"
+                        scope="col"
+                        style="font-weight: 700; box-sizing: border-box;"
+                      >
+                        Total
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-13 MuiTableCell-alignLeft"
+                        scope="col"
+                        style="font-weight: 700; box-sizing: border-box;"
+                      >
+                        control
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-13 MuiTableCell-alignLeft"
+                        scope="col"
+                        style="font-weight: 700; box-sizing: border-box;"
+                      >
+                        test
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    class="MuiTableBody-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root"
+                      index="0"
+                      level="0"
+                      path="0"
+                      style="transition: all ease 300ms; opacity: 0.8;"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        All participants
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        10
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        10
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        0
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   `)

--- a/components/AnalysisSummary.tsx
+++ b/components/AnalysisSummary.tsx
@@ -1,5 +1,6 @@
-import { Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@material-ui/core'
+import { Typography } from '@material-ui/core'
 import _ from 'lodash'
+import MaterialTable from 'material-table'
 import React, { useMemo } from 'react'
 
 import DatetimeText from '@/components/DatetimeText'
@@ -14,6 +15,7 @@ import {
   Variation,
 } from '@/models'
 import AnalysisProcessor from '@/utils/AnalysisProcessor'
+import { createStaticTableOptions } from '@/utils/material-table'
 
 /**
  * Convert a recommendation's endExperiment and chosenVariationId fields to a human-friendly description.
@@ -52,33 +54,22 @@ function ParticipantCounts({
   latestPrimaryMetricAnalyses: Analysis[]
 }) {
   const sortedVariations = _.orderBy(experiment.variations, ['isDefault', 'name'], ['desc', 'asc'])
+  const tableColumns = [
+    { title: 'Strategy', render: ({ analysisStrategy }: Analysis) => AnalysisStrategyToHuman[analysisStrategy] },
+    { title: 'Total', render: ({ participantStats }: Analysis) => participantStats.total },
+  ]
+  sortedVariations.forEach(({ variationId, name }) => {
+    tableColumns.push({
+      title: name,
+      render: ({ participantStats }: Analysis) => participantStats[`variation_${variationId}`] || 0,
+    })
+  })
   return (
-    <TableContainer component={Paper}>
-      <Table>
-        <TableHead>
-          <TableRow>
-            <TableCell>Strategy</TableCell>
-            <TableCell>Total</TableCell>
-            {sortedVariations.map(({ variationId, name }) => (
-              <TableCell key={variationId}>
-                <code>{name}</code>
-              </TableCell>
-            ))}
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {latestPrimaryMetricAnalyses.map(({ analysisStrategy, participantStats }) => (
-            <TableRow key={analysisStrategy}>
-              <TableCell>{AnalysisStrategyToHuman[analysisStrategy]}</TableCell>
-              <TableCell>{participantStats.total}</TableCell>
-              {sortedVariations.map(({ variationId }) => (
-                <TableCell key={variationId}>{participantStats[`variation_${variationId}`] || 0}</TableCell>
-              ))}
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </TableContainer>
+    <MaterialTable
+      columns={tableColumns}
+      data={latestPrimaryMetricAnalyses}
+      options={createStaticTableOptions(latestPrimaryMetricAnalyses.length)}
+    />
   )
 }
 
@@ -88,70 +79,60 @@ function ParticipantCounts({
  * Note: This is likely to change a lot as part of https://github.com/Automattic/abacus/issues/96.
  */
 function LatestResults({ analysisProcessor }: { analysisProcessor: AnalysisProcessor }) {
+  const tableColumns = [
+    { title: 'Strategy', render: ({ analysisStrategy }: Analysis) => AnalysisStrategyToHuman[analysisStrategy] },
+    {
+      title: 'Participants (not final)',
+      render: ({ participantStats }: Analysis) => `${participantStats.total} (${participantStats.not_final})`,
+    },
+    {
+      title: 'Difference interval',
+      render: ({ metricEstimates }: Analysis) =>
+        metricEstimates
+          ? `[${_.round(metricEstimates.diff.bottom, 4)}, ${_.round(metricEstimates.diff.top, 4)}]`
+          : 'N/A',
+    },
+    {
+      title: 'Recommendation',
+      render: ({ recommendation }: Analysis) =>
+        recommendation && (
+          <RecommendationString recommendation={recommendation} experiment={analysisProcessor.experiment} />
+        ),
+    },
+    {
+      title: 'Warnings',
+      render: ({ recommendation }: Analysis) => {
+        if (!recommendation) {
+          return ''
+        }
+        return (
+          <>
+            {recommendation.warnings.map((warning) => (
+              <div key={warning}>{RecommendationWarningToHuman[warning]}</div>
+            ))}
+          </>
+        )
+      },
+    },
+  ]
   return (
     <>
       {analysisProcessor.resultSummaries.map(
         ({ metricAssignmentId, metricName, attributionWindowSeconds, latestAnalyses }) => (
           <div key={metricAssignmentId}>
-            <div>
-              <strong>Metric: </strong>
-              <code>{metricName}</code>
-            </div>
-            <div>
-              <strong>Attribution window: </strong>
-              {AttributionWindowSecondsToHuman[attributionWindowSeconds]}
-            </div>
-            <div>
-              <strong>Last analyzed: </strong>
+            <Typography variant={'subtitle1'}>
+              <strong>
+                <code>{metricName}</code>
+              </strong>{' '}
+              with {AttributionWindowSecondsToHuman[attributionWindowSeconds]} attribution, last analyzed on{' '}
               {DatetimeText({ datetime: latestAnalyses[0].analysisDatetime, excludeTime: true })}
-            </div>
-            <TableContainer component={Paper}>
-              <Table>
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Strategy</TableCell>
-                    <TableCell>Participants (not final)</TableCell>
-                    <TableCell>Difference interval</TableCell>
-                    <TableCell>Recommendation</TableCell>
-                    <TableCell>Warnings</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {latestAnalyses.map(({ analysisStrategy, participantStats, metricEstimates, recommendation }) => (
-                    <TableRow key={`${metricAssignmentId}_${analysisStrategy}`}>
-                      <TableCell>{AnalysisStrategyToHuman[analysisStrategy]}</TableCell>
-                      <TableCell>
-                        {participantStats.total} ({participantStats.not_final})
-                      </TableCell>
-                      {metricEstimates && recommendation ? (
-                        <>
-                          <TableCell>
-                            [{_.round(metricEstimates.diff.bottom, 4)}, {_.round(metricEstimates.diff.top, 4)}]
-                          </TableCell>
-                          <TableCell>
-                            <RecommendationString
-                              recommendation={recommendation}
-                              experiment={analysisProcessor.experiment}
-                            />
-                          </TableCell>
-                          <TableCell>
-                            {recommendation.warnings.map((warning) => (
-                              <div key={warning}>{RecommendationWarningToHuman[warning]}</div>
-                            ))}
-                          </TableCell>
-                        </>
-                      ) : (
-                        <>
-                          <TableCell>N/A</TableCell>
-                          <TableCell>N/A</TableCell>
-                          <TableCell>Not analyzed yet</TableCell>
-                        </>
-                      )}
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </TableContainer>
+            </Typography>
+            <MaterialTable
+              columns={tableColumns}
+              data={latestAnalyses}
+              options={createStaticTableOptions(latestAnalyses.length)}
+            />
+            <br />
           </div>
         ),
       )}

--- a/components/__snapshots__/AnalysisSummary.test.tsx.snap
+++ b/components/__snapshots__/AnalysisSummary.test.tsx.snap
@@ -40,7 +40,10 @@ exports[`shows the analyses JSON in debug mode 1`] = `
         "wide_ci"
       ]
     },
-    "analysisDatetime": "2020-05-10T00:00:00.000Z"
+    "analysisDatetime": "2020-05-10T00:00:00.000Z",
+    "tableData": {
+      "id": 0
+    }
   },
   {
     "metricAssignmentId": 123,
@@ -74,7 +77,10 @@ exports[`shows the analyses JSON in debug mode 1`] = `
       "reason": "rope_in_ci",
       "warnings": []
     },
-    "analysisDatetime": "2020-05-10T00:00:00.000Z"
+    "analysisDatetime": "2020-05-10T00:00:00.000Z",
+    "tableData": {
+      "id": 1
+    }
   },
   {
     "metricAssignmentId": 123,
@@ -108,7 +114,10 @@ exports[`shows the analyses JSON in debug mode 1`] = `
       "reason": "ci_in_rope",
       "warnings": []
     },
-    "analysisDatetime": "2020-05-10T00:00:00.000Z"
+    "analysisDatetime": "2020-05-10T00:00:00.000Z",
+    "tableData": {
+      "id": 2
+    }
   },
   {
     "metricAssignmentId": 123,
@@ -145,7 +154,10 @@ exports[`shows the analyses JSON in debug mode 1`] = `
         "wide_ci"
       ]
     },
-    "analysisDatetime": "2020-05-10T00:00:00.000Z"
+    "analysisDatetime": "2020-05-10T00:00:00.000Z",
+    "tableData": {
+      "id": 3
+    }
   },
   {
     "metricAssignmentId": 123,
@@ -182,7 +194,10 @@ exports[`shows the analyses JSON in debug mode 1`] = `
         "wide_ci"
       ]
     },
-    "analysisDatetime": "2020-05-10T00:00:00.000Z"
+    "analysisDatetime": "2020-05-10T00:00:00.000Z",
+    "tableData": {
+      "id": 4
+    }
   },
   {
     "metricAssignmentId": 123,
@@ -373,7 +388,10 @@ exports[`shows the analyses JSON in debug mode 1`] = `
     },
     "metricEstimates": null,
     "recommendation": null,
-    "analysisDatetime": "2020-05-10T00:00:00.000Z"
+    "analysisDatetime": "2020-05-10T00:00:00.000Z",
+    "tableData": {
+      "id": 0
+    }
   }
 ]
 </pre>

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -31,13 +31,13 @@ const theme = createMuiTheme({
   overrides: {
     MuiCssBaseline: {
       '@global': {
-        // Remove the last table cell border of a top-level MuiTable when in MuiPaper.
-        // Otherwise the paper's border butts up with the last table cell's border.
+        // Remove the last table cell border of a MuiTable when in MuiPaper. Otherwise the
+        // paper's border butts up with the last table cell's border.
         // Note: The child combinators are required to avoid selecting nested tables.
-        '.MuiPaper-root .MuiTable-root > .MuiTableBody-root > .MuiTableRow-root:last-child > .MuiTableCell-root': {
-          borderBottom: '0',
-        },
-        '.MuiTable-root .MuiTableFooter-root .MuiTableRow-root:last-child > .MuiTableCell-root': {
+        [[
+          '.MuiPaper-root .MuiTable-root .MuiTableBody-root > .MuiTableRow-root:last-child > .MuiTableCell-root',
+          '.MuiPaper-root .MuiTable-root .MuiTableFooter-root > .MuiTableRow-root:last-child > .MuiTableCell-root',
+        ].join(', ')]: {
           borderBottom: '0',
         },
       },
@@ -50,16 +50,6 @@ const theme = createMuiTheme({
         },
       },
     },
-    MuiTablePagination: {
-      root: {
-        // Copied from @material-ui/core/TableCell
-        borderTop: `1px solid ${
-          baseTheme.palette.type === 'light'
-            ? lighten(fade(baseTheme.palette.divider, 1), 0.88)
-            : darken(fade(baseTheme.palette.divider, 1), 0.68)
-        }`,
-      },
-    },
     MuiTableCell: {
       head: {
         fontWeight: 700,
@@ -69,6 +59,18 @@ const theme = createMuiTheme({
         [baseTheme.breakpoints.down('xs')]: {
           padding: baseTheme.spacing(1),
         },
+      },
+    },
+    MuiTableFooter: {
+      root: {
+        // Adds back the border that is removed by the global MuiTableCell-root rules in
+        // `theme.overrides.MuiCssBaseline@global`.
+        // Copied from @material-ui/core/TableCell
+        borderTop: `1px solid ${
+          baseTheme.palette.type === 'light'
+            ? lighten(fade(baseTheme.palette.divider, 1), 0.88)
+            : darken(fade(baseTheme.palette.divider, 1), 0.68)
+        }`,
       },
     },
   },

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -1,4 +1,5 @@
 import { createMuiTheme } from '@material-ui/core/styles'
+import { darken, fade, lighten } from '@material-ui/core/styles/colorManipulator'
 
 declare module '@material-ui/core/styles/createPalette' {
   interface TypeBackground {
@@ -33,16 +34,10 @@ const theme = createMuiTheme({
         // Remove the last table cell border of a top-level MuiTable when in MuiPaper.
         // Otherwise the paper's border butts up with the last table cell's border.
         // Note: The child combinators are required to avoid selecting nested tables.
-        '.MuiPaper-root > .MuiTable-root > .MuiTableBody-root > .MuiTableRow-root:last-child > .MuiTableCell-root': {
+        '.MuiPaper-root .MuiTable-root > .MuiTableBody-root > .MuiTableRow-root:last-child > .MuiTableCell-root': {
           borderBottom: '0',
         },
-        // Remove the last table cell border when in a nested MuiTable. Otherwise the parent
-        // table's cell's border butts up with the nested table's last cell border.
-        // Note: Only interested in removing the table cell border from the table body and
-        // not from the table head.
-        // Note: This is a known issue and is scheduled to be addressed in MUI v5. See
-        // https://github.com/mui-org/material-ui/pull/20809.
-        '.MuiTable-root .MuiTable-root .MuiTableBody-root .MuiTableRow-root:last-child > .MuiTableCell-root': {
+        '.MuiTable-root .MuiTableFooter-root .MuiTableRow-root:last-child > .MuiTableCell-root': {
           borderBottom: '0',
         },
       },
@@ -53,6 +48,16 @@ const theme = createMuiTheme({
         [baseTheme.breakpoints.down('xs')]: {
           padding: baseTheme.spacing(1),
         },
+      },
+    },
+    MuiTablePagination: {
+      root: {
+        // Copied from @material-ui/core/TableCell
+        borderTop: `1px solid ${
+          baseTheme.palette.type === 'light'
+            ? lighten(fade(baseTheme.palette.divider, 1), 0.88)
+            : darken(fade(baseTheme.palette.divider, 1), 0.68)
+        }`,
       },
     },
     MuiTableCell: {

--- a/utils/AnalysisProcessor.ts
+++ b/utils/AnalysisProcessor.ts
@@ -1,0 +1,51 @@
+import _ from 'lodash'
+
+import { Analysis, AttributionWindowSeconds, ExperimentFull, MetricBare } from '@/models'
+
+// TODO: document and test
+interface ResultSummary {
+  metricAssignmentId: number
+  attributionWindowSeconds: AttributionWindowSeconds
+  metricName: string
+  latestAnalyses: Analysis[]
+}
+
+export default class AnalysisProcessor {
+  public readonly metricAssignmentIdToLatestAnalyses: { [key: number]: Analysis[] }
+  public readonly resultSummaries: ResultSummary[]
+
+  constructor(
+    public readonly analyses: Analysis[],
+    public readonly experiment: ExperimentFull,
+    public readonly metrics: MetricBare[],
+  ) {
+    this.metricAssignmentIdToLatestAnalyses = _.mapValues(
+      _.groupBy(analyses, 'metricAssignmentId'),
+      (metricAnalyses) => {
+        metricAnalyses = _.orderBy(metricAnalyses, ['analysisDatetime'], ['desc'])
+        return _.sortBy(
+          _.filter(metricAnalyses, ['analysisDatetime', metricAnalyses[0].analysisDatetime]),
+          'analysisStrategy',
+        )
+      },
+    )
+
+    const metricsById = _.zipObject(_.map(metrics, 'metricId'), metrics)
+    this.resultSummaries = _.orderBy(
+      experiment.metricAssignments,
+      ['isPrimary', 'metricAssignmentId'],
+      ['desc', 'asc'],
+    ).map(({ metricAssignmentId, attributionWindowSeconds, metricId }) => {
+      return {
+        metricAssignmentId: metricAssignmentId as number,
+        attributionWindowSeconds,
+        metricName: metricsById[metricId].name,
+        latestAnalyses: this.metricAssignmentIdToLatestAnalyses[metricAssignmentId as number],
+      }
+    })
+  }
+
+  getLatestPrimaryMetricAnalyses() {
+    return this.metricAssignmentIdToLatestAnalyses[this.experiment.getPrimaryMetricAssignmentId() as number]
+  }
+}

--- a/utils/AnalysisProcessor.ts
+++ b/utils/AnalysisProcessor.ts
@@ -2,7 +2,10 @@ import _ from 'lodash'
 
 import { Analysis, AttributionWindowSeconds, ExperimentFull, MetricBare } from '@/models'
 
-// TODO: document and test
+/**
+ * A summary of the latest analysis results for a specific metric assignment, containing the information we need to
+ * show the results to the user.
+ */
 interface ResultSummary {
   metricAssignmentId: number
   attributionWindowSeconds: AttributionWindowSeconds
@@ -10,15 +13,33 @@ interface ResultSummary {
   latestAnalyses: Analysis[]
 }
 
+/**
+ * A helper class to handle the processing of an experiment's analyses.
+ */
 export default class AnalysisProcessor {
+  /**
+   * The analyzed experiment.
+   */
+  public readonly experiment: ExperimentFull
+
+  /**
+   * A mapping from each of the experiment's metric assignments to its latest analyses.
+   *
+   * The mapped analyses are guaranteed to be ordered deterministically by analysisStrategy. Determinism is based on the
+   * assumption that there's a single analysis per analysisStrategy for a given analysisDatetime.
+   */
   public readonly metricAssignmentIdToLatestAnalyses: { [key: number]: Analysis[] }
+
+  /**
+   * A flat summary of the latest experiment results for display purposes. See ResultSummary for details.
+   *
+   * This array is guaranteed to have a deterministic order with the primary metric as the first element and the
+   * remaining elements in ascending order by metricAssignmentId.
+   */
   public readonly resultSummaries: ResultSummary[]
 
-  constructor(
-    public readonly analyses: Analysis[],
-    public readonly experiment: ExperimentFull,
-    public readonly metrics: MetricBare[],
-  ) {
+  constructor(analyses: Analysis[], experiment: ExperimentFull, metrics: MetricBare[]) {
+    this.experiment = experiment
     this.metricAssignmentIdToLatestAnalyses = _.mapValues(
       _.groupBy(analyses, 'metricAssignmentId'),
       (metricAnalyses) => {
@@ -45,6 +66,9 @@ export default class AnalysisProcessor {
     })
   }
 
+  /**
+   * Return the latest analyses for the primary metric assignment from metricAssignmentIdToLatestAnalyses.
+   */
   getLatestPrimaryMetricAnalyses() {
     return this.metricAssignmentIdToLatestAnalyses[this.experiment.getPrimaryMetricAssignmentId() as number]
   }

--- a/utils/material-table.ts
+++ b/utils/material-table.ts
@@ -2,6 +2,9 @@ import { Options } from 'material-table'
 
 import theme from '@/styles/theme'
 
+/**
+ * Default table options for dynamic MaterialTable instances.
+ */
 export const defaultTableOptions: Options = {
   emptyRowsWhenPaging: false,
   pageSize: 25,
@@ -19,4 +22,20 @@ export const defaultTableOptions: Options = {
   rowStyle: {
     opacity: 0.8,
   },
+}
+
+/**
+ * Create an Options object that can be passed to MaterialTable to create a static table with no toolbar or pagination.
+ *
+ * @param numRows the exact number of rows that the table should have.
+ */
+export function createStaticTableOptions(numRows: number): Options {
+  return {
+    ...defaultTableOptions,
+    pageSize: numRows,
+    draggable: false,
+    paging: false,
+    sorting: false,
+    toolbar: false,
+  }
 }


### PR DESCRIPTION
Fix Double Border in MaterialTables.

## How has this been tested?

Manually, visually confirmed double borders were removed from MaterialTables while maintaining the expected borders with raw MUI Tables.