### PR TITLE
Use instant scroll on experiment form

### DIFF
--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -136,7 +136,7 @@ const ExperimentForm = ({
       // TODO: Update current stage error and complete state
       setActiveStageId(stageId)
       if (stageFormPartRefs[stageId].current && rootRef.current) {
-        stageFormPartRefs[stageId].current?.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'start' })
+        stageFormPartRefs[stageId].current?.scrollIntoView({ behavior: 'auto', block: 'start', inline: 'start' })
       }
     },
     [stageFormPartRefs, setActiveStageId],


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR disables scrolling:**
- In a minimal quick way.
- If approved I will add an issue to remove all the scroll code.

From an Experiments suggestion: pbmo2S-qW-p2#comment-987
I think it is a better UX too, might add a mild background "flash" on change.

Best to preview after #239 is merged in

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with mock data (locally or on Vercel)
