### PR TITLE
Make jsx-child-element-spacing an error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -96,7 +96,7 @@ module.exports = {
     ],
 
     'react/display-name': 'off',
-    'react/jsx-child-element-spacing': 'warn',
+    'react/jsx-child-element-spacing': 'error',
     'react/jsx-closing-bracket-location': 'error',
     'react/jsx-closing-tag-location': 'error',
     'react/jsx-curly-newline': 'error',

--- a/components/experiment-creation/Beginning.tsx
+++ b/components/experiment-creation/Beginning.tsx
@@ -28,7 +28,7 @@ const Beginning = () => {
         Design and Document Your Experiment
       </Typography>
       <Typography variant='body2'>
-        We think one of the best ways to prevent a failed experiment is by documenting what you hope to learn.
+        We think one of the best ways to prevent a failed experiment is by documenting what you hope to learn.{/* */}
         <br />
         <br />
         <strong>


### PR DESCRIPTION
As the `jsx-child-element-spacing` warning keeps reappearing, make it an error to denoise the build.

## How has this been tested?

- Automated tests that cover added/changed functionality
- Additional manual testing instructions: Ran `npm run lint:ts` and verified that it's nice and quiet :slightly_smiling_face: 
