### PR TITLE
Fix Double Border Issue

### DIFF
--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -1,4 +1,5 @@
 import { createMuiTheme } from '@material-ui/core/styles'
+import { darken, fade, lighten } from '@material-ui/core/styles/colorManipulator'
 
 declare module '@material-ui/core/styles/createPalette' {
   interface TypeBackground {
@@ -35,19 +36,19 @@ const theme = createMuiTheme({
   overrides: {
     MuiCssBaseline: {
       '@global': {
-        // Remove the last table cell border of a top-level MuiTable when in MuiPaper.
-        // Otherwise the paper's border butts up with the last table cell's border.
-        // Note: The child combinators are required to avoid selecting nested tables.
-        '.MuiPaper-root > .MuiTable-root > .MuiTableBody-root > .MuiTableRow-root:last-child > .MuiTableCell-root': {
-          borderBottom: '0',
-        },
-        // Remove the last table cell border when in a nested MuiTable. Otherwise the parent
-        // table's cell's border butts up with the nested table's last cell border.
+        // Remove the last table cell border of a MuiTable when in MuiPaper. Otherwise the
+        // paper's border butts up with the last table cell's border.
+        // Also removes the last table cell border when in a nested MuiTable. Otherwise the
+        // parent table's cell's border butts up with the nested table's last cell border.
         // Note: Only interested in removing the table cell border from the table body and
-        // not from the table head.
+        // table footer but not from the table head.
         // Note: This is a known issue and is scheduled to be addressed in MUI v5. See
         // https://github.com/mui-org/material-ui/pull/20809.
-        '.MuiTable-root .MuiTable-root .MuiTableBody-root .MuiTableRow-root:last-child > .MuiTableCell-root': {
+        // Note: The child combinators are required to avoid selecting nested tables.
+        [[
+          '.MuiPaper-root .MuiTable-root .MuiTableBody-root > .MuiTableRow-root:last-child > .MuiTableCell-root',
+          '.MuiPaper-root .MuiTable-root .MuiTableFooter-root > .MuiTableRow-root:last-child > .MuiTableCell-root',
+        ].join(', ')]: {
           borderBottom: '0',
         },
       },
@@ -70,6 +71,18 @@ const theme = createMuiTheme({
         [baseTheme.breakpoints.down('xs')]: {
           padding: baseTheme.spacing(1),
         },
+      },
+    },
+    MuiTableFooter: {
+      root: {
+        // Adds back the border that is removed by the global MuiTableCell-root rules in
+        // `theme.overrides.MuiCssBaseline@global`.
+        // Copied from @material-ui/core/TableCell
+        borderTop: `1px solid ${
+          baseTheme.palette.type === 'light'
+            ? lighten(fade(baseTheme.palette.divider, 1), 0.88)
+            : darken(fade(baseTheme.palette.divider, 1), 0.68)
+        }`,
       },
     },
   },


### PR DESCRIPTION
Fix Double Border Issue. (Basically a re-based version of #185).

Removes the double border between the last row in a table and the surrounding paper.

## How has this been tested?

Manually, visually tested.