### PR TITLE
Implement Formik

### DIFF
--- a/components/experiment-creation/Beginning.stories.tsx
+++ b/components/experiment-creation/Beginning.stories.tsx
@@ -1,7 +1,13 @@
 import React from 'react'
 
+import { MockFormik } from '@/helpers/test-utils'
+
 import Beginning from './Beginning'
 
 export default { title: 'ExperimentCreation.Form Parts.Beginning' }
 
-export const FormPart = () => <Beginning />
+export const FormPart = () => (
+  <MockFormik>
+    <Beginning />
+  </MockFormik>
+)

--- a/components/experiment-creation/Beginning.test.tsx
+++ b/components/experiment-creation/Beginning.test.tsx
@@ -2,10 +2,16 @@
 import { render } from '@testing-library/react'
 import React from 'react'
 
+import { MockFormik } from '@/helpers/test-utils'
+
 import Beginning from './Beginning'
 
 test('renders as expected', () => {
-  const { container } = render(<Beginning />)
+  const { container } = render(
+    <MockFormik>
+      <Beginning />
+    </MockFormik>,
+  )
   expect(container).toMatchInlineSnapshot(`
     <div>
       <div

--- a/components/experiment-creation/Beginning.tsx
+++ b/components/experiment-creation/Beginning.tsx
@@ -1,5 +1,7 @@
-import { Button, TextField, Typography } from '@material-ui/core'
+import { Button, Typography } from '@material-ui/core'
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
+import { Field } from 'formik'
+import { TextField } from 'formik-material-ui'
 import React from 'react'
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -41,10 +43,11 @@ const Beginning = () => {
         <Typography variant='body1' gutterBottom>
           Once you&apos;ve designed and documented your experiment, enter the P2 post URL:
         </Typography>
-        <TextField
+        <Field
           className={classes.p2EntryField}
-          placeholder='https://your-p2-post-here'
+          component={TextField}
           name='p2Url'
+          placeholder='https://your-p2-post-here'
           variant='outlined'
         />
       </div>

--- a/components/experiment-creation/ExperimentForm.stories.tsx
+++ b/components/experiment-creation/ExperimentForm.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+import Fixtures from '@/helpers/fixtures'
+import { createNewExperiment, ExperimentFull } from '@/models'
+
+import ExperimentForm from './ExperimentForm'
+
+export default { title: 'ExperimentCreation' }
+
+export const Form = () => (
+  <ExperimentForm
+    metrics={Fixtures.createMetricBares(20)}
+    segments={Fixtures.createSegments(20)}
+    // TODO: Fix the schema...
+    initialExperiment={(createNewExperiment() as unknown) as Partial<ExperimentFull>}
+  />
+)

--- a/components/experiment-creation/ExperimentForm.stories.tsx
+++ b/components/experiment-creation/ExperimentForm.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import Fixtures from '@/helpers/fixtures'
-import { createNewExperiment, ExperimentFull } from '@/models'
+import { createNewExperiment } from '@/models'
 
 import ExperimentForm from './ExperimentForm'
 
@@ -11,7 +11,6 @@ export const Form = () => (
   <ExperimentForm
     metrics={Fixtures.createMetricBares(20)}
     segments={Fixtures.createSegments(20)}
-    // TODO: Fix the schema...
-    initialExperiment={(createNewExperiment() as unknown) as Partial<ExperimentFull>}
+    initialExperiment={createNewExperiment()}
   />
 )

--- a/components/experiment-creation/ExperimentForm.test.tsx
+++ b/components/experiment-creation/ExperimentForm.test.tsx
@@ -1,0 +1,114 @@
+/* eslint-disable no-irregular-whitespace */
+import { render } from '@testing-library/react'
+import React from 'react'
+
+import Fixtures from '@/helpers/fixtures'
+
+import ExperimentForm from './ExperimentForm'
+
+test('renders as expected', () => {
+  const { container } = render(
+    <ExperimentForm
+      metrics={Fixtures.createMetricBares(20)}
+      segments={Fixtures.createSegments(20)}
+      initialExperiment={{}}
+    />,
+  )
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      <div
+        class="makeStyles-root-1"
+      >
+        <form>
+          <div
+            class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
+          >
+            <div
+              class="makeStyles-root-2"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1"
+              >
+                We think one of the best ways to prevent a failed experiment is by documenting what you hope to learn.
+              </p>
+              <div
+                class="makeStyles-p2Entry-4"
+              >
+                <h6
+                  class="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom"
+                >
+                  P2 Link
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom"
+                >
+                  Once you've designed and documented your experiment, enter the P2 post URL:
+                </p>
+                <div
+                  class="MuiFormControl-root MuiTextField-root makeStyles-p2EntryField-5"
+                >
+                  <div
+                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
+                  >
+                    <input
+                      aria-invalid="false"
+                      class="MuiInputBase-input MuiOutlinedInput-input"
+                      name="p2Url"
+                      placeholder="https://your-p2-post-here"
+                      type="text"
+                      value=""
+                    />
+                    <fieldset
+                      aria-hidden="true"
+                      class="PrivateNotchedOutline-root-7 MuiOutlinedInput-notchedOutline"
+                      style="padding-left: 8px;"
+                    >
+                      <legend
+                        class="PrivateNotchedOutline-legend-8"
+                        style="width: 0.01px;"
+                      >
+                        <span>
+                          ​
+                        </span>
+                      </legend>
+                    </fieldset>
+                  </div>
+                </div>
+              </div>
+              <button
+                class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-beginButton-6 MuiButton-containedPrimary MuiButton-containedSizeLarge MuiButton-sizeLarge"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiButton-label"
+                >
+                  Begin
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+          </div>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text"
+            tabindex="0"
+            type="submit"
+          >
+            <span
+              class="MuiButton-label"
+            >
+              Submit
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </form>
+      </div>
+    </div>
+  `)
+})
+
+test.todo('form works as expected')

--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -1,0 +1,45 @@
+// For WIP
+/* eslint-disable */
+import React from 'react'
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles'
+import { MetricBare, Segment, createNewExperiment, ExperimentFull } from '@/models'
+import { Formik } from 'formik'
+import { Paper, Button } from '@material-ui/core'
+import Beginning from './Beginning'
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      '--temp-stop-theme-from-being-prettiered-away': theme.palette.text,
+    },
+  }),
+)
+
+const ExperimentForm = ({
+  metrics,
+  segments,
+  initialExperiment,
+}: {
+  metrics: MetricBare[]
+  segments: Segment[]
+  initialExperiment: Partial<ExperimentFull>
+}) => {
+  const classes = useStyles()
+
+  return (
+    <div className={classes.root}>
+      <Formik initialValues={initialExperiment as {}} onSubmit={(v) => alert(JSON.stringify(v, null, 2))}>
+        {({ handleSubmit }) => (
+          <form onSubmit={handleSubmit}>
+            <Paper>
+              <Beginning />
+            </Paper>
+            <Button type='submit'>Submit</Button>
+          </form>
+        )}
+      </Formik>
+    </div>
+  )
+}
+
+export default ExperimentForm

--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -1,5 +1,6 @@
 // Temporarily ignore until more parts are in place
 /* eslint-disable */
+/* istanbul ignore file */
 import React from 'react'
 import { makeStyles, createStyles, Theme } from '@material-ui/core/styles'
 import { MetricBare, Segment, ExperimentFull } from '@/models'
@@ -13,6 +14,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 )
 
+/* istanbul-ignore next */
 const ExperimentForm = ({
   metrics,
   segments,

--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -1,17 +1,15 @@
-// For WIP
+// Temporarily ignore until more parts are in place
 /* eslint-disable */
 import React from 'react'
 import { makeStyles, createStyles, Theme } from '@material-ui/core/styles'
-import { MetricBare, Segment, createNewExperiment, ExperimentFull } from '@/models'
+import { MetricBare, Segment, ExperimentFull } from '@/models'
 import { Formik } from 'formik'
 import { Paper, Button } from '@material-ui/core'
 import Beginning from './Beginning'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
-    root: {
-      '--temp-stop-theme-from-being-prettiered-away': theme.palette.text,
-    },
+    root: {},
   }),
 )
 
@@ -28,7 +26,7 @@ const ExperimentForm = ({
 
   return (
     <div className={classes.root}>
-      <Formik initialValues={initialExperiment as {}} onSubmit={(v) => alert(JSON.stringify(v, null, 2))}>
+      <Formik initialValues={initialExperiment} onSubmit={(v) => alert(JSON.stringify(v, null, 2))}>
         {({ handleSubmit }) => (
           <form onSubmit={handleSubmit}>
             <Paper>

--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -1,11 +1,13 @@
 // Temporarily ignore until more parts are in place
-/* eslint-disable */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 /* istanbul ignore file */
-import React from 'react'
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles'
-import { MetricBare, Segment, ExperimentFull } from '@/models'
+import { Button, Paper } from '@material-ui/core'
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import { Formik } from 'formik'
-import { Paper, Button } from '@material-ui/core'
+import React from 'react'
+
+import { ExperimentFull, MetricBare, Segment } from '@/models'
+
 import Beginning from './Beginning'
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -14,7 +16,6 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 )
 
-/* istanbul-ignore next */
 const ExperimentForm = ({
   metrics,
   segments,

--- a/helpers/test-utils.tsx
+++ b/helpers/test-utils.tsx
@@ -1,5 +1,6 @@
 import { Queries, render as actualRender, RenderOptions } from '@testing-library/react'
 import mediaQuery from 'css-mediaquery'
+import { Formik } from 'formik'
 import React from 'react'
 
 import ThemeProvider from '@/styles/ThemeProvider'
@@ -39,4 +40,15 @@ export function createMatchMedia(width: number) {
     removeEventListener: jest.fn(),
     removeListener: jest.fn(),
   })
+}
+
+/**
+ * Mock Formik for rendering Formik components when you don't care about the formik connection.
+ */
+export const MockFormik = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <Formik initialValues={{}} onSubmit={() => undefined}>
+      {children}
+    </Formik>
+  )
 }

--- a/helpers/test-utils.tsx
+++ b/helpers/test-utils.tsx
@@ -47,7 +47,14 @@ export function createMatchMedia(width: number) {
  */
 export const MockFormik = ({ children }: { children: React.ReactNode }) => {
   return (
-    <Formik initialValues={{}} onSubmit={() => undefined}>
+    <Formik
+      initialValues={{}}
+      onSubmit={
+        // This isn't meant to be used so it won't be tested
+        /* istanbul ignore next */
+        () => undefined
+      }
+    >
       {children}
     </Formik>
   )

--- a/helpers/test-utils.tsx
+++ b/helpers/test-utils.tsx
@@ -50,8 +50,7 @@ export const MockFormik = ({ children }: { children: React.ReactNode }) => {
     <Formik
       initialValues={{}}
       onSubmit={
-        // This isn't meant to be used so it won't be tested
-        /* istanbul ignore next */
+        /* istanbul ignore next; This is unused */
         () => undefined
       }
     >

--- a/models/ExperimentFull.test.ts
+++ b/models/ExperimentFull.test.ts
@@ -462,19 +462,6 @@ describe('models/ExperimentFull.ts module', () => {
   describe('createNewExperiment', () => {
     it('should return a new experiment', () => {
       expect(createNewExperiment()).toEqual({
-        experimentId: null,
-        name: null,
-        description: null,
-        startDatetime: null,
-        endDatetime: null,
-        status: null,
-        platform: null,
-        ownerLogin: null,
-        conclusionUrl: null,
-        deployedVariationId: null,
-        endReason: null,
-        existingUsersAllowed: null,
-        p2Url: null,
         metricAssignments: [],
         segmentAssignments: [],
         variations: [],

--- a/models/ExperimentFull.ts
+++ b/models/ExperimentFull.ts
@@ -237,19 +237,6 @@ export class ExperimentFull implements ApiDataSource {
 
 export function createNewExperiment(): Partial<ExperimentFull> {
   return ({
-    experimentId: null,
-    name: null,
-    description: null,
-    startDatetime: null,
-    endDatetime: null,
-    status: null,
-    platform: null,
-    ownerLogin: null,
-    conclusionUrl: null,
-    deployedVariationId: null,
-    endReason: null,
-    existingUsersAllowed: null,
-    p2Url: null,
     metricAssignments: [],
     segmentAssignments: [],
     variations: [],

--- a/models/ExperimentFull.ts
+++ b/models/ExperimentFull.ts
@@ -235,8 +235,8 @@ export class ExperimentFull implements ApiDataSource {
   }
 }
 
-export function createNewExperiment() {
-  return {
+export function createNewExperiment(): Partial<ExperimentFull> {
+  return ({
     experimentId: null,
     name: null,
     description: null,
@@ -253,5 +253,6 @@ export function createNewExperiment() {
     metricAssignments: [],
     segmentAssignments: [],
     variations: [],
-  }
+    // TODO: Remove this once schemas are in
+  } as unknown) as Partial<ExperimentFull>
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9706,6 +9706,42 @@
       "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
       "dev": true
     },
+    "formik": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-2.1.4.tgz",
+      "integrity": "sha512-oKz8S+yQBzuQVSEoxkqqJrKQS5XJASWGVn6mrs+oTWrBoHgByVwwI1qHiVc9GKDpZBU9vAxXYAKz2BvujlwunA==",
+      "requires": {
+        "deepmerge": "^2.1.1",
+        "hoist-non-react-statics": "^3.3.0",
+        "lodash": "^4.17.14",
+        "lodash-es": "^4.17.14",
+        "react-fast-compare": "^2.0.1",
+        "scheduler": "^0.18.0",
+        "tiny-warning": "^1.0.2",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+          "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
+        },
+        "react-fast-compare": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+          "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+        },
+        "scheduler": {
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
+          "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
+      }
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -13391,6 +13427,11 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "lodash-es": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
+      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9742,6 +9742,11 @@
         }
       }
     },
+    "formik-material-ui": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/formik-material-ui/-/formik-material-ui-2.0.1.tgz",
+      "integrity": "sha512-kX+SJuFj9AdjLk7sfZczDfJIK8W/MnNtHWFZ182LkhN4743IFho7+VYycd2QL9qnEEv7vdZhbEm1ts+wp3nPEg=="
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "date-fns": "^2.13.0",
     "debug": "^4.1.1",
     "formik": "^2.1.4",
+    "formik-material-ui": "^2.0.1",
     "isomorphic-unfetch": "^3.0.0",
     "lodash": "^4.17.15",
     "material-table": "^1.59.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "clsx": "^1.1.1",
     "date-fns": "^2.13.0",
     "debug": "^4.1.1",
+    "formik": "^2.1.4",
     "isomorphic-unfetch": "^3.0.0",
     "lodash": "^4.17.15",
     "material-table": "^1.59.0",

--- a/pages/experiments/new.tsx
+++ b/pages/experiments/new.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 
 import MetricsApi from '@/api/MetricsApi'
 import SegmentsApi from '@/api/SegmentsApi'
+import ExperimentForm from '@/components/experiment-creation/ExperimentForm'
 import Layout from '@/components/Layout'
 import { createNewExperiment } from '@/models'
 import { useDataLoadingError, useDataSource } from '@/utils/data-loading'
@@ -35,10 +36,12 @@ const ExperimentsNewPage = function () {
     <Layout title='Create an Experiment'>
       <Paper>
         <Typography variant='h5'>initialExperiment</Typography>
+        {isLoading && <LinearProgress />}
+        {!isLoading && metrics && segments && (
+          <ExperimentForm metrics={metrics} segments={segments} initialExperiment={initialExperiment} />
+        )}
         <pre>{JSON.stringify(initialExperiment, null, 2)}</pre>
-        {isLoading ? (
-          <LinearProgress />
-        ) : (
+        {!isLoading && (
           <>
             <Typography variant='h5'>metrics</Typography>
             <pre>{JSON.stringify(metrics, null, 2)}</pre>


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
This PR begins the implementation of Formik:
- Creates form container `ExperimentForm`, to be used for editing staging experiments as well
- Adds `formik-material-ui` to integrate `formik` with MUI
- Implements formik fields for the `Beginning` form-part
- Plugs `ExperimentForm` into `/experiments/new` - so you can try it now

Maintenance case for [`formik-material-ui`](https://github.com/stackworx/formik-material-ui/pull/186):
- Minimal library
- Single purpose
- It really does very little but translate components between MUI and formik
- 2 years old
- Recommended by MUI
- Active maintainer

Part of a series on #9 
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
- MT & AT added
- `ExperimentForm.tsx` has coverage and eslint disabled until future PRs that complete it.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
