### PR TITLE
Experiment Creation Form: Polish the insides

### DIFF
--- a/components/experiment-creation/Audience.tsx
+++ b/components/experiment-creation/Audience.tsx
@@ -140,7 +140,7 @@ const Audience = ({ formikProps }: { formikProps: FormikProps<{ experiment: Part
   return (
     <div className={classes.root}>
       <Typography variant='h4' gutterBottom>
-        Who Is Your Audience
+        Define Your Audience
       </Typography>
 
       <div className={classes.row}>

--- a/components/experiment-creation/Audience.tsx
+++ b/components/experiment-creation/Audience.tsx
@@ -32,9 +32,12 @@ const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {},
     row: {
-      margin: theme.spacing(6, 0),
+      margin: theme.spacing(5, 0),
       display: 'flex',
       alignItems: 'center',
+      '&:first-of-type': {
+        marginTop: theme.spacing(2),
+      },
     },
     segmentationHelperText: {},
     segmentationFieldSet: {

--- a/components/experiment-creation/Audience.tsx
+++ b/components/experiment-creation/Audience.tsx
@@ -140,7 +140,7 @@ const Audience = ({ formikProps }: { formikProps: FormikProps<{ experiment: Part
   return (
     <div className={classes.root}>
       <Typography variant='h4' gutterBottom>
-        Who is your Audience
+        Who Is Your Audience
       </Typography>
 
       <div className={classes.row}>

--- a/components/experiment-creation/Audience.tsx
+++ b/components/experiment-creation/Audience.tsx
@@ -48,6 +48,9 @@ const useStyles = makeStyles((theme: Theme) =>
     variationAllocatedPercentage: {
       width: '7rem',
     },
+    variants: {
+      width: 'auto',
+    },
   }),
 )
 
@@ -219,7 +222,7 @@ const Audience = ({ formikProps }: { formikProps: FormikProps<{ experiment: Part
             (fallback) experience.
           </FormHelperText>
           <TableContainer>
-            <Table>
+            <Table className={classes.variants}>
               <TableHead>
                 <TableRow>
                   <TableCell> Name </TableCell>

--- a/components/experiment-creation/Audience.tsx
+++ b/components/experiment-creation/Audience.tsx
@@ -36,7 +36,7 @@ const useStyles = makeStyles((theme: Theme) =>
       display: 'flex',
       alignItems: 'center',
       '&:first-of-type': {
-        marginTop: theme.spacing(2),
+        marginTop: theme.spacing(3),
       },
     },
     segmentationHelperText: {},
@@ -139,8 +139,8 @@ const Audience = ({ formikProps }: { formikProps: FormikProps<{ experiment: Part
 
   return (
     <div className={classes.root}>
-      <Typography variant='h2' gutterBottom>
-        Audience
+      <Typography variant='h4' gutterBottom>
+        Who is your Audience
       </Typography>
 
       <div className={classes.row}>

--- a/components/experiment-creation/BasicInfo.tsx
+++ b/components/experiment-creation/BasicInfo.tsx
@@ -14,9 +14,12 @@ const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {},
     row: {
-      margin: theme.spacing(6, 0),
+      margin: theme.spacing(5, 0),
       display: 'flex',
       alignItems: 'center',
+      '&:first-of-type': {
+        marginTop: theme.spacing(3),
+      },
     },
     through: {
       flex: 0,

--- a/components/experiment-creation/BasicInfo.tsx
+++ b/components/experiment-creation/BasicInfo.tsx
@@ -51,8 +51,8 @@ const BasicInfo = () => {
 
   return (
     <div className={classes.root}>
-      <Typography variant='h2' gutterBottom>
-        Basic Info
+      <Typography variant='h4' gutterBottom>
+        Tell us the Basics
       </Typography>
 
       <div className={classes.row}>

--- a/components/experiment-creation/BasicInfo.tsx
+++ b/components/experiment-creation/BasicInfo.tsx
@@ -52,7 +52,7 @@ const BasicInfo = () => {
   return (
     <div className={classes.root}>
       <Typography variant='h4' gutterBottom>
-        Tell Us the Basics
+        Basic Info
       </Typography>
 
       <div className={classes.row}>

--- a/components/experiment-creation/BasicInfo.tsx
+++ b/components/experiment-creation/BasicInfo.tsx
@@ -52,7 +52,7 @@ const BasicInfo = () => {
   return (
     <div className={classes.root}>
       <Typography variant='h4' gutterBottom>
-        Tell us the Basics
+        Tell Us the Basics
       </Typography>
 
       <div className={classes.row}>

--- a/components/experiment-creation/Beginning.test.tsx
+++ b/components/experiment-creation/Beginning.test.tsx
@@ -25,7 +25,7 @@ test('renders as expected', () => {
         <p
           class="MuiTypography-root MuiTypography-body2"
         >
-          Without a well documented design, an experiment could be invalid and unsafe for making important decisions.
+          We think one of the best ways to prevent a failed experiment is by documenting what you hope to learn.
           <br />
           <br />
           <strong>

--- a/components/experiment-creation/Beginning.test.tsx
+++ b/components/experiment-creation/Beginning.test.tsx
@@ -17,53 +17,53 @@ test('renders as expected', () => {
       <div
         class="makeStyles-root-1"
       >
-        <p
-          class="MuiTypography-root MuiTypography-body1"
+        <h4
+          class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
         >
-          We think one of the best ways to prevent a failed experiment is by documenting what you hope to learn.
+          Design and Document Your Experiment
+        </h4>
+        <p
+          class="MuiTypography-root MuiTypography-body2"
+        >
+          Without a well documented design, an experiment could be invalid and unsafe for making important decisions.
+          <br />
+          <br />
+          <strong>
+            Start by looking up our Field Guide, it will instruct you on creating a P2 post.
+          </strong>
         </p>
         <div
-          class="makeStyles-p2Entry-3"
+          class="MuiFormControl-root MuiTextField-root makeStyles-p2EntryField-2"
         >
-          <h6
-            class="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom"
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
+            data-shrink="true"
           >
-            P2 Link
-          </h6>
-          <p
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom"
-          >
-            Once you've designed and documented your experiment, enter the P2 post URL:
-          </p>
+            Your Post's URL
+          </label>
           <div
-            class="MuiFormControl-root MuiTextField-root makeStyles-p2EntryField-4"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
           >
-            <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiOutlinedInput-input"
+              name="experiment.p2Url"
+              placeholder="https://your-p2-post-here"
+              type="text"
+              value=""
+            />
+            <fieldset
+              aria-hidden="true"
+              class="PrivateNotchedOutline-root-4 MuiOutlinedInput-notchedOutline"
             >
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input"
-                name="experiment.p2Url"
-                placeholder="https://your-p2-post-here"
-                type="text"
-                value=""
-              />
-              <fieldset
-                aria-hidden="true"
-                class="PrivateNotchedOutline-root-6 MuiOutlinedInput-notchedOutline"
-                style="padding-left: 8px;"
+              <legend
+                class="PrivateNotchedOutline-legendLabelled-6 PrivateNotchedOutline-legendNotched-7"
               >
-                <legend
-                  class="PrivateNotchedOutline-legend-7"
-                  style="width: 0.01px;"
-                >
-                  <span>
-                    ​
-                  </span>
-                </legend>
-              </fieldset>
-            </div>
+                <span>
+                  Your Post's URL
+                </span>
+              </legend>
+            </fieldset>
           </div>
         </div>
       </div>

--- a/components/experiment-creation/Beginning.tsx
+++ b/components/experiment-creation/Beginning.tsx
@@ -7,14 +7,8 @@ import React from 'react'
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {},
-    p2LinkLine: {
-      margin: theme.spacing(6, 0),
-    },
-    p2Entry: {
-      margin: theme.spacing(6, 0),
-    },
     p2EntryField: {
-      marginTop: theme.spacing(1),
+      marginTop: theme.spacing(2),
       width: '100%',
       background: '#fff',
     },

--- a/components/experiment-creation/Beginning.tsx
+++ b/components/experiment-creation/Beginning.tsx
@@ -30,24 +30,22 @@ const Beginning = () => {
 
   return (
     <div className={classes.root}>
-      <Typography variant='body1'>
-        We think one of the best ways to prevent a failed experiment is by documenting what you hope to learn.
+      <Typography variant='h5' gutterBottom>
+        <strong>Start by designing and documenting your experiment.</strong>
       </Typography>
-      <div className={classes.p2Entry}>
-        <Typography variant='h6' gutterBottom>
-          P2 Link
-        </Typography>
-        <Typography variant='body1' gutterBottom>
-          Once you&apos;ve designed and documented your experiment, enter the P2 post URL:
-        </Typography>
-        <Field
-          className={classes.p2EntryField}
-          component={TextField}
-          name='experiment.p2Url'
-          placeholder='https://your-p2-post-here'
-          variant='outlined'
-        />
-      </div>
+      <Typography variant='body2' gutterBottom>
+        Without a well documented design, an experiment could be invalid and unsafe for making important decisions.
+        <br />
+        <br />
+        Get help from our Field Guide and enter your P2 Post&apos;s URL when you are ready:
+      </Typography>
+      <Field
+        className={classes.p2EntryField}
+        component={TextField}
+        name='experiment.p2Url'
+        placeholder='https://your-p2-post-here'
+        variant='outlined'
+      />
     </div>
   )
 }

--- a/components/experiment-creation/Beginning.tsx
+++ b/components/experiment-creation/Beginning.tsx
@@ -8,7 +8,7 @@ const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {},
     p2EntryField: {
-      marginTop: theme.spacing(2),
+      marginTop: theme.spacing(4),
       width: '100%',
       background: '#fff',
     },
@@ -24,21 +24,25 @@ const Beginning = () => {
 
   return (
     <div className={classes.root}>
-      <Typography variant='h5' gutterBottom>
-        <strong>Start by designing and documenting your experiment.</strong>
+      <Typography variant='h4' gutterBottom>
+        Design and Document Your Experiment
       </Typography>
-      <Typography variant='body2' gutterBottom>
+      <Typography variant='body2'>
         Without a well documented design, an experiment could be invalid and unsafe for making important decisions.
         <br />
         <br />
-        Get help from our Field Guide and enter your P2 Post&apos;s URL when you are ready:
+        <strong>Start by looking up our Field Guide, it will instruct you on creating a P2 post.</strong>
       </Typography>
       <Field
         className={classes.p2EntryField}
         component={TextField}
         name='experiment.p2Url'
         placeholder='https://your-p2-post-here'
+        label={`Your Post's URL`}
         variant='outlined'
+        InputLabelProps={{
+          shrink: true,
+        }}
       />
     </div>
   )

--- a/components/experiment-creation/Beginning.tsx
+++ b/components/experiment-creation/Beginning.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@material-ui/core'
+import { Link, Typography } from '@material-ui/core'
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import { Field } from 'formik'
 import { TextField } from 'formik-material-ui'
@@ -31,7 +31,10 @@ const Beginning = () => {
         We think one of the best ways to prevent a failed experiment is by documenting what you hope to learn.
         <br />
         <br />
-        <strong>Start by looking up our Field Guide, it will instruct you on creating a P2 post.</strong>
+        <strong>
+          <Link href='https://github.com/Automattic/abacus/wiki'>Our wiki is a great place to start</Link>, it will
+          instruct you on creating a P2 post.
+        </strong>
       </Typography>
       <Field
         className={classes.p2EntryField}

--- a/components/experiment-creation/Beginning.tsx
+++ b/components/experiment-creation/Beginning.tsx
@@ -28,7 +28,7 @@ const Beginning = () => {
         Design and Document Your Experiment
       </Typography>
       <Typography variant='body2'>
-        Without a well documented design, an experiment could be invalid and unsafe for making important decisions.
+        We think one of the best ways to prevent a failed experiment is by documenting what you hope to learn.
         <br />
         <br />
         <strong>Start by looking up our Field Guide, it will instruct you on creating a P2 post.</strong>

--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -7,7 +7,8 @@ import { Formik } from 'formik'
 import React, { useRef, useState } from 'react'
 import * as yup from 'yup'
 
-import { ExperimentFullNew, experimentFullNewSchema, MetricBare, Segment } from '@/lib/schemas'
+import ExperimentStatus from '@/components/ExperimentStatus'
+import { ExperimentFullNew, experimentFullNewSchema, MetricBare, Segment, Status } from '@/lib/schemas'
 
 import Audience from './Audience'
 import BasicInfo from './BasicInfo'
@@ -224,6 +225,11 @@ const ExperimentForm = ({
                   <Typography variant='body2' gutterBottom>
                     Now is a good time to look over the Field Guide&apos;s experiment creation checklist and confirm
                     everything is in place.
+                  </Typography>
+
+                  <Typography variant='body2' gutterBottom>
+                    Once you submit your experiment it will be set to staging, where it can be edited up until you set
+                    it to running.
                   </Typography>
                   <Typography variant='body2' gutterBottom>
                     <strong> When you are ready, click the Submit button below.</strong>

--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -80,7 +80,7 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     // TODO: Subject to change when we get to polishing overall form UX
     paper: {
-      padding: theme.spacing(2, 6),
+      padding: theme.spacing(3, 4),
       marginBottom: theme.spacing(2),
     },
   }),
@@ -171,7 +171,9 @@ const ExperimentForm = ({
           {(formikProps) => (
             <form onSubmit={formikProps.handleSubmit}>
               <div className={classes.formPart} ref={formPartBeginningRef}>
-                <Beginning />
+                <Paper className={classes.paper}>
+                  <Beginning />
+                </Paper>
                 <div className={classes.formPartActions}>
                   <Button onClick={nextStage} variant='contained' color='primary'>
                     Begin

--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -215,21 +215,19 @@ const ExperimentForm = ({
               </div>
               <div className={classes.formPart} ref={formPartSubmitRef}>
                 <Paper className={classes.paper}>
-                  <Typography variant='body1' gutterBottom>
-                    This last form-part gives the users a chance to pause and consider.
-                    <br />
-                    <br />
-                    It is good to have a mini-checklist here.
-                    <br />
-                    <br />
-                    Maybe a pre-submission summary.
-                    <br />
-                    <br />
-                    It is also good for the users to know the consequences of submitting so they aren&apos;t afraid of
-                    pressing the button.
+                  <Typography variant='h4' gutterBottom>
+                    Confirm and Submit Your Experiment
+                  </Typography>
+                  <Typography variant='body2' gutterBottom>
+                    Now is a good time to look over the Field Guide&apos;s experiment creation checklist and confirm
+                    everything is in place.
+                  </Typography>
+                  <Typography variant='body2' gutterBottom>
+                    <strong> When you are ready, click the Submit button below.</strong>
                   </Typography>
                 </Paper>
                 <div className={classes.formPartActions}>
+                  <Button onClick={prevStage}>Previous</Button>
                   <Button type='submit' variant='contained' color='secondary'>
                     Submit
                   </Button>

--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -1,7 +1,7 @@
 // Temporarily ignore until more parts are in place
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* istanbul ignore file */
-import { Button, Paper, Step, StepButton, Stepper, Typography } from '@material-ui/core'
+import { Button, Link, Paper, Step, StepButton, Stepper, Typography } from '@material-ui/core'
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import { Formik } from 'formik'
 import React, { useRef, useState } from 'react'
@@ -223,8 +223,11 @@ const ExperimentForm = ({
                     Confirm and Submit Your Experiment
                   </Typography>
                   <Typography variant='body2' gutterBottom>
-                    Now is a good time to look over the Field Guide&apos;s experiment creation checklist and confirm
-                    everything is in place.
+                    Now is a good time to{' '}
+                    <Link href='https://github.com/Automattic/abacus/wiki'>
+                      check our wiki&apos;s experiment creation checklist
+                    </Link>{' '}
+                    and confirm everything is in place.
                   </Typography>
 
                   <Typography variant='body2' gutterBottom>

--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -204,6 +204,9 @@ const ExperimentForm = ({
               </div>
               <div className={classes.formPart} ref={formPartMetricsRef}>
                 <Paper className={classes.paper}>
+                  <Typography variant='h4' gutterBottom>
+                    What Are You Measuring
+                  </Typography>
                   <Typography variant='body1'>Metrics Form Part</Typography>
                 </Paper>
                 <div className={classes.formPartActions}>

--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -205,7 +205,7 @@ const ExperimentForm = ({
               <div className={classes.formPart} ref={formPartMetricsRef}>
                 <Paper className={classes.paper}>
                   <Typography variant='h4' gutterBottom>
-                    What Are You Measuring
+                    Assign Metrics
                   </Typography>
                   <Typography variant='body1'>Metrics Form Part</Typography>
                 </Paper>

--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -69,6 +69,7 @@ const useStyles = makeStyles((theme: Theme) =>
     formPart: {
       height: '100%',
       overflow: 'auto',
+      maxWidth: 600,
     },
     formPartActions: {
       display: 'flex',

--- a/components/experiment-creation/__snapshots__/Audience.test.tsx.snap
+++ b/components/experiment-creation/__snapshots__/Audience.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`renders as expected 1`] = `
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
     >
-      Who Is Your Audience
+      Define Your Audience
     </h4>
     <div
       class="makeStyles-row-2"
@@ -590,7 +590,7 @@ exports[`renders as expected 2`] = `
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
     >
-      Who Is Your Audience
+      Define Your Audience
     </h4>
     <div
       class="makeStyles-row-2"

--- a/components/experiment-creation/__snapshots__/Audience.test.tsx.snap
+++ b/components/experiment-creation/__snapshots__/Audience.test.tsx.snap
@@ -5,11 +5,11 @@ exports[`renders as expected 1`] = `
   <div
     class="makeStyles-root-1"
   >
-    <h2
-      class="MuiTypography-root MuiTypography-h2 MuiTypography-gutterBottom"
+    <h4
+      class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
     >
-      Audience
-    </h2>
+      Who Is Your Audience
+    </h4>
     <div
       class="makeStyles-row-2"
     >
@@ -92,19 +92,19 @@ exports[`renders as expected 1`] = `
           >
             <span
               aria-disabled="false"
-              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-7 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
+              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-8 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
             >
               <span
                 class="MuiIconButton-label"
               >
                 <input
-                  class="PrivateSwitchBase-input-10"
+                  class="PrivateSwitchBase-input-11"
                   name="experiment.existingUsersAllowed"
                   type="radio"
                   value="false"
                 />
                 <div
-                  class="PrivateRadioButtonIcon-root-11"
+                  class="PrivateRadioButtonIcon-root-12"
                 >
                   <svg
                     aria-hidden="true"
@@ -118,7 +118,7 @@ exports[`renders as expected 1`] = `
                   </svg>
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-12"
+                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-13"
                     focusable="false"
                     viewBox="0 0 24 24"
                   >
@@ -143,19 +143,19 @@ exports[`renders as expected 1`] = `
           >
             <span
               aria-disabled="false"
-              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-7 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
+              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-8 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
             >
               <span
                 class="MuiIconButton-label"
               >
                 <input
-                  class="PrivateSwitchBase-input-10"
+                  class="PrivateSwitchBase-input-11"
                   name="experiment.existingUsersAllowed"
                   type="radio"
                   value="true"
                 />
                 <div
-                  class="PrivateRadioButtonIcon-root-11"
+                  class="PrivateRadioButtonIcon-root-12"
                 >
                   <svg
                     aria-hidden="true"
@@ -169,7 +169,7 @@ exports[`renders as expected 1`] = `
                   </svg>
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-12"
+                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-13"
                     focusable="false"
                     viewBox="0 0 24 24"
                   >
@@ -221,20 +221,20 @@ exports[`renders as expected 1`] = `
           >
             <span
               aria-disabled="false"
-              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-7 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-8 Mui-checked MuiIconButton-colorSecondary"
+              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-8 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-9 Mui-checked MuiIconButton-colorSecondary"
             >
               <span
                 class="MuiIconButton-label"
               >
                 <input
                   checked=""
-                  class="PrivateSwitchBase-input-10"
+                  class="PrivateSwitchBase-input-11"
                   name="non-formik-segment-exclusion-state-include"
                   type="radio"
                   value="include"
                 />
                 <div
-                  class="PrivateRadioButtonIcon-root-11 PrivateRadioButtonIcon-checked-13"
+                  class="PrivateRadioButtonIcon-root-12 PrivateRadioButtonIcon-checked-14"
                 >
                   <svg
                     aria-hidden="true"
@@ -248,7 +248,7 @@ exports[`renders as expected 1`] = `
                   </svg>
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-12"
+                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-13"
                     focusable="false"
                     viewBox="0 0 24 24"
                   >
@@ -273,19 +273,19 @@ exports[`renders as expected 1`] = `
           >
             <span
               aria-disabled="false"
-              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-7 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
+              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-8 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
             >
               <span
                 class="MuiIconButton-label"
               >
                 <input
-                  class="PrivateSwitchBase-input-10"
+                  class="PrivateSwitchBase-input-11"
                   name="non-formik-segment-exclusion-state-exclude"
                   type="radio"
                   value="exclude"
                 />
                 <div
-                  class="PrivateRadioButtonIcon-root-11"
+                  class="PrivateRadioButtonIcon-root-12"
                 >
                   <svg
                     aria-hidden="true"
@@ -299,7 +299,7 @@ exports[`renders as expected 1`] = `
                   </svg>
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-12"
+                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-13"
                     focusable="false"
                     viewBox="0 0 24 24"
                   >
@@ -400,11 +400,11 @@ exports[`renders as expected 1`] = `
               </div>
               <fieldset
                 aria-hidden="true"
-                class="PrivateNotchedOutline-root-14 MuiOutlinedInput-notchedOutline"
+                class="PrivateNotchedOutline-root-15 MuiOutlinedInput-notchedOutline"
                 style="padding-left: 8px;"
               >
                 <legend
-                  class="PrivateNotchedOutline-legend-15"
+                  class="PrivateNotchedOutline-legend-16"
                   style="width: 0.01px;"
                 >
                   <span>
@@ -440,7 +440,7 @@ exports[`renders as expected 1`] = `
           class="MuiTableContainer-root"
         >
           <table
-            class="MuiTable-root"
+            class="MuiTable-root makeStyles-variants-7"
           >
             <thead
               class="MuiTableHead-root"
@@ -503,11 +503,11 @@ exports[`renders as expected 1`] = `
                       </div>
                       <fieldset
                         aria-hidden="true"
-                        class="PrivateNotchedOutline-root-14 MuiOutlinedInput-notchedOutline"
+                        class="PrivateNotchedOutline-root-15 MuiOutlinedInput-notchedOutline"
                         style="padding-left: 8px;"
                       >
                         <legend
-                          class="PrivateNotchedOutline-legend-15"
+                          class="PrivateNotchedOutline-legend-16"
                           style="width: 0.01px;"
                         >
                           <span>
@@ -557,11 +557,11 @@ exports[`renders as expected 1`] = `
                       </div>
                       <fieldset
                         aria-hidden="true"
-                        class="PrivateNotchedOutline-root-14 MuiOutlinedInput-notchedOutline"
+                        class="PrivateNotchedOutline-root-15 MuiOutlinedInput-notchedOutline"
                         style="padding-left: 8px;"
                       >
                         <legend
-                          class="PrivateNotchedOutline-legend-15"
+                          class="PrivateNotchedOutline-legend-16"
                           style="width: 0.01px;"
                         >
                           <span>
@@ -587,11 +587,11 @@ exports[`renders as expected 2`] = `
   <div
     class="makeStyles-root-1"
   >
-    <h2
-      class="MuiTypography-root MuiTypography-h2 MuiTypography-gutterBottom"
+    <h4
+      class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
     >
-      Audience
-    </h2>
+      Who Is Your Audience
+    </h4>
     <div
       class="makeStyles-row-2"
     >
@@ -674,19 +674,19 @@ exports[`renders as expected 2`] = `
           >
             <span
               aria-disabled="false"
-              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-7 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
+              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-8 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
             >
               <span
                 class="MuiIconButton-label"
               >
                 <input
-                  class="PrivateSwitchBase-input-10"
+                  class="PrivateSwitchBase-input-11"
                   name="experiment.existingUsersAllowed"
                   type="radio"
                   value="false"
                 />
                 <div
-                  class="PrivateRadioButtonIcon-root-11"
+                  class="PrivateRadioButtonIcon-root-12"
                 >
                   <svg
                     aria-hidden="true"
@@ -700,7 +700,7 @@ exports[`renders as expected 2`] = `
                   </svg>
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-12"
+                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-13"
                     focusable="false"
                     viewBox="0 0 24 24"
                   >
@@ -725,19 +725,19 @@ exports[`renders as expected 2`] = `
           >
             <span
               aria-disabled="false"
-              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-7 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
+              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-8 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
             >
               <span
                 class="MuiIconButton-label"
               >
                 <input
-                  class="PrivateSwitchBase-input-10"
+                  class="PrivateSwitchBase-input-11"
                   name="experiment.existingUsersAllowed"
                   type="radio"
                   value="true"
                 />
                 <div
-                  class="PrivateRadioButtonIcon-root-11"
+                  class="PrivateRadioButtonIcon-root-12"
                 >
                   <svg
                     aria-hidden="true"
@@ -751,7 +751,7 @@ exports[`renders as expected 2`] = `
                   </svg>
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-12"
+                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-13"
                     focusable="false"
                     viewBox="0 0 24 24"
                   >
@@ -803,20 +803,20 @@ exports[`renders as expected 2`] = `
           >
             <span
               aria-disabled="false"
-              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-7 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
+              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-8 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
             >
               <span
                 class="MuiIconButton-label"
               >
                 <input
                   checked=""
-                  class="PrivateSwitchBase-input-10"
+                  class="PrivateSwitchBase-input-11"
                   name="non-formik-segment-exclusion-state-include"
                   type="radio"
                   value="include"
                 />
                 <div
-                  class="PrivateRadioButtonIcon-root-11"
+                  class="PrivateRadioButtonIcon-root-12"
                 >
                   <svg
                     aria-hidden="true"
@@ -830,7 +830,7 @@ exports[`renders as expected 2`] = `
                   </svg>
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-12"
+                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-13"
                     focusable="false"
                     viewBox="0 0 24 24"
                   >
@@ -855,19 +855,19 @@ exports[`renders as expected 2`] = `
           >
             <span
               aria-disabled="false"
-              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-7 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-8 Mui-checked MuiIconButton-colorSecondary"
+              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-8 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-9 Mui-checked MuiIconButton-colorSecondary"
             >
               <span
                 class="MuiIconButton-label"
               >
                 <input
-                  class="PrivateSwitchBase-input-10"
+                  class="PrivateSwitchBase-input-11"
                   name="non-formik-segment-exclusion-state-exclude"
                   type="radio"
                   value="exclude"
                 />
                 <div
-                  class="PrivateRadioButtonIcon-root-11 PrivateRadioButtonIcon-checked-13"
+                  class="PrivateRadioButtonIcon-root-12 PrivateRadioButtonIcon-checked-14"
                 >
                   <svg
                     aria-hidden="true"
@@ -881,7 +881,7 @@ exports[`renders as expected 2`] = `
                   </svg>
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-12"
+                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-13"
                     focusable="false"
                     viewBox="0 0 24 24"
                   >
@@ -1004,11 +1004,11 @@ exports[`renders as expected 2`] = `
               </div>
               <fieldset
                 aria-hidden="true"
-                class="PrivateNotchedOutline-root-14 MuiOutlinedInput-notchedOutline"
+                class="PrivateNotchedOutline-root-15 MuiOutlinedInput-notchedOutline"
                 style="padding-left: 8px;"
               >
                 <legend
-                  class="PrivateNotchedOutline-legend-15"
+                  class="PrivateNotchedOutline-legend-16"
                   style="width: 0.01px;"
                 >
                   <span>
@@ -1044,7 +1044,7 @@ exports[`renders as expected 2`] = `
           class="MuiTableContainer-root"
         >
           <table
-            class="MuiTable-root"
+            class="MuiTable-root makeStyles-variants-7"
           >
             <thead
               class="MuiTableHead-root"
@@ -1107,11 +1107,11 @@ exports[`renders as expected 2`] = `
                       </div>
                       <fieldset
                         aria-hidden="true"
-                        class="PrivateNotchedOutline-root-14 MuiOutlinedInput-notchedOutline"
+                        class="PrivateNotchedOutline-root-15 MuiOutlinedInput-notchedOutline"
                         style="padding-left: 8px;"
                       >
                         <legend
-                          class="PrivateNotchedOutline-legend-15"
+                          class="PrivateNotchedOutline-legend-16"
                           style="width: 0.01px;"
                         >
                           <span>
@@ -1161,11 +1161,11 @@ exports[`renders as expected 2`] = `
                       </div>
                       <fieldset
                         aria-hidden="true"
-                        class="PrivateNotchedOutline-root-14 MuiOutlinedInput-notchedOutline"
+                        class="PrivateNotchedOutline-root-15 MuiOutlinedInput-notchedOutline"
                         style="padding-left: 8px;"
                       >
                         <legend
-                          class="PrivateNotchedOutline-legend-15"
+                          class="PrivateNotchedOutline-legend-16"
                           style="width: 0.01px;"
                         >
                           <span>

--- a/components/experiment-creation/__snapshots__/BasicInfo.test.tsx.snap
+++ b/components/experiment-creation/__snapshots__/BasicInfo.test.tsx.snap
@@ -5,11 +5,11 @@ exports[`renders as expected 1`] = `
   <div
     class="makeStyles-root-1"
   >
-    <h2
-      class="MuiTypography-root MuiTypography-h2 MuiTypography-gutterBottom"
+    <h4
+      class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
     >
-      Basic Info
-    </h2>
+      Tell Us the Basics
+    </h4>
     <div
       class="makeStyles-row-2"
     >
@@ -298,11 +298,11 @@ exports[`renders date validation errors as expected 1`] = `
   <div
     class="makeStyles-root-17"
   >
-    <h2
-      class="MuiTypography-root MuiTypography-h2 MuiTypography-gutterBottom"
+    <h4
+      class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
     >
-      Basic Info
-    </h2>
+      Tell Us the Basics
+    </h4>
     <div
       class="makeStyles-row-18"
     >
@@ -593,11 +593,11 @@ exports[`renders date validation errors as expected 2`] = `
   <div
     class="makeStyles-root-17"
   >
-    <h2
-      class="MuiTypography-root MuiTypography-h2 MuiTypography-gutterBottom"
+    <h4
+      class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
     >
-      Basic Info
-    </h2>
+      Tell Us the Basics
+    </h4>
     <div
       class="makeStyles-row-18"
     >
@@ -888,11 +888,11 @@ exports[`renders date validation errors as expected 3`] = `
   <div
     class="makeStyles-root-17"
   >
-    <h2
-      class="MuiTypography-root MuiTypography-h2 MuiTypography-gutterBottom"
+    <h4
+      class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
     >
-      Basic Info
-    </h2>
+      Tell Us the Basics
+    </h4>
     <div
       class="makeStyles-row-18"
     >
@@ -1183,11 +1183,11 @@ exports[`renders date validation errors as expected 4`] = `
   <div
     class="makeStyles-root-17"
   >
-    <h2
-      class="MuiTypography-root MuiTypography-h2 MuiTypography-gutterBottom"
+    <h4
+      class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
     >
-      Basic Info
-    </h2>
+      Tell Us the Basics
+    </h4>
     <div
       class="makeStyles-row-18"
     >
@@ -1478,11 +1478,11 @@ exports[`renders sensible dates as expected 1`] = `
   <div
     class="makeStyles-root-9"
   >
-    <h2
-      class="MuiTypography-root MuiTypography-h2 MuiTypography-gutterBottom"
+    <h4
+      class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
     >
-      Basic Info
-    </h2>
+      Tell Us the Basics
+    </h4>
     <div
       class="makeStyles-row-10"
     >

--- a/components/experiment-creation/__snapshots__/BasicInfo.test.tsx.snap
+++ b/components/experiment-creation/__snapshots__/BasicInfo.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`renders as expected 1`] = `
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
     >
-      Tell Us the Basics
+      Basic Info
     </h4>
     <div
       class="makeStyles-row-2"
@@ -301,7 +301,7 @@ exports[`renders date validation errors as expected 1`] = `
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
     >
-      Tell Us the Basics
+      Basic Info
     </h4>
     <div
       class="makeStyles-row-18"
@@ -596,7 +596,7 @@ exports[`renders date validation errors as expected 2`] = `
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
     >
-      Tell Us the Basics
+      Basic Info
     </h4>
     <div
       class="makeStyles-row-18"
@@ -891,7 +891,7 @@ exports[`renders date validation errors as expected 3`] = `
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
     >
-      Tell Us the Basics
+      Basic Info
     </h4>
     <div
       class="makeStyles-row-18"
@@ -1186,7 +1186,7 @@ exports[`renders date validation errors as expected 4`] = `
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
     >
-      Tell Us the Basics
+      Basic Info
     </h4>
     <div
       class="makeStyles-row-18"
@@ -1481,7 +1481,7 @@ exports[`renders sensible dates as expected 1`] = `
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
     >
-      Tell Us the Basics
+      Basic Info
     </h4>
     <div
       class="makeStyles-row-10"

--- a/components/experiment-creation/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/components/experiment-creation/__snapshots__/ExperimentForm.test.tsx.snap
@@ -299,29 +299,35 @@ exports[`renders as expected 1`] = `
           class="makeStyles-formPart-4"
         >
           <div
-            class="makeStyles-root-7"
+            class="MuiPaper-root makeStyles-paper-6 MuiPaper-elevation1 MuiPaper-rounded"
           >
-            <p
-              class="MuiTypography-root MuiTypography-body1"
-            >
-              We think one of the best ways to prevent a failed experiment is by documenting what you hope to learn.
-            </p>
             <div
-              class="makeStyles-p2Entry-9"
+              class="makeStyles-root-7"
             >
-              <h6
-                class="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom"
+              <h4
+                class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
               >
-                P2 Link
-              </h6>
+                Design and Document Your Experiment
+              </h4>
               <p
-                class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom"
+                class="MuiTypography-root MuiTypography-body2"
               >
-                Once you've designed and documented your experiment, enter the P2 post URL:
+                Without a well documented design, an experiment could be invalid and unsafe for making important decisions.
+                <br />
+                <br />
+                <strong>
+                  Start by looking up our Field Guide, it will instruct you on creating a P2 post.
+                </strong>
               </p>
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-p2EntryField-10"
+                class="MuiFormControl-root MuiTextField-root makeStyles-p2EntryField-8"
               >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
+                  data-shrink="true"
+                >
+                  Your Post's URL
+                </label>
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
                 >
@@ -335,15 +341,13 @@ exports[`renders as expected 1`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-12 MuiOutlinedInput-notchedOutline"
-                    style="padding-left: 8px;"
+                    class="PrivateNotchedOutline-root-10 MuiOutlinedInput-notchedOutline"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-13"
-                      style="width: 0.01px;"
+                      class="PrivateNotchedOutline-legendLabelled-12 PrivateNotchedOutline-legendNotched-13"
                     >
                       <span>
-                        ​
+                        Your Post's URL
                       </span>
                     </legend>
                   </fieldset>
@@ -377,15 +381,15 @@ exports[`renders as expected 1`] = `
             class="MuiPaper-root makeStyles-paper-6 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-16"
+              class="makeStyles-root-14"
             >
-              <h2
-                class="MuiTypography-root MuiTypography-h2 MuiTypography-gutterBottom"
+              <h4
+                class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
               >
-                Basic Info
-              </h2>
+                Tell Us the Basics
+              </h4>
               <div
-                class="makeStyles-row-17"
+                class="makeStyles-row-15"
               >
                 <div
                   class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -417,10 +421,10 @@ exports[`renders as expected 1`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-12 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-10 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-14 PrivateNotchedOutline-legendNotched-15"
+                        class="PrivateNotchedOutline-legendLabelled-12 PrivateNotchedOutline-legendNotched-13"
                       >
                         <span>
                           Experiment name
@@ -437,7 +441,7 @@ exports[`renders as expected 1`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-row-17"
+                class="makeStyles-row-15"
               >
                 <div
                   class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -468,10 +472,10 @@ exports[`renders as expected 1`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-12 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-10 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-14 PrivateNotchedOutline-legendNotched-15"
+                        class="PrivateNotchedOutline-legendLabelled-12 PrivateNotchedOutline-legendNotched-13"
                       >
                         <span>
                           Experiment description
@@ -488,10 +492,10 @@ exports[`renders as expected 1`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-row-17"
+                class="makeStyles-row-15"
               >
                 <div
-                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-19"
+                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-17"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
@@ -525,10 +529,10 @@ exports[`renders as expected 1`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-12 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-10 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-14 PrivateNotchedOutline-legendNotched-15"
+                        class="PrivateNotchedOutline-legendLabelled-12 PrivateNotchedOutline-legendNotched-13"
                       >
                         <span>
                           Start date
@@ -545,12 +549,12 @@ exports[`renders as expected 1`] = `
                   </p>
                 </div>
                 <span
-                  class="makeStyles-through-18"
+                  class="makeStyles-through-16"
                 >
                    through 
                 </span>
                 <div
-                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-19"
+                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-17"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
@@ -582,10 +586,10 @@ exports[`renders as expected 1`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-12 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-10 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-14 PrivateNotchedOutline-legendNotched-15"
+                        class="PrivateNotchedOutline-legendLabelled-12 PrivateNotchedOutline-legendNotched-13"
                       >
                         <span>
                           End date
@@ -603,7 +607,7 @@ exports[`renders as expected 1`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-row-17"
+                class="makeStyles-row-15"
               >
                 <div
                   class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -644,10 +648,10 @@ exports[`renders as expected 1`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-12 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-10 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-14 PrivateNotchedOutline-legendNotched-15"
+                        class="PrivateNotchedOutline-legendLabelled-12 PrivateNotchedOutline-legendNotched-13"
                       >
                         <span>
                           Owner
@@ -705,15 +709,15 @@ exports[`renders as expected 1`] = `
             class="MuiPaper-root makeStyles-paper-6 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-20"
+              class="makeStyles-root-18"
             >
-              <h2
-                class="MuiTypography-root MuiTypography-h2 MuiTypography-gutterBottom"
+              <h4
+                class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
               >
-                Audience
-              </h2>
+                Who Is Your Audience
+              </h4>
               <div
-                class="makeStyles-row-21"
+                class="makeStyles-row-19"
               >
                 <fieldset
                   class="MuiFormControl-root"
@@ -762,7 +766,7 @@ exports[`renders as expected 1`] = `
                 </fieldset>
               </div>
               <div
-                class="makeStyles-row-21"
+                class="makeStyles-row-19"
               >
                 <fieldset
                   class="MuiFormControl-root"
@@ -794,19 +798,19 @@ exports[`renders as expected 1`] = `
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-26 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-25 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
                       >
                         <span
                           class="MuiIconButton-label"
                         >
                           <input
-                            class="PrivateSwitchBase-input-29"
+                            class="PrivateSwitchBase-input-28"
                             name="experiment.existingUsersAllowed"
                             type="radio"
                             value="false"
                           />
                           <div
-                            class="PrivateRadioButtonIcon-root-30"
+                            class="PrivateRadioButtonIcon-root-29"
                           >
                             <svg
                               aria-hidden="true"
@@ -820,7 +824,7 @@ exports[`renders as expected 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-31"
+                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-30"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
@@ -845,19 +849,19 @@ exports[`renders as expected 1`] = `
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-26 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-25 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
                       >
                         <span
                           class="MuiIconButton-label"
                         >
                           <input
-                            class="PrivateSwitchBase-input-29"
+                            class="PrivateSwitchBase-input-28"
                             name="experiment.existingUsersAllowed"
                             type="radio"
                             value="true"
                           />
                           <div
-                            class="PrivateRadioButtonIcon-root-30"
+                            class="PrivateRadioButtonIcon-root-29"
                           >
                             <svg
                               aria-hidden="true"
@@ -871,7 +875,7 @@ exports[`renders as expected 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-31"
+                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-30"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
@@ -895,10 +899,10 @@ exports[`renders as expected 1`] = `
                 </fieldset>
               </div>
               <div
-                class="makeStyles-row-21"
+                class="makeStyles-row-19"
               >
                 <fieldset
-                  class="MuiFormControl-root makeStyles-segmentationFieldSet-23"
+                  class="MuiFormControl-root makeStyles-segmentationFieldSet-21"
                 >
                   <label
                     class="MuiFormLabel-root"
@@ -907,7 +911,7 @@ exports[`renders as expected 1`] = `
                     Targeting
                   </label>
                   <p
-                    class="MuiFormHelperText-root makeStyles-segmentationHelperText-22"
+                    class="MuiFormHelperText-root makeStyles-segmentationHelperText-20"
                   >
                     Who should see this experiment? 
                     <br />
@@ -915,7 +919,7 @@ exports[`renders as expected 1`] = `
                   </p>
                   <div
                     aria-label="include-or-exclude-segments"
-                    class="MuiFormGroup-root makeStyles-segmentationExclusionState-24"
+                    class="MuiFormGroup-root makeStyles-segmentationExclusionState-22"
                     role="radiogroup"
                   >
                     <label
@@ -923,20 +927,20 @@ exports[`renders as expected 1`] = `
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-26 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-27 Mui-checked MuiIconButton-colorSecondary"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-25 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-26 Mui-checked MuiIconButton-colorSecondary"
                       >
                         <span
                           class="MuiIconButton-label"
                         >
                           <input
                             checked=""
-                            class="PrivateSwitchBase-input-29"
+                            class="PrivateSwitchBase-input-28"
                             name="non-formik-segment-exclusion-state-include"
                             type="radio"
                             value="include"
                           />
                           <div
-                            class="PrivateRadioButtonIcon-root-30 PrivateRadioButtonIcon-checked-32"
+                            class="PrivateRadioButtonIcon-root-29 PrivateRadioButtonIcon-checked-31"
                           >
                             <svg
                               aria-hidden="true"
@@ -950,7 +954,7 @@ exports[`renders as expected 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-31"
+                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-30"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
@@ -975,19 +979,19 @@ exports[`renders as expected 1`] = `
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-26 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-25 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
                       >
                         <span
                           class="MuiIconButton-label"
                         >
                           <input
-                            class="PrivateSwitchBase-input-29"
+                            class="PrivateSwitchBase-input-28"
                             name="non-formik-segment-exclusion-state-exclude"
                             type="radio"
                             value="exclude"
                           />
                           <div
-                            class="PrivateRadioButtonIcon-root-30"
+                            class="PrivateRadioButtonIcon-root-29"
                           >
                             <svg
                               aria-hidden="true"
@@ -1001,7 +1005,7 @@ exports[`renders as expected 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-31"
+                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-30"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
@@ -1102,11 +1106,11 @@ exports[`renders as expected 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="PrivateNotchedOutline-root-12 MuiOutlinedInput-notchedOutline"
+                          class="PrivateNotchedOutline-root-10 MuiOutlinedInput-notchedOutline"
                           style="padding-left: 8px;"
                         >
                           <legend
-                            class="PrivateNotchedOutline-legend-13"
+                            class="PrivateNotchedOutline-legend-11"
                             style="width: 0.01px;"
                           >
                             <span>
@@ -1120,10 +1124,10 @@ exports[`renders as expected 1`] = `
                 </fieldset>
               </div>
               <div
-                class="makeStyles-row-21"
+                class="makeStyles-row-19"
               >
                 <fieldset
-                  class="MuiFormControl-root makeStyles-segmentationFieldSet-23"
+                  class="MuiFormControl-root makeStyles-segmentationFieldSet-21"
                 >
                   <label
                     class="MuiFormLabel-root"
@@ -1132,7 +1136,7 @@ exports[`renders as expected 1`] = `
                     Variations
                   </label>
                   <p
-                    class="MuiFormHelperText-root makeStyles-segmentationHelperText-22"
+                    class="MuiFormHelperText-root makeStyles-segmentationHelperText-20"
                   >
                     Define the percentages to include in the experiment. 
                     <br />
@@ -1142,7 +1146,7 @@ exports[`renders as expected 1`] = `
                     class="MuiTableContainer-root"
                   >
                     <table
-                      class="MuiTable-root"
+                      class="MuiTable-root makeStyles-variants-24"
                     >
                       <thead
                         class="MuiTableHead-root"
@@ -1179,7 +1183,7 @@ exports[`renders as expected 1`] = `
                             class="MuiTableCell-root MuiTableCell-body"
                           >
                             <div
-                              class="MuiFormControl-root MuiTextField-root makeStyles-variationAllocatedPercentage-25"
+                              class="MuiFormControl-root MuiTextField-root makeStyles-variationAllocatedPercentage-23"
                             >
                               <div
                                 class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
@@ -1205,11 +1209,11 @@ exports[`renders as expected 1`] = `
                                 </div>
                                 <fieldset
                                   aria-hidden="true"
-                                  class="PrivateNotchedOutline-root-12 MuiOutlinedInput-notchedOutline"
+                                  class="PrivateNotchedOutline-root-10 MuiOutlinedInput-notchedOutline"
                                   style="padding-left: 8px;"
                                 >
                                   <legend
-                                    class="PrivateNotchedOutline-legend-13"
+                                    class="PrivateNotchedOutline-legend-11"
                                     style="width: 0.01px;"
                                   >
                                     <span>
@@ -1233,7 +1237,7 @@ exports[`renders as expected 1`] = `
                             class="MuiTableCell-root MuiTableCell-body"
                           >
                             <div
-                              class="MuiFormControl-root MuiTextField-root makeStyles-variationAllocatedPercentage-25"
+                              class="MuiFormControl-root MuiTextField-root makeStyles-variationAllocatedPercentage-23"
                             >
                               <div
                                 class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
@@ -1259,11 +1263,11 @@ exports[`renders as expected 1`] = `
                                 </div>
                                 <fieldset
                                   aria-hidden="true"
-                                  class="PrivateNotchedOutline-root-12 MuiOutlinedInput-notchedOutline"
+                                  class="PrivateNotchedOutline-root-10 MuiOutlinedInput-notchedOutline"
                                   style="padding-left: 8px;"
                                 >
                                   <legend
-                                    class="PrivateNotchedOutline-legend-13"
+                                    class="PrivateNotchedOutline-legend-11"
                                     style="width: 0.01px;"
                                   >
                                     <span>
@@ -1321,6 +1325,11 @@ exports[`renders as expected 1`] = `
           <div
             class="MuiPaper-root makeStyles-paper-6 MuiPaper-elevation1 MuiPaper-rounded"
           >
+            <h4
+              class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
+            >
+              What Are You Measuring
+            </h4>
             <p
               class="MuiTypography-root MuiTypography-body1"
             >
@@ -1366,24 +1375,41 @@ exports[`renders as expected 1`] = `
           <div
             class="MuiPaper-root makeStyles-paper-6 MuiPaper-elevation1 MuiPaper-rounded"
           >
-            <p
-              class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom"
+            <h4
+              class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
             >
-              This last form-part gives the users a chance to pause and consider.
-              <br />
-              <br />
-              It is good to have a mini-checklist here.
-              <br />
-              <br />
-              Maybe a pre-submission summary.
-              <br />
-              <br />
-              It is also good for the users to know the consequences of submitting so they aren't afraid of pressing the button.
+              Confirm and Submit Your Experiment
+            </h4>
+            <p
+              class="MuiTypography-root MuiTypography-body2 MuiTypography-gutterBottom"
+            >
+              Now is a good time to look over the Field Guide's experiment creation checklist and confirm everything is in place.
+            </p>
+            <p
+              class="MuiTypography-root MuiTypography-body2 MuiTypography-gutterBottom"
+            >
+              <strong>
+                 When you are ready, click the Submit button below.
+              </strong>
             </p>
           </div>
           <div
             class="makeStyles-formPartActions-5"
           >
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                Previous
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary"
               tabindex="0"

--- a/components/experiment-creation/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/components/experiment-creation/__snapshots__/ExperimentForm.test.tsx.snap
@@ -1388,6 +1388,11 @@ exports[`renders as expected 1`] = `
             <p
               class="MuiTypography-root MuiTypography-body2 MuiTypography-gutterBottom"
             >
+              Once you submit your experiment it will be set to staging, where it can be edited up until you set it to running.
+            </p>
+            <p
+              class="MuiTypography-root MuiTypography-body2 MuiTypography-gutterBottom"
+            >
               <strong>
                  When you are ready, click the Submit button below.
               </strong>

--- a/components/experiment-creation/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/components/experiment-creation/__snapshots__/ExperimentForm.test.tsx.snap
@@ -312,7 +312,7 @@ exports[`renders as expected 1`] = `
               <p
                 class="MuiTypography-root MuiTypography-body2"
               >
-                Without a well documented design, an experiment could be invalid and unsafe for making important decisions.
+                We think one of the best ways to prevent a failed experiment is by documenting what you hope to learn.
                 <br />
                 <br />
                 <strong>

--- a/components/experiment-creation/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/components/experiment-creation/__snapshots__/ExperimentForm.test.tsx.snap
@@ -386,7 +386,7 @@ exports[`renders as expected 1`] = `
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
               >
-                Tell Us the Basics
+                Basic Info
               </h4>
               <div
                 class="makeStyles-row-15"
@@ -714,7 +714,7 @@ exports[`renders as expected 1`] = `
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
               >
-                Who Is Your Audience
+                Define Your Audience
               </h4>
               <div
                 class="makeStyles-row-19"
@@ -1328,7 +1328,7 @@ exports[`renders as expected 1`] = `
             <h4
               class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
             >
-              What Are You Measuring
+              Assign Metrics
             </h4>
             <p
               class="MuiTypography-root MuiTypography-body1"

--- a/pages/experiments/new.tsx
+++ b/pages/experiments/new.tsx
@@ -4,7 +4,6 @@ import React from 'react'
 
 import MetricsApi from '@/api/MetricsApi'
 import SegmentsApi from '@/api/SegmentsApi'
-import DebugOutput from '@/components/DebugOutput'
 import ExperimentForm from '@/components/experiment-creation/ExperimentForm'
 import Layout from '@/components/Layout'
 import { createNewExperiment } from '@/lib/experiments'
@@ -37,9 +36,6 @@ const ExperimentsNewPage = function () {
       {!isLoading && metrics && segments && (
         <ExperimentForm metrics={metrics} segments={segments} initialExperiment={initialExperiment} />
       )}
-      <DebugOutput label='Initial Experiment' content={initialExperiment} />
-      <DebugOutput label='Metrics' content={metrics} />
-      <DebugOutput label='Segments' content={segments} />
     </Layout>
   )
 }


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR is an assortment relating the the insides of the form-parts:**
- Restrict the form-part widths. 
   (Not sure if this is an amazing solution but something like this is necessary.)
- Make the variants table field auto-width
- Improve the padding on the Paper
- Improve the content of the Beginning form-part
   Made it a bit more positive focused.
   Referenced the field-guide for instructions. 
   It would be great if we could link it, is there a short-link service we could use?
   > <img width="628" alt="Screen Shot 2020-07-28 at 12 16 40 pm" src="https://user-images.githubusercontent.com/971886/88618659-3dfb3300-d0cc-11ea-947d-a7513f22df31.png">


- Improve the content of the Submit form-part
   > <img width="562" alt="Screen Shot 2020-07-28 at 12 09 28 pm" src="https://user-images.githubusercontent.com/971886/88618623-2623af00-d0cc-11ea-95f9-8009d580149e.png">

- Improve the all the form-part titles
   - Changed the style to an h4
   - Made them friendlier, actionable (imperative form) and reduced the duplication of text on screen:

      > <img width="445" alt="Screen Shot 2020-07-28 at 12 17 48 pm" src="https://user-images.githubusercontent.com/971886/88618752-7a2e9380-d0cc-11ea-99f1-0680a77b4137.png">

      > <img width="221" alt="Screen Shot 2020-07-28 at 12 17 55 pm" src="https://user-images.githubusercontent.com/971886/88618759-7d298400-d0cc-11ea-801c-5b9cad4bfec9.png">

      > <img width="263" alt="Screen Shot 2020-07-28 at 12 18 04 pm" src="https://user-images.githubusercontent.com/971886/88618766-80247480-d0cc-11ea-8ade-b0d18cfb32cf.png">

      > <img width="285" alt="Screen Shot 2020-07-28 at 12 18 09 pm" src="https://user-images.githubusercontent.com/971886/88618769-83b7fb80-d0cc-11ea-9c65-12b514491842.png">

      > <img width="419" alt="Screen Shot 2020-07-28 at 12 18 17 pm" src="https://user-images.githubusercontent.com/971886/88618775-861a5580-d0cc-11ea-92be-48e2ba31464c.png">
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Part of a series on #9 

## How has this been tested?
- Automated tests that cover added/changed functionality
- Manual testing with mock data (locally)
