### PR TITLE
WIP: Normalized Data

### DIFF
--- a/components/AudiencePanel.test.tsx
+++ b/components/AudiencePanel.test.tsx
@@ -15,7 +15,9 @@ import { render } from '@/test-helpers/test-utils'
 import AudiencePanel from './AudiencePanel'
 
 test('renders as expected with no segment assignments', () => {
-  const experiment = Fixtures.createExperimentFull()
+  const experiment = Fixtures.createExperimentFull({
+    segmentAssignments: [],
+  })
   const normalizedExperimentData = normalize<ExperimentFull, ExperimentFullNormalizedEntities>(
     experiment,
     experimentFullNormalizrSchema,
@@ -30,6 +32,7 @@ test('renders as expected with no segment assignments', () => {
 test('renders as expected with existing users allowed', () => {
   const experiment = Fixtures.createExperimentFull({
     existingUsersAllowed: true,
+    segmentAssignments: [],
   })
   const normalizedExperimentData = normalize<ExperimentFull, ExperimentFullNormalizedEntities>(
     experiment,

--- a/components/AudiencePanel.tsx
+++ b/components/AudiencePanel.tsx
@@ -29,7 +29,7 @@ function AudiencePanel({
       const segment = indexedSegments[segmentAssignment.segmentId]
       if (!segment) {
         throw new Error(
-          `Can't find segment matching segmentId '${segmentAssignment.segmentId}' in segmentAssignment (${segmentAssignment.segmentAssignmentId})`,
+          `Can't find segment matching segmentId '${segmentAssignment.segmentId}' of segmentAssignment (${segmentAssignment.segmentAssignmentId})`,
         )
       }
       return { segmentAssignment, segment }

--- a/components/AudiencePanel.tsx
+++ b/components/AudiencePanel.tsx
@@ -1,47 +1,12 @@
 import { TableCellProps } from '@material-ui/core/TableCell'
 import _ from 'lodash'
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import LabelValuePanel from '@/components/LabelValuePanel'
 import SegmentsTable from '@/components/SegmentsTable'
 import VariationsTable from '@/components/VariationsTable'
-import { ExperimentFull, Segment, SegmentAssignment, SegmentType } from '@/lib/schemas'
+import { ExperimentFullNormalizedData, Segment, SegmentType } from '@/lib/schemas'
 import * as Variations from '@/lib/variations'
-
-/**
- * Resolves the segment ID of the segment assignment with the actual segment.
- * If the ID cannot be resolved, then an `Error` will be thrown.
- *
- * @param segmentAssignments - The segment assignments to be resolved.
- * @param segments - The segments to associate with the assignments.
- * @throws {Error} When unable to resolve a segment ID with one of the supplied
- *   segments.
- */
-function resolveSegmentAssignments(
-  segmentAssignments: SegmentAssignment[],
-  segments: Segment[],
-): {
-  segment: Segment
-  isExcluded: boolean
-}[] {
-  const segmentsById: { [segmentId: string]: Segment } = {}
-  segments.forEach((segment) => (segmentsById[segment.segmentId] = segment))
-
-  return segmentAssignments.map((segmentAssignment) => {
-    const segment = segmentsById[segmentAssignment.segmentId]
-
-    if (!segment) {
-      throw Error(
-        `Failed to lookup segment with ID ${segmentAssignment.segmentId} for assignment with ID ${segmentAssignment.segmentAssignmentId}.`,
-      )
-    }
-
-    return {
-      segment,
-      isExcluded: segmentAssignment.isExcluded,
-    }
-  })
-}
 
 /**
  * Renders the audience information of an experiment in a panel component.
@@ -50,19 +15,41 @@ function resolveSegmentAssignments(
  * @param props.segments - The segments to look up (aka resolve) the segment IDs
  *   of the experiment's segment assignments.
  */
-function AudiencePanel({ experiment, segments }: { experiment: ExperimentFull; segments: Segment[] }) {
-  const segmentsByType = useMemo(
-    () => _.groupBy(resolveSegmentAssignments(experiment.segmentAssignments, segments), _.property('segment.type')),
-    [experiment.segmentAssignments, segments],
+function AudiencePanel({
+  normalizedExperimentData,
+  indexedSegments,
+}: {
+  normalizedExperimentData: ExperimentFullNormalizedData
+  indexedSegments: Record<number, Segment>
+}) {
+  const normalizedExperiment = normalizedExperimentData.entities.experiments[normalizedExperimentData.result]
+
+  const segmentAssignmentsWithSegments = Object.values(normalizedExperimentData.entities.segmentAssignments).map(
+    (segmentAssignment) => {
+      const segment = indexedSegments[segmentAssignment.segmentId]
+      if (!segment) {
+        throw new Error(
+          `Can't find segment matching segmentId '${segmentAssignment.segmentId}' in segmentAssignment (${segmentAssignment.segmentAssignmentId})`,
+        )
+      }
+      return { segmentAssignment, segment }
+    },
   )
 
+  const segmentsAssignmentsWithSegmentsByType = _.groupBy(segmentAssignmentsWithSegments, _.property('segment.type'))
+
+  const variations = Variations.sort(Object.values(normalizedExperimentData.entities.variations))
+
   const data = [
-    { label: 'Platform', value: experiment.platform },
-    { label: 'User Type', value: experiment.existingUsersAllowed ? 'All users (new + existing)' : 'New users only' },
+    { label: 'Platform', value: normalizedExperiment.platform },
+    {
+      label: 'User Type',
+      value: normalizedExperiment.existingUsersAllowed ? 'All users (new + existing)' : 'New users only',
+    },
     {
       label: 'Variations',
       padding: 'none' as TableCellProps['padding'],
-      value: <VariationsTable variations={Variations.sort(experiment.variations)} />,
+      value: <VariationsTable variations={variations} />,
     },
     {
       label: 'Segments',
@@ -70,11 +57,11 @@ function AudiencePanel({ experiment, segments }: { experiment: ExperimentFull; s
       value: (
         <>
           <SegmentsTable
-            resolvedSegmentAssignments={segmentsByType[SegmentType.Locale] ?? []}
+            segmentAssignmentsWithSegments={segmentsAssignmentsWithSegmentsByType[SegmentType.Locale] ?? []}
             type={SegmentType.Locale}
           />
           <SegmentsTable
-            resolvedSegmentAssignments={segmentsByType[SegmentType.Country] ?? []}
+            segmentAssignmentsWithSegments={segmentsAssignmentsWithSegmentsByType[SegmentType.Country] ?? []}
             type={SegmentType.Country}
           />
         </>

--- a/components/AudiencePanel.tsx
+++ b/components/AudiencePanel.tsx
@@ -24,7 +24,7 @@ function AudiencePanel({
 }) {
   const normalizedExperiment = normalizedExperimentData.entities.experiments[normalizedExperimentData.result]
 
-  const segmentAssignmentsWithSegments = Object.values(normalizedExperimentData.entities.segmentAssignments).map(
+  const segmentAssignmentsWithSegments = Object.values(normalizedExperimentData.entities.segmentAssignments ?? []).map(
     (segmentAssignment) => {
       const segment = indexedSegments[segmentAssignment.segmentId]
       if (!segment) {

--- a/components/ConclusionsPanel.test.tsx
+++ b/components/ConclusionsPanel.test.tsx
@@ -1,5 +1,7 @@
+import { normalize } from 'normalizr'
 import React from 'react'
 
+import { ExperimentFull, ExperimentFullNormalizedEntities, experimentFullNormalizrSchema } from '@/lib/schemas'
 import Fixtures from '@/test-helpers/fixtures'
 import { render } from '@/test-helpers/test-utils'
 
@@ -11,7 +13,11 @@ test('renders as expected with complete conclusion data', () => {
     deployedVariationId: 2,
     endReason: 'Ran its course.',
   })
-  const { container } = render(<ConclusionsPanel experiment={experiment} />)
+  const normalizedExperimentData = normalize<ExperimentFull, ExperimentFullNormalizedEntities>(
+    experiment,
+    experimentFullNormalizrSchema,
+  )
+  const { container } = render(<ConclusionsPanel normalizedExperimentData={normalizedExperimentData} />)
 
   expect(container).toMatchInlineSnapshot(`
     <div>
@@ -96,7 +102,11 @@ test('renders as expected without deployed variation', () => {
     deployedVariationId: null,
     endReason: 'Ran its course.',
   })
-  const { container } = render(<ConclusionsPanel experiment={experiment} />)
+  const normalizedExperimentData = normalize<ExperimentFull, ExperimentFullNormalizedEntities>(
+    experiment,
+    experimentFullNormalizrSchema,
+  )
+  const { container } = render(<ConclusionsPanel normalizedExperimentData={normalizedExperimentData} />)
 
   expect(container).toMatchInlineSnapshot(`
     <div>

--- a/components/ConclusionsPanel.tsx
+++ b/components/ConclusionsPanel.tsx
@@ -2,22 +2,23 @@ import React from 'react'
 
 import LabelValuePanel from '@/components/LabelValuePanel'
 import * as Experiments from '@/lib/experiments'
-import { ExperimentFull } from '@/lib/schemas'
+import { ExperimentFullNormalizedData } from '@/lib/schemas'
 
 /**
  * Renders the conclusion information of an experiment in a panel component.
  *
  * @param props.experiment - The experiment with the conclusion information.
  */
-function ConclusionsPanel({ experiment }: { experiment: ExperimentFull }) {
-  const deployedVariation = Experiments.getDeployedVariation(experiment)
+function ConclusionsPanel({ normalizedExperimentData }: { normalizedExperimentData: ExperimentFullNormalizedData }) {
+  const normalizedExperiment = normalizedExperimentData.entities.experiments[normalizedExperimentData.result]
+  const deployedVariation = Experiments.getDeployedVariation(normalizedExperimentData)
   const data = [
-    { label: 'Reason the experiment ended', value: experiment.endReason },
+    { label: 'Reason the experiment ended', value: normalizedExperiment.endReason },
     {
       label: 'Conclusion URL',
-      value: !!experiment.conclusionUrl && (
-        <a href={experiment.conclusionUrl} rel='noopener noreferrer' target='_blank'>
-          {experiment.conclusionUrl}
+      value: !!normalizedExperiment.conclusionUrl && (
+        <a href={normalizedExperiment.conclusionUrl} rel='noopener noreferrer' target='_blank'>
+          {normalizedExperiment.conclusionUrl}
         </a>
       ),
     },

--- a/components/ExperimentDetails.test.tsx
+++ b/components/ExperimentDetails.test.tsx
@@ -1,6 +1,16 @@
 import MockDate from 'mockdate'
+import { normalize } from 'normalizr'
 import React from 'react'
 
+import {
+  ExperimentFull,
+  ExperimentFullNormalizedEntities,
+  experimentFullNormalizrSchema,
+  MetricBare,
+  metricBareNormalizrSchema,
+  Segment,
+  segmentNormalizrSchema,
+} from '@/lib/schemas'
 import Fixtures from '@/test-helpers/fixtures'
 import { createMatchMedia, render } from '@/test-helpers/test-utils'
 
@@ -24,7 +34,28 @@ test('renders as expected at large width', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 102, segmentId: 2, isExcluded: true }),
     ],
   })
-  const { container } = render(<ExperimentDetails experiment={experiment} metrics={metrics} segments={segments} />)
+  const normalizedExperimentData = normalize<ExperimentFull, ExperimentFullNormalizedEntities>(
+    experiment,
+    experimentFullNormalizrSchema,
+  )
+  const normalizedExperiment =
+    normalizedExperimentData && normalizedExperimentData.entities.experiments[normalizedExperimentData.result]
+  const {
+    entities: { metrics: indexedMetrics },
+  } = normalize<MetricBare, { metrics: Record<number, MetricBare> }>(metrics, [metricBareNormalizrSchema])
+  const {
+    entities: { segments: indexedSegments },
+  } = normalize<Segment, { segments: Record<number, Segment> }>(segments, [segmentNormalizrSchema])
+
+  const { container } = render(
+    <ExperimentDetails
+      experiment={experiment}
+      indexedMetrics={indexedMetrics}
+      indexedSegments={indexedSegments}
+      normalizedExperiment={normalizedExperiment}
+      normalizedExperimentData={normalizedExperimentData}
+    />,
+  )
 
   expect(container).toMatchSnapshot()
 })
@@ -39,7 +70,28 @@ test('renders as expected at small width', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 102, segmentId: 2, isExcluded: true }),
     ],
   })
-  const { container } = render(<ExperimentDetails experiment={experiment} metrics={metrics} segments={segments} />)
+  const normalizedExperimentData = normalize<ExperimentFull, ExperimentFullNormalizedEntities>(
+    experiment,
+    experimentFullNormalizrSchema,
+  )
+  const normalizedExperiment =
+    normalizedExperimentData && normalizedExperimentData.entities.experiments[normalizedExperimentData.result]
+  const {
+    entities: { metrics: indexedMetrics },
+  } = normalize<MetricBare, { metrics: Record<number, MetricBare> }>(metrics, [metricBareNormalizrSchema])
+  const {
+    entities: { segments: indexedSegments },
+  } = normalize<Segment, { segments: Record<number, Segment> }>(segments, [segmentNormalizrSchema])
+
+  const { container } = render(
+    <ExperimentDetails
+      experiment={experiment}
+      indexedMetrics={indexedMetrics}
+      indexedSegments={indexedSegments}
+      normalizedExperiment={normalizedExperiment}
+      normalizedExperimentData={normalizedExperimentData}
+    />,
+  )
 
   expect(container).toMatchSnapshot()
 })
@@ -56,7 +108,28 @@ test('renders as expected with conclusion data', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 102, segmentId: 2, isExcluded: true }),
     ],
   })
-  const { container } = render(<ExperimentDetails experiment={experiment} metrics={metrics} segments={segments} />)
+  const normalizedExperimentData = normalize<ExperimentFull, ExperimentFullNormalizedEntities>(
+    experiment,
+    experimentFullNormalizrSchema,
+  )
+  const normalizedExperiment =
+    normalizedExperimentData && normalizedExperimentData.entities.experiments[normalizedExperimentData.result]
+  const {
+    entities: { metrics: indexedMetrics },
+  } = normalize<MetricBare, { metrics: Record<number, MetricBare> }>(metrics, [metricBareNormalizrSchema])
+  const {
+    entities: { segments: indexedSegments },
+  } = normalize<Segment, { segments: Record<number, Segment> }>(segments, [segmentNormalizrSchema])
+
+  const { container } = render(
+    <ExperimentDetails
+      experiment={experiment}
+      indexedMetrics={indexedMetrics}
+      indexedSegments={indexedSegments}
+      normalizedExperiment={normalizedExperiment}
+      normalizedExperimentData={normalizedExperimentData}
+    />,
+  )
 
   expect(container).toMatchSnapshot()
 })
@@ -70,7 +143,28 @@ test('renders as expected without conclusion data', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 102, segmentId: 2, isExcluded: true }),
     ],
   })
-  const { container } = render(<ExperimentDetails experiment={experiment} metrics={metrics} segments={segments} />)
+  const normalizedExperimentData = normalize<ExperimentFull, ExperimentFullNormalizedEntities>(
+    experiment,
+    experimentFullNormalizrSchema,
+  )
+  const normalizedExperiment =
+    normalizedExperimentData && normalizedExperimentData.entities.experiments[normalizedExperimentData.result]
+  const {
+    entities: { metrics: indexedMetrics },
+  } = normalize<MetricBare, { metrics: Record<number, MetricBare> }>(metrics, [metricBareNormalizrSchema])
+  const {
+    entities: { segments: indexedSegments },
+  } = normalize<Segment, { segments: Record<number, Segment> }>(segments, [segmentNormalizrSchema])
+
+  const { container } = render(
+    <ExperimentDetails
+      experiment={experiment}
+      indexedMetrics={indexedMetrics}
+      indexedSegments={indexedSegments}
+      normalizedExperiment={normalizedExperiment}
+      normalizedExperimentData={normalizedExperimentData}
+    />,
+  )
 
   expect(container).toMatchSnapshot()
 })

--- a/components/ExperimentDetails.test.tsx
+++ b/components/ExperimentDetails.test.tsx
@@ -49,7 +49,6 @@ test('renders as expected at large width', () => {
 
   const { container } = render(
     <ExperimentDetails
-      experiment={experiment}
       indexedMetrics={indexedMetrics}
       indexedSegments={indexedSegments}
       normalizedExperiment={normalizedExperiment}
@@ -85,7 +84,6 @@ test('renders as expected at small width', () => {
 
   const { container } = render(
     <ExperimentDetails
-      experiment={experiment}
       indexedMetrics={indexedMetrics}
       indexedSegments={indexedSegments}
       normalizedExperiment={normalizedExperiment}
@@ -123,7 +121,6 @@ test('renders as expected with conclusion data', () => {
 
   const { container } = render(
     <ExperimentDetails
-      experiment={experiment}
       indexedMetrics={indexedMetrics}
       indexedSegments={indexedSegments}
       normalizedExperiment={normalizedExperiment}
@@ -158,7 +155,6 @@ test('renders as expected without conclusion data', () => {
 
   const { container } = render(
     <ExperimentDetails
-      experiment={experiment}
       indexedMetrics={indexedMetrics}
       indexedSegments={indexedSegments}
       normalizedExperiment={normalizedExperiment}

--- a/components/ExperimentDetails.tsx
+++ b/components/ExperimentDetails.tsx
@@ -24,11 +24,8 @@ const debug = debugFactory('abacus:components/ExperimentDetails.tsx')
  */
 function ExperimentDetails({
   experiment,
-  /*
-  // Not yet used
   normalizedExperiment,
-  normalizedExperimentData,
-  */
+  // normalizedExperimentData,
   metrics,
   segments,
 }: {
@@ -47,7 +44,7 @@ function ExperimentDetails({
       <Grid item xs={12} lg={7}>
         <Grid container direction='column' spacing={2}>
           <Grid item>
-            <GeneralPanel experiment={experiment} />
+            <GeneralPanel normalizedExperiment={normalizedExperiment} />
           </Grid>
           {isMdDown && (
             <Grid item>

--- a/components/ExperimentDetails.tsx
+++ b/components/ExperimentDetails.tsx
@@ -2,6 +2,7 @@ import Grid from '@material-ui/core/Grid'
 import { useTheme } from '@material-ui/core/styles'
 import useMediaQuery from '@material-ui/core/useMediaQuery'
 import debugFactory from 'debug'
+import { NormalizedSchema } from 'normalizr'
 import React from 'react'
 
 import AudiencePanel from '@/components/AudiencePanel'
@@ -9,7 +10,13 @@ import ConclusionsPanel from '@/components/ConclusionsPanel'
 import GeneralPanel from '@/components/GeneralPanel'
 import MetricAssignmentsPanel from '@/components/MetricAssignmentsPanel'
 import * as Experiments from '@/lib/experiments'
-import { ExperimentFull, MetricBare, Segment } from '@/lib/schemas'
+import {
+  ExperimentFull,
+  ExperimentFullNormalized,
+  ExperimentFullNormalizedEntities,
+  MetricBare,
+  Segment,
+} from '@/lib/schemas'
 
 const debug = debugFactory('abacus:components/ExperimentDetails.tsx')
 
@@ -18,10 +25,17 @@ const debug = debugFactory('abacus:components/ExperimentDetails.tsx')
  */
 function ExperimentDetails({
   experiment,
+  /*
+  // Not yet used
+  normalizedExperiment,
+  normalizedExperimentData,
+  */
   metrics,
   segments,
 }: {
   experiment: ExperimentFull
+  normalizedExperiment: ExperimentFullNormalized
+  normalizedExperimentData: NormalizedSchema<ExperimentFullNormalizedEntities, number>
   metrics: MetricBare[]
   segments: Segment[]
 }) {

--- a/components/ExperimentDetails.tsx
+++ b/components/ExperimentDetails.tsx
@@ -25,15 +25,15 @@ const debug = debugFactory('abacus:components/ExperimentDetails.tsx')
 function ExperimentDetails({
   experiment,
   normalizedExperiment,
-  // normalizedExperimentData,
+  normalizedExperimentData,
   metrics,
-  segments,
+  indexedSegments,
 }: {
   experiment: ExperimentFull
   normalizedExperiment: ExperimentFullNormalized
   normalizedExperimentData: ExperimentFullNormalizedData
   metrics: MetricBare[]
-  segments: Segment[]
+  indexedSegments: Record<number, Segment>
 }) {
   debug('ExperimentDetails#render')
   const theme = useTheme()
@@ -48,7 +48,7 @@ function ExperimentDetails({
           </Grid>
           {isMdDown && (
             <Grid item>
-              <AudiencePanel experiment={experiment} segments={segments} />
+              <AudiencePanel normalizedExperimentData={normalizedExperimentData} indexedSegments={indexedSegments} />
             </Grid>
           )}
           <Grid item>
@@ -63,7 +63,7 @@ function ExperimentDetails({
       </Grid>
       {!isMdDown && (
         <Grid item lg={5}>
-          <AudiencePanel experiment={experiment} segments={segments} />
+          <AudiencePanel normalizedExperimentData={normalizedExperimentData} indexedSegments={indexedSegments} />
         </Grid>
       )}
     </Grid>

--- a/components/ExperimentDetails.tsx
+++ b/components/ExperimentDetails.tsx
@@ -26,13 +26,13 @@ function ExperimentDetails({
   experiment,
   normalizedExperiment,
   normalizedExperimentData,
-  metrics,
+  indexedMetrics,
   indexedSegments,
 }: {
   experiment: ExperimentFull
   normalizedExperiment: ExperimentFullNormalized
   normalizedExperimentData: ExperimentFullNormalizedData
-  metrics: MetricBare[]
+  indexedMetrics: Record<number, MetricBare>
   indexedSegments: Record<number, Segment>
 }) {
   debug('ExperimentDetails#render')
@@ -52,7 +52,10 @@ function ExperimentDetails({
             </Grid>
           )}
           <Grid item>
-            <MetricAssignmentsPanel experiment={experiment} metrics={metrics} />
+            <MetricAssignmentsPanel
+              normalizedExperimentData={normalizedExperimentData}
+              indexedMetrics={indexedMetrics}
+            />
           </Grid>
           {Experiments.hasConclusionData(experiment) && (
             <Grid item>

--- a/components/ExperimentDetails.tsx
+++ b/components/ExperimentDetails.tsx
@@ -59,7 +59,7 @@ function ExperimentDetails({
           </Grid>
           {Experiments.hasConclusionData(experiment) && (
             <Grid item>
-              <ConclusionsPanel experiment={experiment} />
+              <ConclusionsPanel normalizedExperimentData={normalizedExperimentData} />
             </Grid>
           )}
         </Grid>

--- a/components/ExperimentDetails.tsx
+++ b/components/ExperimentDetails.tsx
@@ -2,7 +2,6 @@ import Grid from '@material-ui/core/Grid'
 import { useTheme } from '@material-ui/core/styles'
 import useMediaQuery from '@material-ui/core/useMediaQuery'
 import debugFactory from 'debug'
-import { NormalizedSchema } from 'normalizr'
 import React from 'react'
 
 import AudiencePanel from '@/components/AudiencePanel'
@@ -13,7 +12,7 @@ import * as Experiments from '@/lib/experiments'
 import {
   ExperimentFull,
   ExperimentFullNormalized,
-  ExperimentFullNormalizedEntities,
+  ExperimentFullNormalizedData,
   MetricBare,
   Segment,
 } from '@/lib/schemas'
@@ -35,7 +34,7 @@ function ExperimentDetails({
 }: {
   experiment: ExperimentFull
   normalizedExperiment: ExperimentFullNormalized
-  normalizedExperimentData: NormalizedSchema<ExperimentFullNormalizedEntities, number>
+  normalizedExperimentData: ExperimentFullNormalizedData
   metrics: MetricBare[]
   segments: Segment[]
 }) {

--- a/components/ExperimentDetails.tsx
+++ b/components/ExperimentDetails.tsx
@@ -9,13 +9,7 @@ import ConclusionsPanel from '@/components/ConclusionsPanel'
 import GeneralPanel from '@/components/GeneralPanel'
 import MetricAssignmentsPanel from '@/components/MetricAssignmentsPanel'
 import * as Experiments from '@/lib/experiments'
-import {
-  ExperimentFull,
-  ExperimentFullNormalized,
-  ExperimentFullNormalizedData,
-  MetricBare,
-  Segment,
-} from '@/lib/schemas'
+import { ExperimentFullNormalized, ExperimentFullNormalizedData, MetricBare, Segment } from '@/lib/schemas'
 
 const debug = debugFactory('abacus:components/ExperimentDetails.tsx')
 
@@ -23,13 +17,11 @@ const debug = debugFactory('abacus:components/ExperimentDetails.tsx')
  * Renders the main details of an experiment.
  */
 function ExperimentDetails({
-  experiment,
   normalizedExperiment,
   normalizedExperimentData,
   indexedMetrics,
   indexedSegments,
 }: {
-  experiment: ExperimentFull
   normalizedExperiment: ExperimentFullNormalized
   normalizedExperimentData: ExperimentFullNormalizedData
   indexedMetrics: Record<number, MetricBare>
@@ -57,7 +49,7 @@ function ExperimentDetails({
               indexedMetrics={indexedMetrics}
             />
           </Grid>
-          {Experiments.hasConclusionData(experiment) && (
+          {Experiments.hasConclusionData(normalizedExperiment) && (
             <Grid item>
               <ConclusionsPanel normalizedExperimentData={normalizedExperimentData} />
             </Grid>

--- a/components/ExperimentTabs.test.tsx
+++ b/components/ExperimentTabs.test.tsx
@@ -1,5 +1,7 @@
+import { normalize } from 'normalizr'
 import React from 'react'
 
+import { ExperimentFull, ExperimentFullNormalizedEntities, experimentFullNormalizrSchema } from '@/lib/schemas'
 import Fixtures from '@/test-helpers/fixtures'
 import { render } from '@/test-helpers/test-utils'
 
@@ -10,7 +12,12 @@ test('renders expected links', () => {
     metricAssignments: [],
     segmentAssignments: [],
   })
-  const { getByText } = render(<ExperimentTabs experiment={experiment} tab='details' />)
+  const normalizedExperimentData = normalize<ExperimentFull, ExperimentFullNormalizedEntities>(
+    experiment,
+    experimentFullNormalizrSchema,
+  )
+  const normalizedExperiment = normalizedExperimentData.entities.experiments[normalizedExperimentData.result]
+  const { getByText } = render(<ExperimentTabs normalizedExperiment={normalizedExperiment} tab='details' />)
 
   expect(getByText('Details', { selector: '.MuiTab-wrapper' })).toBeInTheDocument()
   expect(getByText('Results', { selector: '.MuiTab-wrapper' })).toBeInTheDocument()

--- a/components/ExperimentTabs.tsx
+++ b/components/ExperimentTabs.tsx
@@ -4,7 +4,7 @@ import Tabs from '@material-ui/core/Tabs'
 import { useRouter } from 'next/router'
 import React, { ReactNode } from 'react'
 
-import { ExperimentFull, ExperimentFullNormalized } from '@/lib/schemas'
+import { ExperimentFullNormalized } from '@/lib/schemas'
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -42,7 +42,6 @@ export default function ExperimentTabs({
   tab,
 }: {
   className?: string
-  experiment: ExperimentFull
   normalizedExperiment: ExperimentFullNormalized
   tab: 'details' | 'results' | 'snippets'
 }) {

--- a/components/ExperimentTabs.tsx
+++ b/components/ExperimentTabs.tsx
@@ -38,29 +38,30 @@ function LinkTab({ as, label, url, value }: { as?: string; label: ReactNode; url
  */
 export default function ExperimentTabs({
   className,
-  experiment,
-  /*
-  // Not yet used
   normalizedExperiment,
-  */
   tab,
 }: {
   className?: string
   experiment: ExperimentFull
-  normalizedExperiment?: ExperimentFullNormalized
+  normalizedExperiment: ExperimentFullNormalized
   tab: 'details' | 'results' | 'snippets'
 }) {
   return (
     <Tabs className={className} value={tab}>
-      <LinkTab as={`/experiments/${experiment.experimentId}`} label='Details' value='details' url='/experiments/[id]' />
       <LinkTab
-        as={`/experiments/${experiment.experimentId}/results`}
+        as={`/experiments/${normalizedExperiment.experimentId}`}
+        label='Details'
+        value='details'
+        url='/experiments/[id]'
+      />
+      <LinkTab
+        as={`/experiments/${normalizedExperiment.experimentId}/results`}
         label='Results'
         value='results'
         url='/experiments/[id]/results'
       />
       <LinkTab
-        as={`/experiments/${experiment.experimentId}/snippets`}
+        as={`/experiments/${normalizedExperiment.experimentId}/snippets`}
         label='Snippets'
         value='snippets'
         url='/experiments/[id]/snippets'

--- a/components/ExperimentTabs.tsx
+++ b/components/ExperimentTabs.tsx
@@ -4,7 +4,7 @@ import Tabs from '@material-ui/core/Tabs'
 import { useRouter } from 'next/router'
 import React, { ReactNode } from 'react'
 
-import { ExperimentFull } from '@/lib/schemas'
+import { ExperimentFull, ExperimentFullNormalized } from '@/lib/schemas'
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -39,10 +39,15 @@ function LinkTab({ as, label, url, value }: { as?: string; label: ReactNode; url
 export default function ExperimentTabs({
   className,
   experiment,
+  /*
+  // Not yet used
+  normalizedExperiment,
+  */
   tab,
 }: {
   className?: string
   experiment: ExperimentFull
+  normalizedExperiment?: ExperimentFullNormalized
   tab: 'details' | 'results' | 'snippets'
 }) {
   return (

--- a/components/GeneralPanel.test.tsx
+++ b/components/GeneralPanel.test.tsx
@@ -1,6 +1,8 @@
 import MockDate from 'mockdate'
+import { normalize } from 'normalizr'
 import React from 'react'
 
+import { ExperimentFull, ExperimentFullNormalizedEntities, experimentFullNormalizrSchema } from '@/lib/schemas'
 import Fixtures from '@/test-helpers/fixtures'
 import { render } from '@/test-helpers/test-utils'
 
@@ -10,7 +12,12 @@ MockDate.set('2020-07-21')
 
 test('renders as expected', () => {
   const experiment = Fixtures.createExperimentFull()
-  const { container } = render(<GeneralPanel experiment={experiment} />)
+  const normalizedExperimentData = normalize<ExperimentFull, ExperimentFullNormalizedEntities>(
+    experiment,
+    experimentFullNormalizrSchema,
+  )
+  const normalizedExperiment = normalizedExperimentData.entities.experiments[normalizedExperimentData.result]
+  const { container } = render(<GeneralPanel normalizedExperiment={normalizedExperiment} />)
 
   expect(container).toMatchInlineSnapshot(`
     <div>

--- a/components/GeneralPanel.tsx
+++ b/components/GeneralPanel.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 import DatetimeText from '@/components/DatetimeText'
 import LabelValuePanel from '@/components/LabelValuePanel'
-import { ExperimentFull } from '@/lib/schemas'
+import { ExperimentFullNormalized } from '@/lib/schemas'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -19,15 +19,15 @@ const useStyles = makeStyles((theme: Theme) =>
  *
  * @param props.experiment - The experiment with the general information.
  */
-function GeneralPanel({ experiment }: { experiment: ExperimentFull }) {
+function GeneralPanel({ normalizedExperiment }: { normalizedExperiment: ExperimentFullNormalized }) {
   const classes = useStyles()
   const data = [
-    { label: 'Description', value: experiment.description },
+    { label: 'Description', value: normalizedExperiment.description },
     {
       label: 'P2 Link',
       value: (
-        <a href={experiment.p2Url} rel='noopener noreferrer' target='_blank'>
-          {experiment.p2Url}
+        <a href={normalizedExperiment.p2Url} rel='noopener noreferrer' target='_blank'>
+          {normalizedExperiment.p2Url}
         </a>
       ),
     },
@@ -35,13 +35,13 @@ function GeneralPanel({ experiment }: { experiment: ExperimentFull }) {
       label: 'Dates',
       value: (
         <>
-          <DatetimeText datetime={experiment.startDatetime} excludeTime />
+          <DatetimeText datetime={normalizedExperiment.startDatetime} excludeTime />
           <span className={classes.to}>to</span>
-          <DatetimeText datetime={experiment.endDatetime} excludeTime />
+          <DatetimeText datetime={normalizedExperiment.endDatetime} excludeTime />
         </>
       ),
     },
-    { label: 'Owner', value: experiment.ownerLogin },
+    { label: 'Owner', value: normalizedExperiment.ownerLogin },
   ]
   return <LabelValuePanel data={data} title='General' />
 }

--- a/components/MetricAssignmentsPanel.tsx
+++ b/components/MetricAssignmentsPanel.tsx
@@ -6,39 +6,13 @@ import TableCell from '@material-ui/core/TableCell'
 import TableHead from '@material-ui/core/TableHead'
 import TableRow from '@material-ui/core/TableRow'
 import Typography from '@material-ui/core/Typography'
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import Label from '@/components/Label'
 import { AttributionWindowSecondsToHuman } from '@/lib/metric-assignments'
 import * as MetricAssignments from '@/lib/metric-assignments'
-import { ExperimentFull, MetricAssignment, MetricBare } from '@/lib/schemas'
+import { ExperimentFullNormalizedData, MetricBare } from '@/lib/schemas'
 import { formatBoolean, formatUsCurrencyDollar } from '@/utils/formatters'
-
-/**
- * Resolves the metric ID of the metric assignment with the actual metric. If the
- * ID cannot be resolved, then an `Error` will be thrown.
- *
- * @param metricAssignments - The metric assignments to be resolved.
- * @param metrics - The metrics to associate with the assignments.
- * @throws {Error} When unable to resolve a metric ID with one of the supplied
- *   metrics.
- */
-function resolveMetricAssignments(metricAssignments: MetricAssignment[], metrics: MetricBare[]) {
-  const metricsById: { [metricId: string]: MetricBare } = {}
-  metrics.forEach((metric) => (metricsById[metric.metricId] = metric))
-
-  return metricAssignments.map((metricAssignment) => {
-    const metric = metricsById[metricAssignment.metricId]
-
-    if (!metric) {
-      throw Error(
-        `Failed to lookup metric with ID ${metricAssignment.metricId} for assignment with ID ${metricAssignment.metricAssignmentId}.`,
-      )
-    }
-
-    return { ...metricAssignment, metric }
-  })
-}
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -58,12 +32,28 @@ const useStyles = makeStyles((theme: Theme) =>
  * @param props.metrics - The metrics to look up (aka resolve) the metric IDs of the
  *   experiment's metric assignments.
  */
-function MetricAssignmentsPanel({ experiment, metrics }: { experiment: ExperimentFull; metrics: MetricBare[] }) {
+function MetricAssignmentsPanel({
+  normalizedExperimentData,
+  indexedMetrics,
+}: {
+  normalizedExperimentData: ExperimentFullNormalizedData
+  indexedMetrics: Record<number, MetricBare>
+}) {
   const classes = useStyles()
-  const resolvedMetricAssignments = useMemo(
-    () => resolveMetricAssignments(MetricAssignments.sort(experiment.metricAssignments), metrics),
-    [experiment, metrics],
+
+  const sortedMetricAssignments = MetricAssignments.sort(
+    Object.values(normalizedExperimentData.entities.metricAssignments),
   )
+
+  const metricAssignmentsWithMetrics = sortedMetricAssignments.map((metricAssignment) => {
+    const metric = indexedMetrics[metricAssignment.metricId]
+    if (!metric) {
+      throw new Error(
+        `Can't find metric matching metricId '${metricAssignment.metricId}' of metricAssignment (${metricAssignment.metricAssignmentId})`,
+      )
+    }
+    return { metricAssignment, metric }
+  })
 
   return (
     <Paper>
@@ -88,23 +78,21 @@ function MetricAssignmentsPanel({ experiment, metrics }: { experiment: Experimen
           </TableRow>
         </TableHead>
         <TableBody>
-          {resolvedMetricAssignments.map((resolvedMetricAssignment) => (
-            <TableRow key={resolvedMetricAssignment.metricAssignmentId}>
+          {metricAssignmentsWithMetrics.map(({ metricAssignment, metric }) => (
+            <TableRow key={metricAssignment.metricAssignmentId}>
               <TableCell>
-                {resolvedMetricAssignment.metric.name}
-                {resolvedMetricAssignment.isPrimary && <Label className={classes.primary} text='Primary' />}
+                {metric.name}
+                {metricAssignment.isPrimary && <Label className={classes.primary} text='Primary' />}
               </TableCell>
               <TableCell>
                 <span>
-                  {resolvedMetricAssignment.metric.parameterType === 'revenue'
-                    ? formatUsCurrencyDollar(resolvedMetricAssignment.minDifference)
-                    : `${resolvedMetricAssignment.minDifference} pp`}
+                  {metric.parameterType === 'revenue'
+                    ? formatUsCurrencyDollar(metricAssignment.minDifference)
+                    : `${metricAssignment.minDifference} pp`}
                 </span>
               </TableCell>
-              <TableCell>
-                {AttributionWindowSecondsToHuman[resolvedMetricAssignment.attributionWindowSeconds]}
-              </TableCell>
-              <TableCell>{formatBoolean(resolvedMetricAssignment.changeExpected)}</TableCell>
+              <TableCell>{AttributionWindowSecondsToHuman[metricAssignment.attributionWindowSeconds]}</TableCell>
+              <TableCell>{formatBoolean(metricAssignment.changeExpected)}</TableCell>
             </TableRow>
           ))}
         </TableBody>

--- a/components/SegmentsTable.test.tsx
+++ b/components/SegmentsTable.test.tsx
@@ -1,17 +1,23 @@
 import React from 'react'
 
-import { Segment, SegmentType } from '@/lib/schemas'
+import { Segment, SegmentAssignment, SegmentType } from '@/lib/schemas'
 import { render } from '@/test-helpers/test-utils'
 
 import SegmentsTable from './SegmentsTable'
 
 test('renders as expected with segment names not in order', () => {
-  const resolvedSegmentAssignments: Array<{ segment: Segment; isExcluded: boolean }> = [
-    { segment: { segmentId: 1, name: 'foo', type: SegmentType.Country }, isExcluded: false },
-    { segment: { segmentId: 2, name: 'bar', type: SegmentType.Country }, isExcluded: true },
+  const resolvedSegmentAssignments: Array<{ segment: Segment; segmentAssignment: SegmentAssignment }> = [
+    {
+      segment: { segmentId: 1, name: 'foo', type: SegmentType.Country },
+      segmentAssignment: { segmentAssignmentId: 1, segmentId: 1, isExcluded: false },
+    },
+    {
+      segment: { segmentId: 2, name: 'bar', type: SegmentType.Country },
+      segmentAssignment: { segmentAssignmentId: 2, segmentId: 2, isExcluded: true },
+    },
   ]
   const { container } = render(
-    <SegmentsTable resolvedSegmentAssignments={resolvedSegmentAssignments} type={SegmentType.Country} />,
+    <SegmentsTable segmentAssignmentsWithSegments={resolvedSegmentAssignments} type={SegmentType.Country} />,
   )
 
   expect(container).toMatchInlineSnapshot(`

--- a/components/SegmentsTable.tsx
+++ b/components/SegmentsTable.tsx
@@ -5,10 +5,10 @@ import TableCell from '@material-ui/core/TableCell'
 import TableHead from '@material-ui/core/TableHead'
 import TableRow from '@material-ui/core/TableRow'
 import _ from 'lodash'
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import Label from '@/components/Label'
-import { Segment, SegmentType } from '@/lib/schemas'
+import { Segment, SegmentAssignment, SegmentType } from '@/lib/schemas'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -34,19 +34,17 @@ const SegmentTypeToHeading = {
  * @param props.type - The segment type the segment assignments represent.
  */
 function SegmentsTable({
-  resolvedSegmentAssignments,
+  segmentAssignmentsWithSegments,
   type,
 }: {
-  resolvedSegmentAssignments: {
+  segmentAssignmentsWithSegments: {
+    segmentAssignment: SegmentAssignment
     segment: Segment
-    isExcluded: boolean
   }[]
   type: SegmentType
 }) {
-  const sortedResolvedSegmentAssignments = useMemo(
-    () => _.orderBy(resolvedSegmentAssignments, [_.property('segment.name')]),
-    [resolvedSegmentAssignments],
-  )
+  const sortedSegmentAssignmentsWithSegments = _.orderBy(segmentAssignmentsWithSegments, [_.property('segment.name')])
+
   const classes = useStyles()
   return (
     <Table>
@@ -58,22 +56,19 @@ function SegmentsTable({
         </TableRow>
       </TableHead>
       <TableBody>
-        {resolvedSegmentAssignments.length === 0 ? (
+        {sortedSegmentAssignmentsWithSegments.length === 0 ? (
           <TableRow>
             <TableCell>All {type === SegmentType.Country ? 'countries' : 'locales'} included</TableCell>
           </TableRow>
         ) : (
-          sortedResolvedSegmentAssignments.map(
-            (resolvedSegmentAssignment) =>
-              resolvedSegmentAssignment.segment && (
-                <TableRow key={resolvedSegmentAssignment.segment.segmentId}>
-                  <TableCell>
-                    {resolvedSegmentAssignment.segment.name}
-                    {resolvedSegmentAssignment.isExcluded && <Label className={classes.excluded} text='Excluded' />}
-                  </TableCell>
-                </TableRow>
-              ),
-          )
+          sortedSegmentAssignmentsWithSegments.map(({ segmentAssignment, segment }) => (
+            <TableRow key={segment.segmentId}>
+              <TableCell>
+                {segment.name}
+                {segmentAssignment.isExcluded && <Label className={classes.excluded} text='Excluded' />}
+              </TableCell>
+            </TableRow>
+          ))
         )}
       </TableBody>
     </Table>

--- a/components/experiment-creation/Audience.test.tsx
+++ b/components/experiment-creation/Audience.test.tsx
@@ -3,7 +3,7 @@ import { Formik, FormikProps } from 'formik'
 import React from 'react'
 
 import { createNewExperiment } from '@/lib/experiments'
-import { ExperimentFullNew } from '@/lib/schemas'
+import { ExperimentFullNew, Segment, SegmentType } from '@/lib/schemas'
 
 import Audience from './Audience'
 
@@ -20,6 +20,13 @@ document.createRange = () => ({
 })
 
 test('renders as expected', async () => {
+  const indexedSegments: Record<number, Segment> = {
+    1: { segmentId: 1, name: 'us', type: SegmentType.Country },
+    2: { segmentId: 2, name: 'au', type: SegmentType.Country },
+    3: { segmentId: 3, name: 'en-US', type: SegmentType.Locale },
+    4: { segmentId: 4, name: 'en-AU', type: SegmentType.Locale },
+  }
+
   const { container } = render(
     <Formik
       initialValues={{ experiment: createNewExperiment() }}
@@ -28,7 +35,9 @@ test('renders as expected', async () => {
         () => undefined
       }
     >
-      {(formikProps: FormikProps<{ experiment: Partial<ExperimentFullNew> }>) => <Audience formikProps={formikProps} />}
+      {(formikProps: FormikProps<{ experiment: Partial<ExperimentFullNew> }>) => (
+        <Audience formikProps={formikProps} indexedSegments={indexedSegments} />
+      )}
     </Formik>,
   )
   expect(container).toMatchSnapshot()

--- a/components/experiment-creation/Audience.tsx
+++ b/components/experiment-creation/Audience.tsx
@@ -58,7 +58,7 @@ enum SegmentExclusionState {
 
 const SegmentsAutocomplete = (
   props: AutocompleteProps<Segment, true, false, false> & {
-    normalizedSegments: Record<number, Segment>
+    indexedSegments: Record<number, Segment>
     segmentExclusionState: SegmentExclusionState
   },
 ) => {
@@ -70,7 +70,7 @@ const SegmentsAutocomplete = (
 
   // Here we translate SegmentAssignment (outside) <-> Segment (inside)
   const segmentAssignmentToSegment = (segmentAssignment: SegmentAssignmentNew) => {
-    const segment = props.normalizedSegments[segmentAssignment.segmentId]
+    const segment = props.indexedSegments[segmentAssignment.segmentId]
     /* istanbul ignore next; Should never happen */
     if (!segment) {
       throw new Error('Could not find segment with specified segmentId.')
@@ -94,7 +94,7 @@ const SegmentsAutocomplete = (
 
   return (
     <Autocomplete
-      {...fieldToAutocomplete(_.omit(props, 'segmentExclusionState', 'normalizedSegments'))}
+      {...fieldToAutocomplete(_.omit(props, 'segmentExclusionState', 'indexedSegments'))}
       multiple={true}
       onChange={onChange}
       value={value}
@@ -104,10 +104,10 @@ const SegmentsAutocomplete = (
 }
 
 const Audience = ({
-  normalizedSegments,
+  indexedSegments,
   formikProps,
 }: {
-  normalizedSegments: Record<number, Segment>
+  indexedSegments: Record<number, Segment>
   formikProps: FormikProps<{ experiment: Partial<ExperimentFullNew> }>
 }) => {
   const classes = useStyles()
@@ -202,13 +202,13 @@ const Audience = ({
           <Field
             name='experiment.segmentAssignments'
             component={SegmentsAutocomplete}
-            options={Object.values(normalizedSegments)}
+            options={Object.values(indexedSegments)}
             // TODO: Error state, see https://stackworx.github.io/formik-material-ui/docs/api/material-ui-lab
             renderInput={(params: AutocompleteRenderInputParams) => (
               <MuiTextField {...params} variant='outlined' placeholder='Search and select to customize' />
             )}
             segmentExclusionState={segmentExclusionState}
-            normalizedSegments={normalizedSegments}
+            indexedSegments={indexedSegments}
             fullWidth
             id='segments-select'
           />

--- a/components/experiment-creation/ExperimentForm.test.tsx
+++ b/components/experiment-creation/ExperimentForm.test.tsx
@@ -1,19 +1,30 @@
 /* eslint-disable no-irregular-whitespace */
 import { render } from '@testing-library/react'
 import MockDate from 'mockdate'
+import { normalize } from 'normalizr'
 import React from 'react'
 
 import { createNewExperiment } from '@/lib/experiments'
+import { MetricBare, metricBareNormalizrSchema, Segment, segmentNormalizrSchema } from '@/lib/schemas'
 import Fixtures from '@/test-helpers/fixtures'
 
 import ExperimentForm from './ExperimentForm'
 
 test('renders as expected', () => {
   MockDate.set('2020-07-21')
+  const metrics = Fixtures.createMetricBares(20)
+  const segments = Fixtures.createSegments(20)
+  const {
+    entities: { metrics: indexedMetrics },
+  } = normalize<MetricBare, { metrics: Record<number, MetricBare> }>(metrics, [metricBareNormalizrSchema])
+  const {
+    entities: { segments: indexedSegments },
+  } = normalize<Segment, { segments: Record<number, Segment> }>(segments, [segmentNormalizrSchema])
+
   const { container } = render(
     <ExperimentForm
-      metrics={Fixtures.createMetricBares(20)}
-      segments={Fixtures.createSegments(20)}
+      indexedMetrics={indexedMetrics}
+      indexedSegments={indexedSegments}
       initialExperiment={createNewExperiment()}
     />,
   )

--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -86,12 +86,12 @@ const useStyles = makeStyles((theme: Theme) =>
 )
 
 const ExperimentForm = ({
-  metrics,
-  segments,
+  normalizedMetrics,
+  normalizedSegments,
   initialExperiment,
 }: {
-  metrics: MetricBare[]
-  segments: Segment[]
+  normalizedMetrics: Record<string, MetricBare>
+  normalizedSegments: Record<string, Segment>
   initialExperiment: Partial<ExperimentFullNew>
 }) => {
   const classes = useStyles()

--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -190,7 +190,7 @@ const ExperimentForm = ({
               </div>
               <div className={classes.formPart} ref={formPartAudienceRef}>
                 <Paper className={classes.paper}>
-                  <Audience formikProps={formikProps} />
+                  <Audience formikProps={formikProps} normalizedSegments={normalizedSegments} />
                 </Paper>
                 <div className={classes.formPartActions}>
                   <Button onClick={prevStage}>Previous</Button>

--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -86,12 +86,12 @@ const useStyles = makeStyles((theme: Theme) =>
 )
 
 const ExperimentForm = ({
-  normalizedMetrics,
-  normalizedSegments,
+  indexedMetrics,
+  indexedSegments,
   initialExperiment,
 }: {
-  normalizedMetrics: Record<string, MetricBare>
-  normalizedSegments: Record<string, Segment>
+  indexedMetrics: Record<string, MetricBare>
+  indexedSegments: Record<string, Segment>
   initialExperiment: Partial<ExperimentFullNew>
 }) => {
   const classes = useStyles()
@@ -190,7 +190,7 @@ const ExperimentForm = ({
               </div>
               <div className={classes.formPart} ref={formPartAudienceRef}>
                 <Paper className={classes.paper}>
-                  <Audience formikProps={formikProps} normalizedSegments={normalizedSegments} />
+                  <Audience formikProps={formikProps} indexedSegments={indexedSegments} />
                 </Paper>
                 <div className={classes.formPartActions}>
                   <Button onClick={prevStage}>Previous</Button>

--- a/lib/experiments.test.ts
+++ b/lib/experiments.test.ts
@@ -1,16 +1,36 @@
+import { normalize } from 'normalizr'
+
 import Fixtures from '@/test-helpers/fixtures'
 
 import * as Experiments from './experiments'
-import { AnalysisStrategy, Platform } from './schemas'
+import {
+  AnalysisStrategy,
+  ExperimentFull,
+  ExperimentFullNormalizedEntities,
+  experimentFullNormalizrSchema,
+  Platform,
+} from './schemas'
 
 describe('lib/experiments.ts module', () => {
   describe('getDeployedVariation', () => {
     it('should return null when no deployed variation declared', () => {
-      expect(Experiments.getDeployedVariation(Fixtures.createExperimentFull())).toBeNull()
+      const experiment = Fixtures.createExperimentFull()
+      const normalizedExperimentData = normalize<ExperimentFull, ExperimentFullNormalizedEntities>(
+        experiment,
+        experimentFullNormalizrSchema,
+      )
+
+      expect(Experiments.getDeployedVariation(normalizedExperimentData)).toBeNull()
     })
 
     it('should return the deployed variation when declared', () => {
-      expect(Experiments.getDeployedVariation(Fixtures.createExperimentFull({ deployedVariationId: 1 }))).toEqual({
+      const experiment = Fixtures.createExperimentFull({ deployedVariationId: 1 })
+      const normalizedExperimentData = normalize<ExperimentFull, ExperimentFullNormalizedEntities>(
+        experiment,
+        experimentFullNormalizrSchema,
+      )
+
+      expect(Experiments.getDeployedVariation(normalizedExperimentData)).toEqual({
         variationId: 1,
         name: 'control',
         isDefault: true,
@@ -19,8 +39,14 @@ describe('lib/experiments.ts module', () => {
     })
 
     it('should throw an error when deployed variation is declared but cannot be resolved', () => {
+      const experiment = Fixtures.createExperimentFull({ deployedVariationId: 0 })
+      const normalizedExperimentData = normalize<ExperimentFull, ExperimentFullNormalizedEntities>(
+        experiment,
+        experimentFullNormalizrSchema,
+      )
+
       expect(() => {
-        Experiments.getDeployedVariation(Fixtures.createExperimentFull({ deployedVariationId: 0 }))
+        Experiments.getDeployedVariation(normalizedExperimentData)
       }).toThrowError()
     })
   })

--- a/lib/experiments.ts
+++ b/lib/experiments.ts
@@ -1,4 +1,11 @@
-import { AnalysisStrategy, ExperimentFull, ExperimentFullNew, Platform, Variation } from './schemas'
+import {
+  AnalysisStrategy,
+  ExperimentFull,
+  ExperimentFullNew,
+  ExperimentFullNormalizedData,
+  Platform,
+  Variation,
+} from './schemas'
 
 /**
  * Return the deployed variation if one has been selected, otherwise `null`.
@@ -6,19 +13,19 @@ import { AnalysisStrategy, ExperimentFull, ExperimentFullNew, Platform, Variatio
  * @throws {Error} If a `deployedVariationId` is set but cannot be found in the
  *   variations.
  */
-export function getDeployedVariation(experiment: ExperimentFull): null | Variation {
-  let deployedVariation = null
+export function getDeployedVariation(normalizedExperimentData: ExperimentFullNormalizedData): null | Variation {
+  const normalizedExperiment = normalizedExperimentData.entities.experiments[normalizedExperimentData.result]
 
-  if (typeof experiment.deployedVariationId === 'number') {
-    deployedVariation = experiment.variations.find(
-      (variation) => experiment.deployedVariationId === variation.variationId,
+  if (typeof normalizedExperiment.deployedVariationId !== 'number') {
+    return null
+  }
+
+  const deployedVariation = normalizedExperimentData.entities.variations[normalizedExperiment.deployedVariationId]
+
+  if (!deployedVariation) {
+    throw new Error(
+      `Failed to resolve the deployed variation with ID ${normalizedExperiment.deployedVariationId} for experiment with ID ${normalizedExperiment.experimentId}.`,
     )
-
-    if (!deployedVariation) {
-      throw Error(
-        `Failed to resolve the deployed variation with ID ${experiment.deployedVariationId} for experiment with ID ${experiment.experimentId}.`,
-      )
-    }
   }
 
   return deployedVariation

--- a/lib/experiments.ts
+++ b/lib/experiments.ts
@@ -2,6 +2,7 @@ import {
   AnalysisStrategy,
   ExperimentFull,
   ExperimentFullNew,
+  ExperimentFullNormalized,
   ExperimentFullNormalizedData,
   Platform,
   Variation,
@@ -41,7 +42,7 @@ export function getPrimaryMetricAssignmentId(experiment: ExperimentFull): number
 /**
  * Determines whether conclusion data has been entered for this experiment.
  */
-export function hasConclusionData(experiment: ExperimentFull): boolean {
+export function hasConclusionData(experiment: ExperimentFull | ExperimentFullNormalized): boolean {
   return !!experiment.endReason || !!experiment.conclusionUrl || typeof experiment.deployedVariationId === 'number'
 }
 

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -60,6 +60,11 @@ export const metricBareSchema = yup
   .defined()
   .camelCase()
 export type MetricBare = yup.InferType<typeof metricBareSchema>
+export const metricBareNormalizrSchema = new normalizr.schema.Entity<MetricBare>(
+  'metrics',
+  {},
+  { idAttribute: 'metricId' },
+)
 
 export const metricFullSchema = metricBareSchema
   .shape({

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -121,6 +121,11 @@ export const metricAssignmentSchema = metricAssignmentNewSchema
   .defined()
   .camelCase()
 export type MetricAssignment = yup.InferType<typeof metricAssignmentSchema>
+export const metricAssignmentNormalizrSchema = new normalizr.schema.Entity<MetricAssignment>(
+  'metricAssignments',
+  {},
+  { idAttribute: 'metricAssignmentId' },
+)
 
 export enum SegmentType {
   Country = 'country',
@@ -154,6 +159,11 @@ export const segmentAssignmentSchema = segmentAssignmentNewSchema
   .defined()
   .camelCase()
 export type SegmentAssignment = yup.InferType<typeof segmentAssignmentSchema>
+export const segmentAssignmentNormalizrSchema = new normalizr.schema.Entity<SegmentAssignment>(
+  'segmentAssignments',
+  {},
+  { idAttribute: 'segmentAssignmentId' },
+)
 
 export const variationNewSchema = yup
   .object({
@@ -172,6 +182,11 @@ export const variationSchema = variationNewSchema
   .defined()
   .camelCase()
 export type Variation = yup.InferType<typeof variationSchema>
+export const variationNormalizrSchema = new normalizr.schema.Entity<Variation>(
+  'variations',
+  {},
+  { idAttribute: 'variationId' },
+)
 
 export enum Platform {
   Calypso = 'calypso',
@@ -217,6 +232,15 @@ export const experimentFullSchema = experimentBareSchema
   .defined()
   .camelCase()
 export type ExperimentFull = yup.InferType<typeof experimentFullSchema>
+export const experimentFullNormalizrSchema = new normalizr.schema.Entity<ExperimentFull>(
+  'experiments',
+  {
+    metricsAssignments: [metricAssignmentNormalizrSchema],
+    segmentAssignments: [segmentAssignmentNormalizrSchema],
+    variations: [variationNormalizrSchema],
+  },
+  { idAttribute: 'experimentId' },
+)
 
 const now = new Date()
 export const experimentFullNewSchema = experimentFullSchema.shape({

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -235,7 +235,7 @@ export type ExperimentFull = yup.InferType<typeof experimentFullSchema>
 export const experimentFullNormalizrSchema = new normalizr.schema.Entity<ExperimentFull>(
   'experiments',
   {
-    metricsAssignments: [metricAssignmentNormalizrSchema],
+    metricAssignments: [metricAssignmentNormalizrSchema],
     segmentAssignments: [segmentAssignmentNormalizrSchema],
     variations: [variationNormalizrSchema],
   },

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -2,6 +2,7 @@
 // https://app.swaggerhub.com/apis/yanir/experiments/0.1.0
 
 import * as dateFns from 'date-fns'
+import * as normalizr from 'normalizr'
 import * as yup from 'yup'
 
 const idSchema = yup.number().integer().positive()
@@ -130,6 +131,7 @@ export const segmentSchema = yup
   .defined()
   .camelCase()
 export type Segment = yup.InferType<typeof segmentSchema>
+export const segmentNormalizrSchema = new normalizr.schema.Entity<Segment>('segments', {}, { idAttribute: 'segmentId' })
 
 export const segmentAssignmentNewSchema = yup
   .object({

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -255,6 +255,7 @@ export interface ExperimentFullNormalizedEntities {
   segmentAssignments: Record<number, SegmentAssignment>
   variations: Record<number, Variation>
 }
+export type ExperimentFullNormalizedData = normalizr.NormalizedSchema<ExperimentFullNormalizedEntities, number>
 
 const now = new Date()
 export const experimentFullNewSchema = experimentFullSchema.shape({

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -246,7 +246,7 @@ export type ExperimentFullNormalized = Omit<
   'metricAssignments' | 'segmentAssignments' | 'variations'
 > & {
   metricAssignments: number[]
-  segmentAssignments: number[]
+  segmentAssignments?: number[]
   variations: number[]
 }
 export interface ExperimentFullNormalizedEntities {

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -241,6 +241,20 @@ export const experimentFullNormalizrSchema = new normalizr.schema.Entity<Experim
   },
   { idAttribute: 'experimentId' },
 )
+export type ExperimentFullNormalized = Omit<
+  ExperimentFull,
+  'metricAssignments' | 'segmentAssignments' | 'variations'
+> & {
+  metricAssignments: number[]
+  segmentAssignments: number[]
+  variations: number[]
+}
+export interface ExperimentFullNormalizedEntities {
+  experiments: Record<number, ExperimentFullNormalized>
+  metricAssignments: Record<number, MetricAssignment>
+  segmentAssignments: Record<number, SegmentAssignment>
+  variations: Record<number, Variation>
+}
 
 const now = new Date()
 export const experimentFullNewSchema = experimentFullSchema.shape({

--- a/package-lock.json
+++ b/package-lock.json
@@ -14578,6 +14578,11 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
       "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
     },
+    "normalizr": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/normalizr/-/normalizr-3.6.0.tgz",
+      "integrity": "sha512-25cd8DiDu+pL46KIaxtVVvvEPjGacJgv0yUg950evr62dQ/ks2JO1kf7+Vi5/rMFjaSTSTls7aCnmRlUSljtiA=="
+    },
     "notistack": {
       "version": "0.9.17",
       "resolved": "https://registry.npmjs.org/notistack/-/notistack-0.9.17.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lodash": "^4.17.19",
     "material-table": "^1.59.0",
     "next": "^9.3.5",
+    "normalizr": "^3.6.0",
     "notistack": "^0.9.17",
     "qc-to_bool": "^1.1.2",
     "qc-to_int": "^1.0.1",

--- a/pages/experiments/[id].tsx
+++ b/pages/experiments/[id].tsx
@@ -80,12 +80,7 @@ export default function ExperimentPage() {
         metrics &&
         segments && (
           <>
-            <ExperimentTabs
-              className={classes.tabs}
-              experiment={experiment}
-              normalizedExperiment={normalizedExperiment}
-              tab='details'
-            />
+            <ExperimentTabs className={classes.tabs} normalizedExperiment={normalizedExperiment} tab='details' />
             <ExperimentDetails
               experiment={experiment}
               normalizedExperiment={normalizedExperiment}

--- a/pages/experiments/[id].tsx
+++ b/pages/experiments/[id].tsx
@@ -2,6 +2,7 @@ import { LinearProgress } from '@material-ui/core'
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import debugFactory from 'debug'
 import { useRouter } from 'next/router'
+import { denormalize, normalize } from 'normalizr'
 import { toIntOrNull } from 'qc-to_int'
 import React from 'react'
 
@@ -11,7 +12,7 @@ import SegmentsApi from '@/api/SegmentsApi'
 import ExperimentDetails from '@/components/ExperimentDetails'
 import ExperimentTabs from '@/components/ExperimentTabs'
 import Layout from '@/components/Layout'
-import { ExperimentFull } from '@/lib/schemas'
+import { ExperimentFull, ExperimentFullNormalizedEntities, experimentFullNormalizrSchema } from '@/lib/schemas'
 import { useDataLoadingError, useDataSource } from '@/utils/data-loading'
 import { createUnresolvingPromise, or } from '@/utils/general'
 
@@ -31,11 +32,28 @@ export default function ExperimentPage() {
   const experimentId = toIntOrNull(router.query.id)
   debug(`ExperimentPage#render ${experimentId}`)
 
-  const { isLoading: experimentIsLoading, data: experiment, error: experimentError } = useDataSource(
-    () => (experimentId ? ExperimentsApi.findById(experimentId) : createUnresolvingPromise<ExperimentFull>()),
-    [experimentId],
-  )
+  const {
+    isLoading: experimentIsLoading,
+    data: normalizedExperimentData,
+    error: experimentError,
+  } = useDataSource(async () => {
+    if (!experimentId) {
+      return createUnresolvingPromise<null>()
+    }
+    const experiment = await ExperimentsApi.findById(experimentId)
+    const normalizedExperiment = normalize<ExperimentFull, ExperimentFullNormalizedEntities>(
+      experiment,
+      experimentFullNormalizrSchema,
+    )
+    return normalizedExperiment
+  }, [experimentId])
   useDataLoadingError(experimentError, 'Experiment')
+  const normalizedExperiment =
+    normalizedExperimentData && normalizedExperimentData.entities.experiments[normalizedExperimentData.result]
+  // Keeping this denormalized experiment here as temporary scafolding:
+  const experiment =
+    normalizedExperimentData &&
+    denormalize(normalizedExperimentData.result, experimentFullNormalizrSchema, normalizedExperimentData.entities)
 
   const { isLoading: metricsIsLoading, data: metrics, error: metricsError } = useDataSource(
     () => MetricsApi.findAll(),
@@ -56,12 +74,25 @@ export default function ExperimentPage() {
       {isLoading ? (
         <LinearProgress />
       ) : (
+        normalizedExperiment &&
+        normalizedExperimentData &&
         experiment &&
         metrics &&
         segments && (
           <>
-            <ExperimentTabs className={classes.tabs} experiment={experiment} tab='details' />
-            <ExperimentDetails experiment={experiment} metrics={metrics} segments={segments} />
+            <ExperimentTabs
+              className={classes.tabs}
+              experiment={experiment}
+              normalizedExperiment={normalizedExperiment}
+              tab='details'
+            />
+            <ExperimentDetails
+              experiment={experiment}
+              normalizedExperiment={normalizedExperiment}
+              normalizedExperimentData={normalizedExperimentData}
+              metrics={metrics}
+              segments={segments}
+            />
           </>
         )
       )}

--- a/pages/experiments/[id].tsx
+++ b/pages/experiments/[id].tsx
@@ -2,7 +2,7 @@ import { LinearProgress } from '@material-ui/core'
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import debugFactory from 'debug'
 import { useRouter } from 'next/router'
-import { denormalize, normalize } from 'normalizr'
+import { normalize } from 'normalizr'
 import { toIntOrNull } from 'qc-to_int'
 import React from 'react'
 
@@ -58,10 +58,6 @@ export default function ExperimentPage() {
   useDataLoadingError(experimentError, 'Experiment')
   const normalizedExperiment =
     normalizedExperimentData && normalizedExperimentData.entities.experiments[normalizedExperimentData.result]
-  // Keeping this denormalized experiment here as temporary scafolding:
-  const experiment =
-    normalizedExperimentData &&
-    denormalize(normalizedExperimentData.result, experimentFullNormalizrSchema, normalizedExperimentData.entities)
 
   const { isLoading: metricsIsLoading, data: indexedMetrics, error: metricsError } = useDataSource(async () => {
     const metrics = await MetricsApi.findAll()
@@ -84,19 +80,17 @@ export default function ExperimentPage() {
   const isLoading = or(experimentIsLoading, metricsIsLoading, segmentsIsLoading)
 
   return (
-    <Layout title={`Experiment: ${experiment?.name || ''}`}>
+    <Layout title={`Experiment: ${normalizedExperiment?.name || ''}`}>
       {isLoading ? (
         <LinearProgress />
       ) : (
         normalizedExperiment &&
         normalizedExperimentData &&
-        experiment &&
         indexedMetrics &&
         indexedSegments && (
           <>
             <ExperimentTabs className={classes.tabs} normalizedExperiment={normalizedExperiment} tab='details' />
             <ExperimentDetails
-              experiment={experiment}
               normalizedExperiment={normalizedExperiment}
               normalizedExperimentData={normalizedExperimentData}
               indexedMetrics={indexedMetrics}

--- a/pages/experiments/[id]/results.tsx
+++ b/pages/experiments/[id]/results.tsx
@@ -36,11 +36,11 @@ export default function ResultsPage() {
       return createUnresolvingPromise<null>()
     }
     const experiment = await ExperimentsApi.findById(experimentId)
-    const normalizedExperiment = normalize<ExperimentFull, ExperimentFullNormalizedEntities>(
+    const normalizedExperimentData = normalize<ExperimentFull, ExperimentFullNormalizedEntities>(
       experiment,
       experimentFullNormalizrSchema,
     )
-    return normalizedExperiment
+    return normalizedExperimentData
   }, [experimentId])
   useDataLoadingError(experimentError, 'Experiment')
   const normalizedExperiment =

--- a/pages/experiments/new.tsx
+++ b/pages/experiments/new.tsx
@@ -1,5 +1,6 @@
 import { LinearProgress } from '@material-ui/core'
 import debugFactory from 'debug'
+import { normalize } from 'normalizr'
 import React from 'react'
 
 import MetricsApi from '@/api/MetricsApi'
@@ -8,6 +9,7 @@ import DebugOutput from '@/components/DebugOutput'
 import ExperimentForm from '@/components/experiment-creation/ExperimentForm'
 import Layout from '@/components/Layout'
 import { createNewExperiment } from '@/lib/experiments'
+import { MetricBare, metricBareNormalizrSchema, Segment, segmentNormalizrSchema } from '@/lib/schemas'
 import { useDataLoadingError, useDataSource } from '@/utils/data-loading'
 import { or } from '@/utils/general'
 
@@ -17,16 +19,22 @@ const ExperimentsNewPage = function () {
   debug('ExperimentsNewPage#render')
   const initialExperiment = createNewExperiment()
 
-  const { isLoading: metricsIsLoading, data: metrics, error: metricsError } = useDataSource(
-    () => MetricsApi.findAll(),
-    [],
-  )
+  const { isLoading: metricsIsLoading, data: normalizedMetrics, error: metricsError } = useDataSource(async () => {
+    const metrics = await MetricsApi.findAll()
+    const {
+      entities: { metrics: normalizedMetrics },
+    } = normalize<MetricBare>(metrics, [metricBareNormalizrSchema])
+    return normalizedMetrics
+  }, [])
   useDataLoadingError(metricsError, 'Metrics')
 
-  const { isLoading: segmentsIsLoading, data: segments, error: segmentsError } = useDataSource(
-    () => SegmentsApi.findAll(),
-    [],
-  )
+  const { isLoading: segmentsIsLoading, data: normalizedSegments, error: segmentsError } = useDataSource(async () => {
+    const segments = await SegmentsApi.findAll()
+    const {
+      entities: { segments: normalizedSegments },
+    } = normalize<Segment>(segments, [segmentNormalizrSchema])
+    return normalizedSegments
+  }, [])
   useDataLoadingError(segmentsError, 'Segments')
 
   const isLoading = or(metricsIsLoading, segmentsIsLoading)
@@ -34,12 +42,16 @@ const ExperimentsNewPage = function () {
   return (
     <Layout title='Create an Experiment'>
       {isLoading && <LinearProgress />}
-      {!isLoading && metrics && segments && (
-        <ExperimentForm metrics={metrics} segments={segments} initialExperiment={initialExperiment} />
+      {!isLoading && normalizedMetrics && normalizedSegments && (
+        <ExperimentForm
+          normalizedMetrics={normalizedMetrics}
+          normalizedSegments={normalizedSegments}
+          initialExperiment={initialExperiment}
+        />
       )}
       <DebugOutput label='Initial Experiment' content={initialExperiment} />
-      <DebugOutput label='Metrics' content={metrics} />
-      <DebugOutput label='Segments' content={segments} />
+      <DebugOutput label='Metrics' content={normalizedMetrics} />
+      <DebugOutput label='Segments' content={normalizedSegments} />
     </Layout>
   )
 }

--- a/pages/experiments/new.tsx
+++ b/pages/experiments/new.tsx
@@ -19,21 +19,21 @@ const ExperimentsNewPage = function () {
   debug('ExperimentsNewPage#render')
   const initialExperiment = createNewExperiment()
 
-  const { isLoading: metricsIsLoading, data: normalizedMetrics, error: metricsError } = useDataSource(async () => {
+  const { isLoading: metricsIsLoading, data: indexedMetrics, error: metricsError } = useDataSource(async () => {
     const metrics = await MetricsApi.findAll()
     const {
-      entities: { metrics: normalizedMetrics },
+      entities: { metrics: indexedMetrics },
     } = normalize<MetricBare>(metrics, [metricBareNormalizrSchema])
-    return normalizedMetrics
+    return indexedMetrics
   }, [])
   useDataLoadingError(metricsError, 'Metrics')
 
-  const { isLoading: segmentsIsLoading, data: normalizedSegments, error: segmentsError } = useDataSource(async () => {
+  const { isLoading: segmentsIsLoading, data: indexedSegments, error: segmentsError } = useDataSource(async () => {
     const segments = await SegmentsApi.findAll()
     const {
-      entities: { segments: normalizedSegments },
+      entities: { segments: indexedSegments },
     } = normalize<Segment>(segments, [segmentNormalizrSchema])
-    return normalizedSegments
+    return indexedSegments
   }, [])
   useDataLoadingError(segmentsError, 'Segments')
 
@@ -42,16 +42,16 @@ const ExperimentsNewPage = function () {
   return (
     <Layout title='Create an Experiment'>
       {isLoading && <LinearProgress />}
-      {!isLoading && normalizedMetrics && normalizedSegments && (
+      {!isLoading && indexedMetrics && indexedSegments && (
         <ExperimentForm
-          normalizedMetrics={normalizedMetrics}
-          normalizedSegments={normalizedSegments}
+          indexedMetrics={indexedMetrics}
+          indexedSegments={indexedSegments}
           initialExperiment={initialExperiment}
         />
       )}
       <DebugOutput label='Initial Experiment' content={initialExperiment} />
-      <DebugOutput label='Metrics' content={normalizedMetrics} />
-      <DebugOutput label='Segments' content={normalizedSegments} />
+      <DebugOutput label='Metrics' content={indexedMetrics} />
+      <DebugOutput label='Segments' content={indexedSegments} />
     </Layout>
   )
 }

--- a/pages/experiments/new.tsx
+++ b/pages/experiments/new.tsx
@@ -23,7 +23,7 @@ const ExperimentsNewPage = function () {
     const metrics = await MetricsApi.findAll()
     const {
       entities: { metrics: indexedMetrics },
-    } = normalize<MetricBare>(metrics, [metricBareNormalizrSchema])
+    } = normalize<MetricBare, { metrics: Record<number, MetricBare> }>(metrics, [metricBareNormalizrSchema])
     return indexedMetrics
   }, [])
   useDataLoadingError(metricsError, 'Metrics')
@@ -32,7 +32,7 @@ const ExperimentsNewPage = function () {
     const segments = await SegmentsApi.findAll()
     const {
       entities: { segments: indexedSegments },
-    } = normalize<Segment>(segments, [segmentNormalizrSchema])
+    } = normalize<Segment, { segments: Record<number, Segment> }>(segments, [segmentNormalizrSchema])
     return indexedSegments
   }, [])
   useDataLoadingError(segmentsError, 'Segments')


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
_For an example of normalisation [see the `normalizr` docs](https://github.com/paularmstrong/normalizr#quick-start)_

**We use denormalised data up top and normalise below, this PR flips that around.**
- Uses [`normalizr`](https://github.com/paularmstrong/normalizr) a solid, minimal and reliable lib.
- Uses schemas to index the metrics/segments data for experiment creation.
   Not exactly necessary, we could be just using an `index<T>(data: T, id) -> Record<number, T>` function for simplicity but I like the centralisation.
- Populates the Segments in experiment creation
- Adds a normalizr schema and types for ExperimentFull
- Shows the data-loading and normalisation of experiment full

Not too much to go on this:
- Pass the normalised data down for experiments, replacing indexing code
- Clean up some of the code using denormalised data
- Remove the references to denormalised `experiment`
- Fix tests

Fixes #201

---

**Rationale:** 
- Some of our code is doing cartwheels to get normalised data, ends up being tied to specific parts when it is a global concern.
- Having data readily available in a normalised shape allows us to use normalised data without a second thought. 
   We have no consistent way of doing that currently.
- It is easier (and cheaper) to denormalise data than to normalise it, so normalised is better to start off with.
- If we do change to a global state management system (like Redux) we would likely be working with normalised data.


**Design decisions:**
- Normalize as needed using an opt-in approach, *but* use standard normalisation shapes (`normalizr` schema and normalized types). 
- If entities come from a normalisation we keep those together when passing them around.
   - It is a snapshot of a single entity, we don't want to pollute it (merge with other data) or lose any parts (split it).
- Be explicit about whether the data is normalized.

**This PR introduces some new naming conventions:**
   - `indexedX` - for indexed data, eg. `indexedMetrics`
   - `normalizedX` - for a single normalized entity without children, eg. `normalizedExperiment`
   - `normalizedXData` - for a complete normalized entity 
   - See also the typescript name conventions, may change those yet to be more consistent with the above
 
 

<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

- It hasn't yet.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->
<!--
- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
- Manual testing with mock data (locally or on Vercel)
- Additional manual testing instructions (please specify):
-->