### PR TITLE
Fix footer grammar

### DIFF
--- a/components/Layout.test.tsx
+++ b/components/Layout.test.tsx
@@ -82,7 +82,7 @@ test('renders layout with declared title and children', () => {
         <p
           class="MuiTypography-root MuiTypography-body1"
         >
-          The Abacus footer, brought to you by Automattic.
+          The Abacus footer. Brought to you by Automattic.
         </p>
       </div>
     </footer>

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -103,7 +103,7 @@ const Layout = ({ title, children }: { title: string; children?: ReactNode }) =>
       </Container>
       <footer className={classes.footer}>
         <Container>
-          <Typography variant='body1'>The Abacus footer, brought to you by Automattic.</Typography>
+          <Typography variant='body1'>The Abacus footer. Brought to you by Automattic.</Typography>
         </Container>
       </footer>
     </div>


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
Change "The Abacus footer, brought to you by Automattic." to "The Abacus footer. Brought to you by Automattic."
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
- AT & MT

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
