### PR TITLE
Tweak experiment results and improve fixtures

### DIFF
--- a/components/MetricAssignmentsPanel.test.tsx
+++ b/components/MetricAssignmentsPanel.test.tsx
@@ -119,6 +119,58 @@ test('renders as expected with all metrics resolvable', () => {
                 No
               </td>
             </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                metric_2
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <span>
+                  $0.50
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                1 hour
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                Yes
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                metric_3
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <span>
+                  12 pp
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                6 hours
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                Yes
+              </td>
+            </tr>
           </tbody>
         </table>
       </div>

--- a/components/MetricsTable.test.tsx
+++ b/components/MetricsTable.test.tsx
@@ -51,12 +51,12 @@ test('with some metrics, loads and opens metric details', async () => {
   const tBodyElmt = container.querySelector('tbody') as HTMLTableSectionElement
   expect(tBodyElmt).not.toBeNull()
 
-  for (let i = 0; i < 6; i++) {
+  for (let i = 1; i < 7; i++) {
     const metricFull = Fixtures.createMetricFull(i)
     mockedMetricsApi.findById.mockResolvedValueOnce(metricFull)
 
     // Open metric details
-    fireEvent.click(getByText(container, /metric_0/))
+    fireEvent.click(getByText(container, /metric_1/))
 
     await waitFor(() => getByText(container, /Higher is Better/), { container })
     metricFull.higherIsBetter ? getByText(container, /Yes/) : getByText(container, /No/)
@@ -72,6 +72,6 @@ test('with some metrics, loads and opens metric details', async () => {
     )
 
     // Close metric details
-    fireEvent.click(getByText(container, /metric_0/))
+    fireEvent.click(getByText(container, /metric_1/))
   }
 })

--- a/components/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/components/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -228,6 +228,58 @@ exports[`renders as expected at large width 1`] = `
                     No
                   </td>
                 </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    metric_2
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    <span>
+                      $0.50
+                    </span>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    1 hour
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    Yes
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    metric_3
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    <span>
+                      12 pp
+                    </span>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    6 hours
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    Yes
+                  </td>
+                </tr>
               </tbody>
             </table>
           </div>
@@ -900,6 +952,58 @@ exports[`renders as expected at small width 1`] = `
                     No
                   </td>
                 </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    metric_2
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    <span>
+                      $0.50
+                    </span>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    1 hour
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    Yes
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    metric_3
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    <span>
+                      12 pp
+                    </span>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    6 hours
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    Yes
+                  </td>
+                </tr>
               </tbody>
             </table>
           </div>
@@ -1353,6 +1457,58 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     No
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    metric_2
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    <span>
+                      $0.50
+                    </span>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    1 hour
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    Yes
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    metric_3
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    <span>
+                      12 pp
+                    </span>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    6 hours
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    Yes
                   </td>
                 </tr>
               </tbody>
@@ -1883,6 +2039,58 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     No
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    metric_2
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    <span>
+                      $0.50
+                    </span>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    1 hour
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    Yes
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    metric_3
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    <span>
+                      12 pp
+                    </span>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    6 hours
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    Yes
                   </td>
                 </tr>
               </tbody>

--- a/components/experiment-results/ExperimentResults.test.tsx
+++ b/components/experiment-results/ExperimentResults.test.tsx
@@ -16,7 +16,6 @@ test('renders an appropriate message with no analyses', () => {
 test('renders the full tables with some analyses', () => {
   const { container } = render(<ExperimentResults analyses={analyses} experiment={experiment} metrics={metrics} />)
 
-  expect(container).toHaveTextContent(`Found ${analyses.length} analysis objects in total.`)
   // In non-debug mode, we shouldn't have a <pre> element with the JSON.
   expect(container.querySelector('pre')).toBeNull()
 
@@ -274,7 +273,9 @@ test('renders the full tables with some analyses', () => {
            
           with 
           1 week
-           attribution, last analyzed on 
+           attribution,
+           
+          last analyzed on 
           <span
             class="makeStyles-root-7"
             title="09/05/2020, 20:00:00"
@@ -374,7 +375,7 @@ test('renders the full tables with some analyses', () => {
                           class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                           style="box-sizing: border-box;"
                         >
-                          End experiment; deploy 
+                          Deploy 
                           <code>
                             test
                           </code>
@@ -420,7 +421,7 @@ test('renders the full tables with some analyses', () => {
                           class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                           style="box-sizing: border-box;"
                         >
-                          Keep running
+                          Inconclusive
                         </td>
                         <td
                           class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -456,7 +457,7 @@ test('renders the full tables with some analyses', () => {
                           class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                           style="box-sizing: border-box;"
                         >
-                          End experiment; deploy either variation
+                          Deploy either variation
                         </td>
                         <td
                           class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -492,7 +493,7 @@ test('renders the full tables with some analyses', () => {
                           class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                           style="box-sizing: border-box;"
                         >
-                          End experiment; deploy 
+                          Deploy 
                           <code>
                             test
                           </code>
@@ -538,7 +539,7 @@ test('renders the full tables with some analyses', () => {
                           class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                           style="box-sizing: border-box;"
                         >
-                          End experiment; deploy 
+                          Deploy 
                           <code>
                             test
                           </code>
@@ -576,7 +577,9 @@ test('renders the full tables with some analyses', () => {
            
           with 
           4 weeks
-           attribution, last analyzed on 
+           attribution,
+           
+          last analyzed on 
           <span
             class="makeStyles-root-7"
             title="09/05/2020, 20:00:00"
@@ -692,6 +695,419 @@ test('renders the full tables with some analyses', () => {
         </div>
         <br />
       </div>
+      <div>
+        <h6
+          class="MuiTypography-root MuiTypography-subtitle1"
+        >
+          <strong>
+            <code>
+              metric_2
+            </code>
+          </strong>
+           
+          with 
+          1 hour
+           attribution,
+           
+          <strong>
+            not analyzed yet
+          </strong>
+        </h6>
+        <div
+          class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+          style="position: relative;"
+        >
+          <div
+            class="Component-horizontalScrollContainer-5"
+            style="overflow-x: auto; position: relative;"
+          >
+            <div>
+              <div
+                style="overflow-y: auto;"
+              >
+                <div>
+                  <table
+                    class="MuiTable-root"
+                    style="table-layout: auto;"
+                  >
+                    <thead
+                      class="MuiTableHead-root"
+                    >
+                      <tr
+                        class="MuiTableRow-root MuiTableRow-head"
+                      >
+                        <th
+                          class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                          scope="col"
+                          style="font-weight: 700; box-sizing: border-box;"
+                        >
+                          Strategy
+                        </th>
+                        <th
+                          class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                          scope="col"
+                          style="font-weight: 700; box-sizing: border-box;"
+                        >
+                          Participants (not final)
+                        </th>
+                        <th
+                          class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                          scope="col"
+                          style="font-weight: 700; box-sizing: border-box;"
+                        >
+                          Difference interval
+                        </th>
+                        <th
+                          class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                          scope="col"
+                          style="font-weight: 700; box-sizing: border-box;"
+                        >
+                          Recommendation
+                        </th>
+                        <th
+                          class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                          scope="col"
+                          style="font-weight: 700; box-sizing: border-box;"
+                        >
+                          Warnings
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody
+                      class="MuiTableBody-root"
+                    />
+                  </table>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <br />
+      </div>
+      <div>
+        <h6
+          class="MuiTypography-root MuiTypography-subtitle1"
+        >
+          <strong>
+            <code>
+              metric_3
+            </code>
+          </strong>
+           
+          with 
+          6 hours
+           attribution,
+           
+          last analyzed on 
+          <span
+            class="makeStyles-root-7"
+            title="09/05/2020, 20:00:00"
+          >
+            2020-05-10
+          </span>
+        </h6>
+        <div
+          class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+          style="position: relative;"
+        >
+          <div
+            class="Component-horizontalScrollContainer-5"
+            style="overflow-x: auto; position: relative;"
+          >
+            <div>
+              <div
+                style="overflow-y: auto;"
+              >
+                <div>
+                  <table
+                    class="MuiTable-root"
+                    style="table-layout: auto;"
+                  >
+                    <thead
+                      class="MuiTableHead-root"
+                    >
+                      <tr
+                        class="MuiTableRow-root MuiTableRow-head"
+                      >
+                        <th
+                          class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                          scope="col"
+                          style="font-weight: 700; box-sizing: border-box;"
+                        >
+                          Strategy
+                        </th>
+                        <th
+                          class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                          scope="col"
+                          style="font-weight: 700; box-sizing: border-box;"
+                        >
+                          Participants (not final)
+                        </th>
+                        <th
+                          class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                          scope="col"
+                          style="font-weight: 700; box-sizing: border-box;"
+                        >
+                          Difference interval
+                        </th>
+                        <th
+                          class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                          scope="col"
+                          style="font-weight: 700; box-sizing: border-box;"
+                        >
+                          Recommendation
+                        </th>
+                        <th
+                          class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                          scope="col"
+                          style="font-weight: 700; box-sizing: border-box;"
+                        >
+                          Warnings
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody
+                      class="MuiTableBody-root"
+                    >
+                      <tr
+                        class="MuiTableRow-root"
+                        index="0"
+                        level="0"
+                        path="0"
+                        style="transition: all ease 300ms; opacity: 0.8;"
+                      >
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          All participants
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          2000 (200)
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          [-0.01, 0.01]
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          Deploy 
+                          <code>
+                            test
+                          </code>
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          <div>
+                            Experiment period is too short. Wait a few days to be safer.
+                          </div>
+                          <div>
+                            The CI is too wide in comparison to the ROPE. Collect more data to be safer.
+                          </div>
+                        </td>
+                      </tr>
+                      <tr
+                        class="MuiTableRow-root"
+                        index="1"
+                        level="0"
+                        path="1"
+                        style="transition: all ease 300ms; opacity: 0.8;"
+                      >
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          Without crossovers
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          1800 (180)
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          [-0.01, 0.01]
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          Deploy 
+                          <code>
+                            test
+                          </code>
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          <div>
+                            Experiment period is too short. Wait a few days to be safer.
+                          </div>
+                          <div>
+                            The CI is too wide in comparison to the ROPE. Collect more data to be safer.
+                          </div>
+                        </td>
+                      </tr>
+                      <tr
+                        class="MuiTableRow-root"
+                        index="2"
+                        level="0"
+                        path="2"
+                        style="transition: all ease 300ms; opacity: 0.8;"
+                      >
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          Without spammers
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          1700 (170)
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          [-0.01, 0.01]
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          Deploy 
+                          <code>
+                            test
+                          </code>
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          <div>
+                            Experiment period is too short. Wait a few days to be safer.
+                          </div>
+                          <div>
+                            The CI is too wide in comparison to the ROPE. Collect more data to be safer.
+                          </div>
+                        </td>
+                      </tr>
+                      <tr
+                        class="MuiTableRow-root"
+                        index="3"
+                        level="0"
+                        path="3"
+                        style="transition: all ease 300ms; opacity: 0.8;"
+                      >
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          Without crossovers and spammers
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          1600 (160)
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          [-0.01, 0.01]
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          Deploy 
+                          <code>
+                            test
+                          </code>
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          <div>
+                            Experiment period is too short. Wait a few days to be safer.
+                          </div>
+                          <div>
+                            The CI is too wide in comparison to the ROPE. Collect more data to be safer.
+                          </div>
+                        </td>
+                      </tr>
+                      <tr
+                        class="MuiTableRow-root"
+                        index="4"
+                        level="0"
+                        path="4"
+                        style="transition: all ease 300ms; opacity: 0.8;"
+                      >
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          Exposed without crossovers and spammers
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          1400 (140)
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          [-0.01, 0.01]
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          Deploy 
+                          <code>
+                            test
+                          </code>
+                        </td>
+                        <td
+                          class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                          style="box-sizing: border-box;"
+                        >
+                          <div>
+                            Experiment period is too short. Wait a few days to be safer.
+                          </div>
+                          <div>
+                            The CI is too wide in comparison to the ROPE. Collect more data to be safer.
+                          </div>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <br />
+      </div>
     </div>
   `)
 })
@@ -706,7 +1122,6 @@ test('renders the full tables with some analyses and a different primary metric'
   const { container } = render(
     <ExperimentResults analyses={analyses} experiment={diffPrimaryExperiment} metrics={metrics} />,
   )
-  expect(container).toHaveTextContent(`Found ${analyses.length} analysis objects in total.`)
 
   // Only looking at the participant counts for this test: They should match the primary metric.
   expect(container.querySelector('.analysis-participant-counts')).toMatchInlineSnapshot(`
@@ -819,5 +1234,6 @@ test('shows the analyses JSON in debug mode', () => {
   const { container } = render(
     <ExperimentResults analyses={analyses} experiment={experiment} metrics={metrics} debugMode={true} />,
   )
+  expect(container).toHaveTextContent(`Found ${analyses.length} analysis objects in total.`)
   expect(container.querySelector('pre.debug-json')).toMatchSnapshot()
 })

--- a/components/experiment-results/ExperimentResults.tsx
+++ b/components/experiment-results/ExperimentResults.tsx
@@ -34,14 +34,11 @@ export default function ExperimentResults({
   )
 
   if (analyses.length === 0) {
-    return <h2>No analyses yet for {experiment.name}.</h2>
+    return <p>No analyses yet for {experiment.name}.</p>
   }
 
   return (
     <>
-      <h2>Analysis summary</h2>
-      <p>Found {analyses.length} analysis objects in total.</p>
-
       <div className='analysis-participant-counts'>
         <h3>Participant counts for the primary metric</h3>
         <ParticipantCounts
@@ -61,7 +58,14 @@ export default function ExperimentResults({
         />
       </div>
 
-      {debugMode ? <pre className='debug-json'>{JSON.stringify(analyses, null, 2)}</pre> : ''}
+      {debugMode ? (
+        <>
+          <p>Found {analyses.length} analysis objects in total.</p>
+          <pre className='debug-json'>{JSON.stringify(analyses, null, 2)}</pre>
+        </>
+      ) : (
+        ''
+      )}
     </>
   )
 }

--- a/components/experiment-results/FullLatestAnalyses.tsx
+++ b/components/experiment-results/FullLatestAnalyses.tsx
@@ -33,7 +33,7 @@ export default function FullLatestAnalyses({
       return {
         metricAssignment,
         metric: metricsById[metricAssignment.metricId],
-        latestAnalyses: metricAssignmentIdToLatestAnalyses[metricAssignment.metricAssignmentId as number],
+        latestAnalyses: metricAssignmentIdToLatestAnalyses[metricAssignment.metricAssignmentId as number] || [],
       }
     })
   }, [experiment, metricsById, metricAssignmentIdToLatestAnalyses])
@@ -79,8 +79,14 @@ export default function FullLatestAnalyses({
             <strong>
               <code>{metric.name}</code>
             </strong>{' '}
-            with {AttributionWindowSecondsToHuman[metricAssignment.attributionWindowSeconds]} attribution, last analyzed
-            on <DatetimeText datetime={latestAnalyses[0].analysisDatetime} excludeTime={true} />
+            with {AttributionWindowSecondsToHuman[metricAssignment.attributionWindowSeconds]} attribution,{' '}
+            {latestAnalyses.length > 0 ? (
+              <>
+                last analyzed on <DatetimeText datetime={latestAnalyses[0].analysisDatetime} excludeTime={true} />
+              </>
+            ) : (
+              <strong>not analyzed yet</strong>
+            )}
           </Typography>
           <MaterialTable
             columns={tableColumns}

--- a/components/experiment-results/RecommendationString.tsx
+++ b/components/experiment-results/RecommendationString.tsx
@@ -19,11 +19,11 @@ export default function RecommendationString({
       ) as Variation
       return (
         <>
-          End experiment; deploy <code>{chosenVariation.name}</code>
+          Deploy <code>{chosenVariation.name}</code>
         </>
       )
     }
-    return <>End experiment; deploy either variation</>
+    return <>Deploy either variation</>
   }
-  return <>Keep running</>
+  return <>Inconclusive</>
 }

--- a/components/experiment-results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/components/experiment-results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -392,6 +392,206 @@ exports[`shows the analyses JSON in debug mode 1`] = `
     "tableData": {
       "id": 0
     }
+  },
+  {
+    "metricAssignmentId": 126,
+    "analysisStrategy": "itt_pure",
+    "participantStats": {
+      "total": 2000,
+      "not_final": 200,
+      "variation_1": 1200,
+      "variation_2": 800
+    },
+    "metricEstimates": {
+      "diff": {
+        "estimate": 0,
+        "bottom": -0.01,
+        "top": 0.01
+      },
+      "variation_1": {
+        "estimate": 0.12,
+        "bottom": 0,
+        "top": 10
+      },
+      "variation_2": {
+        "estimate": -0.12,
+        "bottom": -1.123,
+        "top": 1
+      }
+    },
+    "recommendation": {
+      "endExperiment": true,
+      "chosenVariationId": 2,
+      "reason": "ci_in_rope",
+      "warnings": [
+        "short_period",
+        "wide_ci"
+      ]
+    },
+    "analysisDatetime": "2020-05-10T00:00:00.000Z",
+    "tableData": {
+      "id": 0
+    }
+  },
+  {
+    "metricAssignmentId": 126,
+    "analysisStrategy": "mitt_no_crossovers",
+    "participantStats": {
+      "total": 1800,
+      "not_final": 180,
+      "variation_1": 1080,
+      "variation_2": 720
+    },
+    "metricEstimates": {
+      "diff": {
+        "estimate": 0,
+        "bottom": -0.01,
+        "top": 0.01
+      },
+      "variation_1": {
+        "estimate": 0.12,
+        "bottom": 0,
+        "top": 10
+      },
+      "variation_2": {
+        "estimate": -0.12,
+        "bottom": -1.123,
+        "top": 1
+      }
+    },
+    "recommendation": {
+      "endExperiment": true,
+      "chosenVariationId": 2,
+      "reason": "ci_in_rope",
+      "warnings": [
+        "short_period",
+        "wide_ci"
+      ]
+    },
+    "analysisDatetime": "2020-05-10T00:00:00.000Z",
+    "tableData": {
+      "id": 1
+    }
+  },
+  {
+    "metricAssignmentId": 126,
+    "analysisStrategy": "mitt_no_spammers",
+    "participantStats": {
+      "total": 1700,
+      "not_final": 170,
+      "variation_1": 920,
+      "variation_2": 780
+    },
+    "metricEstimates": {
+      "diff": {
+        "estimate": 0,
+        "bottom": -0.01,
+        "top": 0.01
+      },
+      "variation_1": {
+        "estimate": 0.12,
+        "bottom": 0,
+        "top": 10
+      },
+      "variation_2": {
+        "estimate": -0.12,
+        "bottom": -1.123,
+        "top": 1
+      }
+    },
+    "recommendation": {
+      "endExperiment": true,
+      "chosenVariationId": 2,
+      "reason": "ci_in_rope",
+      "warnings": [
+        "short_period",
+        "wide_ci"
+      ]
+    },
+    "analysisDatetime": "2020-05-10T00:00:00.000Z",
+    "tableData": {
+      "id": 2
+    }
+  },
+  {
+    "metricAssignmentId": 126,
+    "analysisStrategy": "mitt_no_spammers_no_crossovers",
+    "participantStats": {
+      "total": 1600,
+      "not_final": 160,
+      "variation_1": 960,
+      "variation_2": 640
+    },
+    "metricEstimates": {
+      "diff": {
+        "estimate": 0,
+        "bottom": -0.01,
+        "top": 0.01
+      },
+      "variation_1": {
+        "estimate": 0.12,
+        "bottom": 0,
+        "top": 10
+      },
+      "variation_2": {
+        "estimate": -0.12,
+        "bottom": -1.123,
+        "top": 1
+      }
+    },
+    "recommendation": {
+      "endExperiment": true,
+      "chosenVariationId": 2,
+      "reason": "ci_in_rope",
+      "warnings": [
+        "short_period",
+        "wide_ci"
+      ]
+    },
+    "analysisDatetime": "2020-05-10T00:00:00.000Z",
+    "tableData": {
+      "id": 3
+    }
+  },
+  {
+    "metricAssignmentId": 126,
+    "analysisStrategy": "pp_naive",
+    "participantStats": {
+      "total": 1400,
+      "not_final": 140,
+      "variation_1": 840,
+      "variation_2": 560
+    },
+    "metricEstimates": {
+      "diff": {
+        "estimate": 0,
+        "bottom": -0.01,
+        "top": 0.01
+      },
+      "variation_1": {
+        "estimate": 0.12,
+        "bottom": 0,
+        "top": 10
+      },
+      "variation_2": {
+        "estimate": -0.12,
+        "bottom": -1.123,
+        "top": 1
+      }
+    },
+    "recommendation": {
+      "endExperiment": true,
+      "chosenVariationId": 2,
+      "reason": "ci_in_rope",
+      "warnings": [
+        "short_period",
+        "wide_ci"
+      ]
+    },
+    "analysisDatetime": "2020-05-10T00:00:00.000Z",
+    "tableData": {
+      "id": 4
+    }
   }
 ]
 </pre>

--- a/helpers/fixtures.ts
+++ b/helpers/fixtures.ts
@@ -189,6 +189,58 @@ function createAnalyses() {
       metricEstimates: null,
       recommendation: null,
     }),
+
+    // Similar to the set of "latest" analyses for the default metric assignment, but with consistent recommendations.
+    createAnalysis({
+      metricAssignmentId: 126,
+      analysisStrategy: AnalysisStrategy.IttPure,
+      participantStats: {
+        total: 2000,
+        not_final: 200,
+        variation_1: 1200,
+        variation_2: 800,
+      },
+    }),
+    createAnalysis({
+      metricAssignmentId: 126,
+      analysisStrategy: AnalysisStrategy.MittNoCrossovers,
+      participantStats: {
+        total: 1800,
+        not_final: 180,
+        variation_1: 1080,
+        variation_2: 720,
+      },
+    }),
+    createAnalysis({
+      metricAssignmentId: 126,
+      analysisStrategy: AnalysisStrategy.MittNoSpammers,
+      participantStats: {
+        total: 1700,
+        not_final: 170,
+        variation_1: 920,
+        variation_2: 780,
+      },
+    }),
+    createAnalysis({
+      metricAssignmentId: 126,
+      analysisStrategy: AnalysisStrategy.MittNoSpammersNoCrossovers,
+      participantStats: {
+        total: 1600,
+        not_final: 160,
+        variation_1: 960,
+        variation_2: 640,
+      },
+    }),
+    createAnalysis({
+      metricAssignmentId: 126,
+      analysisStrategy: AnalysisStrategy.PpNaive,
+      participantStats: {
+        total: 1400,
+        not_final: 140,
+        variation_1: 840,
+        variation_2: 560,
+      },
+    }),
   ]
 }
 
@@ -249,6 +301,22 @@ function createExperimentFull(fieldOverrides: Partial<ExperimentFull> = {}) {
         isPrimary: false,
         minDifference: 10.5,
       }),
+      createMetricAssignment({
+        metricAssignmentId: 125,
+        metricId: 2,
+        attributionWindowSeconds: AttributionWindowSeconds.OneHour,
+        changeExpected: true,
+        isPrimary: false,
+        minDifference: 0.5,
+      }),
+      createMetricAssignment({
+        metricAssignmentId: 126,
+        metricId: 3,
+        attributionWindowSeconds: AttributionWindowSeconds.SixHours,
+        changeExpected: true,
+        isPrimary: false,
+        minDifference: 12,
+      }),
     ],
     segmentAssignments: [],
     ...fieldOverrides,
@@ -265,7 +333,7 @@ function createMetricBare(id: number) {
 }
 
 function createMetricBares(numMetrics = 3) {
-  return _.range(numMetrics).map(createMetricBare)
+  return _.range(1, numMetrics + 1).map(createMetricBare)
 }
 
 function createMetricFull(id: number) {
@@ -283,7 +351,7 @@ function createMetricFull(id: number) {
     name: `metric_${id}`,
     description: `This is metric ${id}`,
     parameterType,
-    higherIsBetter: id % 3 === 0 ? true : false,
+    higherIsBetter: id % 3 === 0,
     eventParams: parameterType === 'conversion' ? eventParams : null,
     revenueParams: parameterType === 'revenue' ? revenueParams : null,
   })


### PR DESCRIPTION
Another PR carved out of #199 with the following changes:

* Adjust `FullLatestAnalyses` to handle the case where some metric assignments don't have analyses yet.
* Change the wording in `RecommendationString` to be independent of the experiment's status (e.g., saying "end experiment" when the experiment has already ended isn't helpful).
* Minor tweaks to the `ExperimentResults` component.
* Extend the test fixtures to cover more cases and reflect the schema better.

## How has this been tested?

* Inspected the rendered changes in Storybook.
* Verified and adjusted the snapshots and automated tests to match the fixture and component changes.