### PR TITLE
Experiment Creation Form: Polish the Scrolling

### DIFF
--- a/components/experiment-creation/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/components/experiment-creation/__snapshots__/ExperimentForm.test.tsx.snap
@@ -292,14 +292,17 @@ exports[`renders as expected 1`] = `
       </div>
     </div>
     <div
-      class="makeStyles-form-3"
+      class="makeStyles-formConstrictor-3"
     >
-      <form>
+      <form
+        class="makeStyles-form-4"
+      >
         <div
-          class="makeStyles-formPart-4"
+          class="makeStyles-formPart-5"
+          style="width: 0px;"
         >
           <div
-            class="makeStyles-root-7"
+            class="makeStyles-root-8"
           >
             <p
               class="MuiTypography-root MuiTypography-body1"
@@ -307,7 +310,7 @@ exports[`renders as expected 1`] = `
               We think one of the best ways to prevent a failed experiment is by documenting what you hope to learn.
             </p>
             <div
-              class="makeStyles-p2Entry-9"
+              class="makeStyles-p2Entry-10"
             >
               <h6
                 class="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom"
@@ -320,7 +323,7 @@ exports[`renders as expected 1`] = `
                 Once you've designed and documented your experiment, enter the P2 post URL:
               </p>
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-p2EntryField-10"
+                class="MuiFormControl-root MuiTextField-root makeStyles-p2EntryField-11"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
@@ -335,11 +338,11 @@ exports[`renders as expected 1`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-12 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-13 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-13"
+                      class="PrivateNotchedOutline-legend-14"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -352,7 +355,7 @@ exports[`renders as expected 1`] = `
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-5"
+            class="makeStyles-formPartActions-6"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -371,13 +374,14 @@ exports[`renders as expected 1`] = `
           </div>
         </div>
         <div
-          class="makeStyles-formPart-4"
+          class="makeStyles-formPart-5"
+          style="width: 0px;"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-6 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-7 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-16"
+              class="makeStyles-root-17"
             >
               <h2
                 class="MuiTypography-root MuiTypography-h2 MuiTypography-gutterBottom"
@@ -385,7 +389,7 @@ exports[`renders as expected 1`] = `
                 Basic Info
               </h2>
               <div
-                class="makeStyles-row-17"
+                class="makeStyles-row-18"
               >
                 <div
                   class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -417,10 +421,10 @@ exports[`renders as expected 1`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-12 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-13 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-14 PrivateNotchedOutline-legendNotched-15"
+                        class="PrivateNotchedOutline-legendLabelled-15 PrivateNotchedOutline-legendNotched-16"
                       >
                         <span>
                           Experiment name
@@ -437,7 +441,7 @@ exports[`renders as expected 1`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-row-17"
+                class="makeStyles-row-18"
               >
                 <div
                   class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -468,10 +472,10 @@ exports[`renders as expected 1`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-12 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-13 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-14 PrivateNotchedOutline-legendNotched-15"
+                        class="PrivateNotchedOutline-legendLabelled-15 PrivateNotchedOutline-legendNotched-16"
                       >
                         <span>
                           Experiment description
@@ -488,10 +492,10 @@ exports[`renders as expected 1`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-row-17"
+                class="makeStyles-row-18"
               >
                 <div
-                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-19"
+                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-20"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
@@ -525,10 +529,10 @@ exports[`renders as expected 1`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-12 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-13 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-14 PrivateNotchedOutline-legendNotched-15"
+                        class="PrivateNotchedOutline-legendLabelled-15 PrivateNotchedOutline-legendNotched-16"
                       >
                         <span>
                           Start date
@@ -545,12 +549,12 @@ exports[`renders as expected 1`] = `
                   </p>
                 </div>
                 <span
-                  class="makeStyles-through-18"
+                  class="makeStyles-through-19"
                 >
                    through 
                 </span>
                 <div
-                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-19"
+                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-20"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
@@ -582,10 +586,10 @@ exports[`renders as expected 1`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-12 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-13 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-14 PrivateNotchedOutline-legendNotched-15"
+                        class="PrivateNotchedOutline-legendLabelled-15 PrivateNotchedOutline-legendNotched-16"
                       >
                         <span>
                           End date
@@ -603,7 +607,7 @@ exports[`renders as expected 1`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-row-17"
+                class="makeStyles-row-18"
               >
                 <div
                   class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -644,10 +648,10 @@ exports[`renders as expected 1`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-12 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-13 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-14 PrivateNotchedOutline-legendNotched-15"
+                        class="PrivateNotchedOutline-legendLabelled-15 PrivateNotchedOutline-legendNotched-16"
                       >
                         <span>
                           Owner
@@ -666,7 +670,7 @@ exports[`renders as expected 1`] = `
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-5"
+            class="makeStyles-formPartActions-6"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -699,13 +703,14 @@ exports[`renders as expected 1`] = `
           </div>
         </div>
         <div
-          class="makeStyles-formPart-4"
+          class="makeStyles-formPart-5"
+          style="width: 0px;"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-6 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-7 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-20"
+              class="makeStyles-root-21"
             >
               <h2
                 class="MuiTypography-root MuiTypography-h2 MuiTypography-gutterBottom"
@@ -713,7 +718,7 @@ exports[`renders as expected 1`] = `
                 Audience
               </h2>
               <div
-                class="makeStyles-row-21"
+                class="makeStyles-row-22"
               >
                 <fieldset
                   class="MuiFormControl-root"
@@ -762,7 +767,7 @@ exports[`renders as expected 1`] = `
                 </fieldset>
               </div>
               <div
-                class="makeStyles-row-21"
+                class="makeStyles-row-22"
               >
                 <fieldset
                   class="MuiFormControl-root"
@@ -794,19 +799,19 @@ exports[`renders as expected 1`] = `
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-26 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-27 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
                       >
                         <span
                           class="MuiIconButton-label"
                         >
                           <input
-                            class="PrivateSwitchBase-input-29"
+                            class="PrivateSwitchBase-input-30"
                             name="experiment.existingUsersAllowed"
                             type="radio"
                             value="false"
                           />
                           <div
-                            class="PrivateRadioButtonIcon-root-30"
+                            class="PrivateRadioButtonIcon-root-31"
                           >
                             <svg
                               aria-hidden="true"
@@ -820,7 +825,7 @@ exports[`renders as expected 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-31"
+                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-32"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
@@ -845,19 +850,19 @@ exports[`renders as expected 1`] = `
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-26 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-27 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
                       >
                         <span
                           class="MuiIconButton-label"
                         >
                           <input
-                            class="PrivateSwitchBase-input-29"
+                            class="PrivateSwitchBase-input-30"
                             name="experiment.existingUsersAllowed"
                             type="radio"
                             value="true"
                           />
                           <div
-                            class="PrivateRadioButtonIcon-root-30"
+                            class="PrivateRadioButtonIcon-root-31"
                           >
                             <svg
                               aria-hidden="true"
@@ -871,7 +876,7 @@ exports[`renders as expected 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-31"
+                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-32"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
@@ -895,10 +900,10 @@ exports[`renders as expected 1`] = `
                 </fieldset>
               </div>
               <div
-                class="makeStyles-row-21"
+                class="makeStyles-row-22"
               >
                 <fieldset
-                  class="MuiFormControl-root makeStyles-segmentationFieldSet-23"
+                  class="MuiFormControl-root makeStyles-segmentationFieldSet-24"
                 >
                   <label
                     class="MuiFormLabel-root"
@@ -907,7 +912,7 @@ exports[`renders as expected 1`] = `
                     Targeting
                   </label>
                   <p
-                    class="MuiFormHelperText-root makeStyles-segmentationHelperText-22"
+                    class="MuiFormHelperText-root makeStyles-segmentationHelperText-23"
                   >
                     Who should see this experiment? 
                     <br />
@@ -915,7 +920,7 @@ exports[`renders as expected 1`] = `
                   </p>
                   <div
                     aria-label="include-or-exclude-segments"
-                    class="MuiFormGroup-root makeStyles-segmentationExclusionState-24"
+                    class="MuiFormGroup-root makeStyles-segmentationExclusionState-25"
                     role="radiogroup"
                   >
                     <label
@@ -923,20 +928,20 @@ exports[`renders as expected 1`] = `
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-26 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-27 Mui-checked MuiIconButton-colorSecondary"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-27 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-28 Mui-checked MuiIconButton-colorSecondary"
                       >
                         <span
                           class="MuiIconButton-label"
                         >
                           <input
                             checked=""
-                            class="PrivateSwitchBase-input-29"
+                            class="PrivateSwitchBase-input-30"
                             name="non-formik-segment-exclusion-state-include"
                             type="radio"
                             value="include"
                           />
                           <div
-                            class="PrivateRadioButtonIcon-root-30 PrivateRadioButtonIcon-checked-32"
+                            class="PrivateRadioButtonIcon-root-31 PrivateRadioButtonIcon-checked-33"
                           >
                             <svg
                               aria-hidden="true"
@@ -950,7 +955,7 @@ exports[`renders as expected 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-31"
+                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-32"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
@@ -975,19 +980,19 @@ exports[`renders as expected 1`] = `
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-26 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-27 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
                       >
                         <span
                           class="MuiIconButton-label"
                         >
                           <input
-                            class="PrivateSwitchBase-input-29"
+                            class="PrivateSwitchBase-input-30"
                             name="non-formik-segment-exclusion-state-exclude"
                             type="radio"
                             value="exclude"
                           />
                           <div
-                            class="PrivateRadioButtonIcon-root-30"
+                            class="PrivateRadioButtonIcon-root-31"
                           >
                             <svg
                               aria-hidden="true"
@@ -1001,7 +1006,7 @@ exports[`renders as expected 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-31"
+                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-32"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
@@ -1102,11 +1107,11 @@ exports[`renders as expected 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="PrivateNotchedOutline-root-12 MuiOutlinedInput-notchedOutline"
+                          class="PrivateNotchedOutline-root-13 MuiOutlinedInput-notchedOutline"
                           style="padding-left: 8px;"
                         >
                           <legend
-                            class="PrivateNotchedOutline-legend-13"
+                            class="PrivateNotchedOutline-legend-14"
                             style="width: 0.01px;"
                           >
                             <span>
@@ -1120,10 +1125,10 @@ exports[`renders as expected 1`] = `
                 </fieldset>
               </div>
               <div
-                class="makeStyles-row-21"
+                class="makeStyles-row-22"
               >
                 <fieldset
-                  class="MuiFormControl-root makeStyles-segmentationFieldSet-23"
+                  class="MuiFormControl-root makeStyles-segmentationFieldSet-24"
                 >
                   <label
                     class="MuiFormLabel-root"
@@ -1132,7 +1137,7 @@ exports[`renders as expected 1`] = `
                     Variations
                   </label>
                   <p
-                    class="MuiFormHelperText-root makeStyles-segmentationHelperText-22"
+                    class="MuiFormHelperText-root makeStyles-segmentationHelperText-23"
                   >
                     Define the percentages to include in the experiment. 
                     <br />
@@ -1179,7 +1184,7 @@ exports[`renders as expected 1`] = `
                             class="MuiTableCell-root MuiTableCell-body"
                           >
                             <div
-                              class="MuiFormControl-root MuiTextField-root makeStyles-variationAllocatedPercentage-25"
+                              class="MuiFormControl-root MuiTextField-root makeStyles-variationAllocatedPercentage-26"
                             >
                               <div
                                 class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
@@ -1205,11 +1210,11 @@ exports[`renders as expected 1`] = `
                                 </div>
                                 <fieldset
                                   aria-hidden="true"
-                                  class="PrivateNotchedOutline-root-12 MuiOutlinedInput-notchedOutline"
+                                  class="PrivateNotchedOutline-root-13 MuiOutlinedInput-notchedOutline"
                                   style="padding-left: 8px;"
                                 >
                                   <legend
-                                    class="PrivateNotchedOutline-legend-13"
+                                    class="PrivateNotchedOutline-legend-14"
                                     style="width: 0.01px;"
                                   >
                                     <span>
@@ -1233,7 +1238,7 @@ exports[`renders as expected 1`] = `
                             class="MuiTableCell-root MuiTableCell-body"
                           >
                             <div
-                              class="MuiFormControl-root MuiTextField-root makeStyles-variationAllocatedPercentage-25"
+                              class="MuiFormControl-root MuiTextField-root makeStyles-variationAllocatedPercentage-26"
                             >
                               <div
                                 class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
@@ -1259,11 +1264,11 @@ exports[`renders as expected 1`] = `
                                 </div>
                                 <fieldset
                                   aria-hidden="true"
-                                  class="PrivateNotchedOutline-root-12 MuiOutlinedInput-notchedOutline"
+                                  class="PrivateNotchedOutline-root-13 MuiOutlinedInput-notchedOutline"
                                   style="padding-left: 8px;"
                                 >
                                   <legend
-                                    class="PrivateNotchedOutline-legend-13"
+                                    class="PrivateNotchedOutline-legend-14"
                                     style="width: 0.01px;"
                                   >
                                     <span>
@@ -1283,7 +1288,7 @@ exports[`renders as expected 1`] = `
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-5"
+            class="makeStyles-formPartActions-6"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -1316,10 +1321,11 @@ exports[`renders as expected 1`] = `
           </div>
         </div>
         <div
-          class="makeStyles-formPart-4"
+          class="makeStyles-formPart-5"
+          style="width: 0px;"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-6 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-7 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <p
               class="MuiTypography-root MuiTypography-body1"
@@ -1328,7 +1334,7 @@ exports[`renders as expected 1`] = `
             </p>
           </div>
           <div
-            class="makeStyles-formPartActions-5"
+            class="makeStyles-formPartActions-6"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -1361,10 +1367,11 @@ exports[`renders as expected 1`] = `
           </div>
         </div>
         <div
-          class="makeStyles-formPart-4"
+          class="makeStyles-formPart-5"
+          style="width: 0px;"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-6 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-7 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <p
               class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom"
@@ -1382,7 +1389,7 @@ exports[`renders as expected 1`] = `
             </p>
           </div>
           <div
-            class="makeStyles-formPartActions-5"
+            class="makeStyles-formPartActions-6"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2257,6 +2257,11 @@
         "react-lifecycles-compat": "^3.0.4"
       }
     },
+    "@rehooks/component-size": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rehooks/component-size/-/component-size-1.0.3.tgz",
+      "integrity": "sha512-pnYld+8SSF2vXwdLOqBGUyOrv/SjzwLjIUcs/4c1JJgR0q4E9eBtBfuZMD6zUD51fvSehSsbnlQMzotSmPTXPg=="
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@material-ui/core": "^4.10.0",
     "@material-ui/lab": "^4.0.0-alpha.56",
+    "@rehooks/component-size": "^1.0.3",
     "clsx": "^1.1.1",
     "date-fns": "^2.13.0",
     "debug": "^4.1.1",


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR makes the scrolling horizontal:**
- Allows a better experience for scrolling the long forms as you don't need an internal scroll bar
- Works well with the prev-next buttons

Demo Vid: https://d.pr/v/DeN4hm

In doing so I have had to dynamically set the width on the form-parts.

I have used the npm library `@rehooks/component-size`:
- 2+ years old.
- Micro library, does only one thing.
- Well maintained.
- Very easily replaceable. 

<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

**Responsive considerations:**

For small screen sizes this will all get disabled and we will just have a long scrolling form with no stepper.

**Should ExperimentForm be refactored?**

ExperimentForm is getting quite big.

The component currently has three tasks:
1. Manages the steps and the stepper.
2. Initialises the form.
3. Manages the scrolling of the form.


These tasks are interconnected:
- `1 <-> 2` Syncing the validation and completion state with the steps.
- `1 <-> 3` Syncing the scroll with the step

Right now my feeling is that I want to see them change a bit further until separating them out, and it is likely that `3` will be separated out first.


## How has this been tested?

- Automated tests that cover added/changed functionality
- Manual testing with mock data (locally)
- More tests for Experiment Creation Form coming once it is stable.
