### PR TITLE
Add canonical sorting methods and simplify AnalysisSummary

### DIFF
--- a/components/AnalysisSummary.test.tsx
+++ b/components/AnalysisSummary.test.tsx
@@ -275,8 +275,7 @@ test('renders the full tables with some analyses', () => {
            
           with 
           1 week
-           attribution, last analyzed on
-           
+           attribution, last analyzed on 
           <span
             class="makeStyles-root-7"
             title="09/05/2020, 20:00:00"
@@ -578,8 +577,7 @@ test('renders the full tables with some analyses', () => {
            
           with 
           4 weeks
-           attribution, last analyzed on
-           
+           attribution, last analyzed on 
           <span
             class="makeStyles-root-7"
             title="09/05/2020, 20:00:00"

--- a/components/AudiencePanel.tsx
+++ b/components/AudiencePanel.tsx
@@ -61,7 +61,7 @@ function AudiencePanel({ experiment, segments }: { experiment: ExperimentFull; s
     {
       label: 'Variations',
       padding: 'none' as TableCellProps['padding'],
-      value: <VariationsTable variations={experiment.variations} />,
+      value: <VariationsTable variations={experiment.getSortedVariations()} />,
     },
     {
       label: 'Segments',

--- a/components/MetricAssignmentsPanel.tsx
+++ b/components/MetricAssignmentsPanel.tsx
@@ -6,7 +6,6 @@ import TableCell from '@material-ui/core/TableCell'
 import TableHead from '@material-ui/core/TableHead'
 import TableRow from '@material-ui/core/TableRow'
 import Typography from '@material-ui/core/Typography'
-import _ from 'lodash'
 import React, { useMemo } from 'react'
 
 import Label from '@/components/Label'
@@ -60,13 +59,8 @@ const useStyles = makeStyles((theme: Theme) =>
 function MetricAssignmentsPanel({ experiment, metrics }: { experiment: ExperimentFull; metrics: MetricBare[] }) {
   const classes = useStyles()
   const resolvedMetricAssignments = useMemo(
-    () =>
-      _.orderBy(
-        resolveMetricAssignments(experiment.metricAssignments, metrics),
-        ['isPrimary', _.property('metric.name')],
-        ['desc', 'asc'],
-      ),
-    [experiment.metricAssignments, metrics],
+    () => resolveMetricAssignments(experiment.getSortedMetricAssignments(), metrics),
+    [experiment, metrics],
   )
 
   return (

--- a/components/VariationsTable.tsx
+++ b/components/VariationsTable.tsx
@@ -4,7 +4,6 @@ import TableBody from '@material-ui/core/TableBody'
 import TableCell from '@material-ui/core/TableCell'
 import TableHead from '@material-ui/core/TableHead'
 import TableRow from '@material-ui/core/TableRow'
-import _ from 'lodash'
 import React from 'react'
 
 import Label from '@/components/Label'
@@ -19,13 +18,12 @@ const useStyles = makeStyles((theme: Theme) =>
 )
 
 /**
- * Renders the variations in tabular formation.
+ * Renders the variations in tabular formation, in the order that they're given.
  *
  * @param props.variations - The variations to render.
  */
 function VariationsTable({ variations }: { variations: Variation[] }) {
   const classes = useStyles()
-  const sortedVariations = _.orderBy(variations, ['isDefault', 'name'], ['desc', 'asc'])
   return (
     <Table>
       <TableHead>
@@ -39,7 +37,7 @@ function VariationsTable({ variations }: { variations: Variation[] }) {
         </TableRow>
       </TableHead>
       <TableBody>
-        {sortedVariations.map((variation) => {
+        {variations.map((variation) => {
           return (
             <TableRow key={variation.variationId}>
               <TableCell>

--- a/models/ExperimentFull.test.ts
+++ b/models/ExperimentFull.test.ts
@@ -1,5 +1,5 @@
 import Fixtures from '@/helpers/fixtures'
-import { AttributionWindowSeconds, Platform, Status } from '@/models'
+import { AttributionWindowSeconds, Platform, Status, Variation } from '@/models'
 
 import { createNewExperiment, ExperimentFull } from './ExperimentFull'
 
@@ -371,6 +371,90 @@ describe('models/ExperimentFull.ts module', () => {
 
       it('should return false if no conclusion data is set', () => {
         expect(Fixtures.createExperimentFull().hasConclusionData()).toBe(false)
+      })
+    })
+
+    describe('getSortedVariations', () => {
+      it('returns the variations sorted in the canonical order', () => {
+        const sortedVariations = [
+          new Variation({
+            variationId: 1,
+            name: 'control',
+            isDefault: true,
+            allocatedPercentage: 60,
+          }),
+          new Variation({
+            variationId: 3,
+            name: 'test_a',
+            isDefault: false,
+            allocatedPercentage: 30,
+          }),
+          new Variation({
+            variationId: 2,
+            name: 'test_b',
+            isDefault: false,
+            allocatedPercentage: 10,
+          }),
+        ]
+
+        expect(Fixtures.createExperimentFull({ variations: sortedVariations }).getSortedVariations()).toEqual(
+          sortedVariations,
+        )
+        expect(
+          Fixtures.createExperimentFull({
+            variations: [sortedVariations[1], sortedVariations[0], sortedVariations[2]],
+          }).getSortedVariations(),
+        ).toEqual(sortedVariations)
+        expect(
+          Fixtures.createExperimentFull({
+            variations: [sortedVariations[2], sortedVariations[1], sortedVariations[0]],
+          }).getSortedVariations(),
+        ).toEqual(sortedVariations)
+      })
+    })
+
+    describe('getSortedMetricAssignments', () => {
+      it('returns the metric assignments sorted in the canonical order', () => {
+        const sortedMetricAssignments = [
+          Fixtures.createMetricAssignment({
+            metricAssignmentId: 123,
+            metricId: 1,
+            attributionWindowSeconds: AttributionWindowSeconds.OneWeek,
+            changeExpected: true,
+            isPrimary: true,
+            minDifference: 0.1,
+          }),
+          Fixtures.createMetricAssignment({
+            metricAssignmentId: 124,
+            metricId: 2,
+            attributionWindowSeconds: AttributionWindowSeconds.FourWeeks,
+            changeExpected: false,
+            isPrimary: false,
+            minDifference: 10.5,
+          }),
+          Fixtures.createMetricAssignment({
+            metricAssignmentId: 125,
+            metricId: 3,
+            attributionWindowSeconds: AttributionWindowSeconds.OneHour,
+            changeExpected: false,
+            isPrimary: false,
+            minDifference: 0.05,
+          }),
+        ]
+
+        expect(
+          Fixtures.createExperimentFull({ metricAssignments: sortedMetricAssignments }).getSortedMetricAssignments(),
+        ).toEqual(sortedMetricAssignments)
+        expect(
+          Fixtures.createExperimentFull({
+            metricAssignments: [sortedMetricAssignments[1], sortedMetricAssignments[0], sortedMetricAssignments[2]],
+          }).getSortedMetricAssignments(),
+        ).toEqual(sortedMetricAssignments)
+        expect(
+          Fixtures.createExperimentFull({
+            metricAssignments: [sortedMetricAssignments[2], sortedMetricAssignments[1], sortedMetricAssignments[0]],
+          }).getSortedMetricAssignments(),
+        ).toEqual(sortedMetricAssignments)
       })
     })
   })

--- a/models/ExperimentFull.ts
+++ b/models/ExperimentFull.ts
@@ -1,3 +1,5 @@
+import _ from 'lodash'
+
 import { ApiData } from '@/api/ApiData'
 import { ApiDataSource } from '@/api/ApiDataSource'
 import { ExcludeMethods } from '@/types/ExcludeMethods'
@@ -216,6 +218,20 @@ export class ExperimentFull implements ApiDataSource {
    */
   hasConclusionData(): boolean {
     return !!this.endReason || !!this.conclusionUrl || typeof this.deployedVariationId === 'number'
+  }
+
+  /**
+   * Return the experiment's variations sorted in the canonical order: Default first, then by name.
+   */
+  getSortedVariations(): Variation[] {
+    return _.orderBy(this.variations, ['isDefault', 'name'], ['desc', 'asc'])
+  }
+
+  /**
+   * Return the experiment's variations sorted in the canonical order: Primary first, then by ID.
+   */
+  getSortedMetricAssignments() {
+    return _.orderBy(this.metricAssignments, ['isPrimary', 'metricAssignmentId'], ['desc', 'asc'])
   }
 }
 


### PR DESCRIPTION
In preparation to addressing #96 and #98 and as an alternative to #180, this PR adds `getSortedVariations()` and `getSortedMetricAssignments()` to `ExperimentFull` and uses them to simplify the `AnalysisSummary` component and other components that should follow the canonical order for those fields.

## How has this been tested?

Automated testing, which now includes tests for the new methods.