### PR TITLE
Fix segments field placeholder

### DIFF
--- a/components/experiment-creation/Audience.tsx
+++ b/components/experiment-creation/Audience.tsx
@@ -203,7 +203,11 @@ const Audience = ({ formikProps }: { formikProps: FormikProps<{ experiment: Part
             options={Object.values(segments)}
             // TODO: Error state, see https://stackworx.github.io/formik-material-ui/docs/api/material-ui-lab
             renderInput={(params: AutocompleteRenderInputParams) => (
-              <MuiTextField {...params} variant='outlined' placeholder='Search and select to customize' />
+              <MuiTextField
+                {...params}
+                variant='outlined'
+                placeholder={segmentAssignmentsField.value.length === 0 ? 'Search and select to customize' : undefined}
+              />
             )}
             segmentExclusionState={segmentExclusionState}
             fullWidth

--- a/components/experiment-creation/__snapshots__/Audience.test.tsx.snap
+++ b/components/experiment-creation/__snapshots__/Audience.test.tsx.snap
@@ -943,7 +943,6 @@ exports[`renders as expected 2`] = `
                 autocomplete="off"
                 class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
                 id="segments-select"
-                placeholder="Search and select to customize"
                 spellcheck="false"
                 type="text"
                 value=""


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
Currently the placeholder sticks around even after input has been entered, this is undesirable behaviour.
This PR fixes that.
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with mock data (locally)

