### PR TITLE
Add normalisation to populate creation form

### DIFF
--- a/components/experiment-creation/Audience.test.tsx
+++ b/components/experiment-creation/Audience.test.tsx
@@ -3,7 +3,7 @@ import { Formik, FormikProps } from 'formik'
 import React from 'react'
 
 import { createNewExperiment } from '@/lib/experiments'
-import { ExperimentFullNew } from '@/lib/schemas'
+import { ExperimentFullNew, Segment, SegmentType } from '@/lib/schemas'
 
 import Audience from './Audience'
 
@@ -20,6 +20,13 @@ document.createRange = () => ({
 })
 
 test('renders as expected', async () => {
+  const indexedSegments: Record<number, Segment> = {
+    1: { segmentId: 1, name: 'us', type: SegmentType.Country },
+    2: { segmentId: 2, name: 'au', type: SegmentType.Country },
+    3: { segmentId: 3, name: 'en-US', type: SegmentType.Locale },
+    4: { segmentId: 4, name: 'en-AU', type: SegmentType.Locale },
+  }
+
   const { container } = render(
     <Formik
       initialValues={{ experiment: createNewExperiment() }}
@@ -28,7 +35,9 @@ test('renders as expected', async () => {
         () => undefined
       }
     >
-      {(formikProps: FormikProps<{ experiment: Partial<ExperimentFullNew> }>) => <Audience formikProps={formikProps} />}
+      {(formikProps: FormikProps<{ experiment: Partial<ExperimentFullNew> }>) => (
+        <Audience indexedSegments={indexedSegments} formikProps={formikProps} />
+      )}
     </Formik>,
   )
   expect(container).toMatchSnapshot()

--- a/components/experiment-creation/Audience.tsx
+++ b/components/experiment-creation/Audience.tsx
@@ -58,7 +58,7 @@ enum SegmentExclusionState {
 
 const SegmentsAutocomplete = (
   props: AutocompleteProps<Segment, true, false, false> & {
-    normalizedSegments: Record<number, Segment>
+    indexedSegments: Record<number, Segment>
     segmentExclusionState: SegmentExclusionState
   },
 ) => {
@@ -70,7 +70,7 @@ const SegmentsAutocomplete = (
 
   // Here we translate SegmentAssignment (outside) <-> Segment (inside)
   const segmentAssignmentToSegment = (segmentAssignment: SegmentAssignmentNew) => {
-    const segment = props.normalizedSegments[segmentAssignment.segmentId]
+    const segment = props.indexedSegments[segmentAssignment.segmentId]
     /* istanbul ignore next; Should never happen */
     if (!segment) {
       throw new Error('Could not find segment with specified segmentId.')
@@ -94,7 +94,7 @@ const SegmentsAutocomplete = (
 
   return (
     <Autocomplete
-      {...fieldToAutocomplete(_.omit(props, 'segmentExclusionState', 'normalizedSegments'))}
+      {...fieldToAutocomplete(_.omit(props, 'segmentExclusionState', 'indexedSegments'))}
       multiple={true}
       onChange={onChange}
       value={value}
@@ -104,10 +104,10 @@ const SegmentsAutocomplete = (
 }
 
 const Audience = ({
-  normalizedSegments,
+  indexedSegments,
   formikProps,
 }: {
-  normalizedSegments: Record<number, Segment>
+  indexedSegments: Record<number, Segment>
   formikProps: FormikProps<{ experiment: Partial<ExperimentFullNew> }>
 }) => {
   const classes = useStyles()
@@ -202,13 +202,13 @@ const Audience = ({
           <Field
             name='experiment.segmentAssignments'
             component={SegmentsAutocomplete}
-            options={Object.values(normalizedSegments)}
+            options={Object.values(indexedSegments)}
             // TODO: Error state, see https://stackworx.github.io/formik-material-ui/docs/api/material-ui-lab
             renderInput={(params: AutocompleteRenderInputParams) => (
               <MuiTextField {...params} variant='outlined' placeholder='Search and select to customize' />
             )}
             segmentExclusionState={segmentExclusionState}
-            normalizedSegments={normalizedSegments}
+            indexedSegments={indexedSegments}
             fullWidth
             id='segments-select'
           />

--- a/components/experiment-creation/ExperimentForm.test.tsx
+++ b/components/experiment-creation/ExperimentForm.test.tsx
@@ -4,6 +4,7 @@ import MockDate from 'mockdate'
 import React from 'react'
 
 import { createNewExperiment } from '@/lib/experiments'
+import * as Normalizr from '@/lib/normalizr'
 import Fixtures from '@/test-helpers/fixtures'
 
 import ExperimentForm from './ExperimentForm'
@@ -12,8 +13,8 @@ test('renders as expected', () => {
   MockDate.set('2020-07-21')
   const { container } = render(
     <ExperimentForm
-      metrics={Fixtures.createMetricBares(20)}
-      segments={Fixtures.createSegments(20)}
+      indexedMetrics={Normalizr.indexMetrics(Fixtures.createMetricBares(20))}
+      indexedSegments={Normalizr.indexSegments(Fixtures.createSegments(20))}
       initialExperiment={createNewExperiment()}
     />,
   )

--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -86,12 +86,12 @@ const useStyles = makeStyles((theme: Theme) =>
 )
 
 const ExperimentForm = ({
-  metrics,
-  segments,
+  normalizedMetrics,
+  normalizedSegments,
   initialExperiment,
 }: {
-  metrics: MetricBare[]
-  segments: Segment[]
+  normalizedMetrics: Record<string, MetricBare>
+  normalizedSegments: Record<string, Segment>
   initialExperiment: Partial<ExperimentFullNew>
 }) => {
   const classes = useStyles()

--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -190,7 +190,7 @@ const ExperimentForm = ({
               </div>
               <div className={classes.formPart} ref={formPartAudienceRef}>
                 <Paper className={classes.paper}>
-                  <Audience formikProps={formikProps} />
+                  <Audience formikProps={formikProps} normalizedSegments={normalizedSegments} />
                 </Paper>
                 <div className={classes.formPartActions}>
                   <Button onClick={prevStage}>Previous</Button>

--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -86,12 +86,12 @@ const useStyles = makeStyles((theme: Theme) =>
 )
 
 const ExperimentForm = ({
-  normalizedMetrics,
-  normalizedSegments,
+  indexedMetrics,
+  indexedSegments,
   initialExperiment,
 }: {
-  normalizedMetrics: Record<string, MetricBare>
-  normalizedSegments: Record<string, Segment>
+  indexedMetrics: Record<string, MetricBare>
+  indexedSegments: Record<string, Segment>
   initialExperiment: Partial<ExperimentFullNew>
 }) => {
   const classes = useStyles()
@@ -190,7 +190,7 @@ const ExperimentForm = ({
               </div>
               <div className={classes.formPart} ref={formPartAudienceRef}>
                 <Paper className={classes.paper}>
-                  <Audience formikProps={formikProps} normalizedSegments={normalizedSegments} />
+                  <Audience formikProps={formikProps} indexedSegments={indexedSegments} />
                 </Paper>
                 <div className={classes.formPartActions}>
                   <Button onClick={prevStage}>Previous</Button>

--- a/lib/normalizr.ts
+++ b/lib/normalizr.ts
@@ -6,6 +6,7 @@ export function indexMetrics<Metric extends MetricBare | MetricFull>(metrics: Me
   const {
     entities: { metrics: indexedMetrics },
   } = normalize<Metric>(metrics, [metricBareNormalizrSchema])
+  /* istanbul ignore next */
   if (!indexedMetrics) {
     throw new Error(`No metrics produced after normalisation, this should never happen.`)
   }
@@ -16,6 +17,7 @@ export function indexSegments(segments: Segment[]) {
   const {
     entities: { segments: indexedSegments },
   } = normalize<Segment>(segments, [segmentNormalizrSchema])
+  /* istanbul ignore next */
   if (!indexedSegments) {
     throw new Error(`No segments produced after normalisation, this should never happen.`)
   }

--- a/lib/normalizr.ts
+++ b/lib/normalizr.ts
@@ -1,0 +1,23 @@
+import { normalize } from 'normalizr'
+
+import { MetricBare, metricBareNormalizrSchema, MetricFull, Segment, segmentNormalizrSchema } from './schemas'
+
+export function indexMetrics<Metric extends MetricBare | MetricFull>(metrics: Metric[]) {
+  const {
+    entities: { metrics: indexedMetrics },
+  } = normalize<Metric>(metrics, [metricBareNormalizrSchema])
+  if (!indexedMetrics) {
+    throw new Error(`No metrics produced after normalisation, this should never happen.`)
+  }
+  return indexedMetrics
+}
+
+export function indexSegments(segments: Segment[]) {
+  const {
+    entities: { segments: indexedSegments },
+  } = normalize<Segment>(segments, [segmentNormalizrSchema])
+  if (!indexedSegments) {
+    throw new Error(`No segments produced after normalisation, this should never happen.`)
+  }
+  return indexedSegments
+}

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -60,6 +60,11 @@ export const metricBareSchema = yup
   .defined()
   .camelCase()
 export type MetricBare = yup.InferType<typeof metricBareSchema>
+export const metricBareNormalizrSchema = new normalizr.schema.Entity<MetricBare>(
+  'metrics',
+  {},
+  { idAttribute: 'metricId' },
+)
 
 export const metricFullSchema = metricBareSchema
   .shape({

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -2,6 +2,7 @@
 // https://app.swaggerhub.com/apis/yanir/experiments/0.1.0
 
 import * as dateFns from 'date-fns'
+import * as normalizr from 'normalizr'
 import * as yup from 'yup'
 
 const idSchema = yup.number().integer().positive()
@@ -130,6 +131,7 @@ export const segmentSchema = yup
   .defined()
   .camelCase()
 export type Segment = yup.InferType<typeof segmentSchema>
+export const segmentNormalizrSchema = new normalizr.schema.Entity<Segment>('segments', {}, { idAttribute: 'segmentId' })
 
 export const segmentAssignmentNewSchema = yup
   .object({

--- a/package-lock.json
+++ b/package-lock.json
@@ -14578,6 +14578,11 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
       "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
     },
+    "normalizr": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/normalizr/-/normalizr-3.6.0.tgz",
+      "integrity": "sha512-25cd8DiDu+pL46KIaxtVVvvEPjGacJgv0yUg950evr62dQ/ks2JO1kf7+Vi5/rMFjaSTSTls7aCnmRlUSljtiA=="
+    },
     "notistack": {
       "version": "0.9.17",
       "resolved": "https://registry.npmjs.org/notistack/-/notistack-0.9.17.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lodash": "^4.17.19",
     "material-table": "^1.59.0",
     "next": "^9.3.5",
+    "normalizr": "^3.6.0",
     "notistack": "^0.9.17",
     "qc-to_bool": "^1.1.2",
     "qc-to_int": "^1.0.1",

--- a/pages/experiments/new.tsx
+++ b/pages/experiments/new.tsx
@@ -1,5 +1,6 @@
 import { LinearProgress } from '@material-ui/core'
 import debugFactory from 'debug'
+import { normalize } from 'normalizr'
 import React from 'react'
 
 import MetricsApi from '@/api/MetricsApi'
@@ -8,6 +9,7 @@ import DebugOutput from '@/components/DebugOutput'
 import ExperimentForm from '@/components/experiment-creation/ExperimentForm'
 import Layout from '@/components/Layout'
 import { createNewExperiment } from '@/lib/experiments'
+import { MetricBare, metricBareNormalizrSchema, Segment, segmentNormalizrSchema } from '@/lib/schemas'
 import { useDataLoadingError, useDataSource } from '@/utils/data-loading'
 import { or } from '@/utils/general'
 
@@ -17,16 +19,22 @@ const ExperimentsNewPage = function () {
   debug('ExperimentsNewPage#render')
   const initialExperiment = createNewExperiment()
 
-  const { isLoading: metricsIsLoading, data: metrics, error: metricsError } = useDataSource(
-    () => MetricsApi.findAll(),
-    [],
-  )
+  const { isLoading: metricsIsLoading, data: normalizedMetrics, error: metricsError } = useDataSource(async () => {
+    const metrics = await MetricsApi.findAll()
+    const {
+      entities: { metrics: normalizedMetrics },
+    } = normalize<MetricBare>(metrics, [metricBareNormalizrSchema])
+    return normalizedMetrics
+  }, [])
   useDataLoadingError(metricsError, 'Metrics')
 
-  const { isLoading: segmentsIsLoading, data: segments, error: segmentsError } = useDataSource(
-    () => SegmentsApi.findAll(),
-    [],
-  )
+  const { isLoading: segmentsIsLoading, data: normalizedSegments, error: segmentsError } = useDataSource(async () => {
+    const segments = await SegmentsApi.findAll()
+    const {
+      entities: { segments: normalizedSegments },
+    } = normalize<Segment>(segments, [segmentNormalizrSchema])
+    return normalizedSegments
+  }, [])
   useDataLoadingError(segmentsError, 'Segments')
 
   const isLoading = or(metricsIsLoading, segmentsIsLoading)
@@ -34,12 +42,16 @@ const ExperimentsNewPage = function () {
   return (
     <Layout title='Create an Experiment'>
       {isLoading && <LinearProgress />}
-      {!isLoading && metrics && segments && (
-        <ExperimentForm metrics={metrics} segments={segments} initialExperiment={initialExperiment} />
+      {!isLoading && normalizedMetrics && normalizedSegments && (
+        <ExperimentForm
+          normalizedMetrics={normalizedMetrics}
+          normalizedSegments={normalizedSegments}
+          initialExperiment={initialExperiment}
+        />
       )}
       <DebugOutput label='Initial Experiment' content={initialExperiment} />
-      <DebugOutput label='Metrics' content={metrics} />
-      <DebugOutput label='Segments' content={segments} />
+      <DebugOutput label='Metrics' content={normalizedMetrics} />
+      <DebugOutput label='Segments' content={normalizedSegments} />
     </Layout>
   )
 }

--- a/pages/experiments/new.tsx
+++ b/pages/experiments/new.tsx
@@ -19,21 +19,21 @@ const ExperimentsNewPage = function () {
   debug('ExperimentsNewPage#render')
   const initialExperiment = createNewExperiment()
 
-  const { isLoading: metricsIsLoading, data: normalizedMetrics, error: metricsError } = useDataSource(async () => {
+  const { isLoading: metricsIsLoading, data: indexedMetrics, error: metricsError } = useDataSource(async () => {
     const metrics = await MetricsApi.findAll()
     const {
-      entities: { metrics: normalizedMetrics },
+      entities: { metrics: indexedMetrics },
     } = normalize<MetricBare>(metrics, [metricBareNormalizrSchema])
-    return normalizedMetrics
+    return indexedMetrics
   }, [])
   useDataLoadingError(metricsError, 'Metrics')
 
-  const { isLoading: segmentsIsLoading, data: normalizedSegments, error: segmentsError } = useDataSource(async () => {
+  const { isLoading: segmentsIsLoading, data: indexedSegments, error: segmentsError } = useDataSource(async () => {
     const segments = await SegmentsApi.findAll()
     const {
-      entities: { segments: normalizedSegments },
+      entities: { segments: indexedSegments },
     } = normalize<Segment>(segments, [segmentNormalizrSchema])
-    return normalizedSegments
+    return indexedSegments
   }, [])
   useDataLoadingError(segmentsError, 'Segments')
 
@@ -42,16 +42,16 @@ const ExperimentsNewPage = function () {
   return (
     <Layout title='Create an Experiment'>
       {isLoading && <LinearProgress />}
-      {!isLoading && normalizedMetrics && normalizedSegments && (
+      {!isLoading && indexedMetrics && indexedSegments && (
         <ExperimentForm
-          normalizedMetrics={normalizedMetrics}
-          normalizedSegments={normalizedSegments}
+          indexedMetrics={indexedMetrics}
+          indexedSegments={indexedSegments}
           initialExperiment={initialExperiment}
         />
       )}
       <DebugOutput label='Initial Experiment' content={initialExperiment} />
-      <DebugOutput label='Metrics' content={normalizedMetrics} />
-      <DebugOutput label='Segments' content={normalizedSegments} />
+      <DebugOutput label='Metrics' content={indexedMetrics} />
+      <DebugOutput label='Segments' content={indexedSegments} />
     </Layout>
   )
 }

--- a/pages/experiments/new.tsx
+++ b/pages/experiments/new.tsx
@@ -1,6 +1,5 @@
 import { LinearProgress } from '@material-ui/core'
 import debugFactory from 'debug'
-import { normalize } from 'normalizr'
 import React from 'react'
 
 import MetricsApi from '@/api/MetricsApi'
@@ -9,7 +8,7 @@ import DebugOutput from '@/components/DebugOutput'
 import ExperimentForm from '@/components/experiment-creation/ExperimentForm'
 import Layout from '@/components/Layout'
 import { createNewExperiment } from '@/lib/experiments'
-import { MetricBare, metricBareNormalizrSchema, Segment, segmentNormalizrSchema } from '@/lib/schemas'
+import * as Normalizr from '@/lib/normalizr'
 import { useDataLoadingError, useDataSource } from '@/utils/data-loading'
 import { or } from '@/utils/general'
 
@@ -21,19 +20,13 @@ const ExperimentsNewPage = function () {
 
   const { isLoading: metricsIsLoading, data: indexedMetrics, error: metricsError } = useDataSource(async () => {
     const metrics = await MetricsApi.findAll()
-    const {
-      entities: { metrics: indexedMetrics },
-    } = normalize<MetricBare>(metrics, [metricBareNormalizrSchema])
-    return indexedMetrics
+    return Normalizr.indexMetrics(metrics)
   }, [])
   useDataLoadingError(metricsError, 'Metrics')
 
   const { isLoading: segmentsIsLoading, data: indexedSegments, error: segmentsError } = useDataSource(async () => {
     const segments = await SegmentsApi.findAll()
-    const {
-      entities: { segments: indexedSegments },
-    } = normalize<Segment>(segments, [segmentNormalizrSchema])
-    return indexedSegments
+    return Normalizr.indexSegments(segments)
   }, [])
   useDataLoadingError(segmentsError, 'Segments')
 


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
_Split from #236, part 1/3. See the original PR for design discussion._

This PR:
- Adds `normalizer`
- Uses schemas to index the metrics/segments data for experiment creation.
- Populates the Segments in experiment creation
- Adds `/lib/normalizr` to hold normalisation functions.

**Should we have normalised fixtures?**
I don't particularly like the idea of normalised fixtures and I would want to go the opposite direction if possible: have fixtures of the server data rather than our internal format. 

With the added refactoring since the original PR I think it is quite light to normalise data in the tests.

<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with mock data (locally or on Vercel)
