### PR TITLE
Relax the requirement on segment name

### DIFF
--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -117,7 +117,7 @@ export enum SegmentType {
 export const segmentSchema = yup
   .object({
     segmentId: idSchema.defined(),
-    name: nameSchema.defined(),
+    name: yup.string().defined(),
     type: yup.string().oneOf(Object.values(SegmentType)).defined(),
   })
   .defined()


### PR DESCRIPTION
Seeing some more errors on the production Experiment details page. Our database of pre-defined segments doesn't obey `^[a-z][a-z0-9_]*[a-z0-9]$`.

![Screen Shot 2020-07-23 at 4 58 36 PM](https://user-images.githubusercontent.com/4505888/88349745-c4e39080-cd05-11ea-84ed-5a1a65af1bd1.png)

## How has this been tested?

- Automated tests that cover added/changed functionality
- (to do) Manual testing with production data (locally)
- Manual testing with mock data (locally or on Vercel)
