### PR TITLE
Populate metric fields from server in Experiment Creation form

### DIFF
--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -9,6 +9,7 @@ import _ from 'lodash'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import * as yup from 'yup'
 
+import { indexMetrics } from '@/lib/normalizers'
 import { ExperimentFullNew, experimentFullNewSchema, MetricBare, Segment } from '@/lib/schemas'
 
 import Audience from './Audience'
@@ -228,7 +229,7 @@ const ExperimentForm = ({
               </div>
               <div className={classes.formPart} ref={formPartMetricsRef} style={{ width: constrictorSizes.width }}>
                 <Paper className={classes.paper}>
-                  <Metrics />
+                  <Metrics indexedMetrics={indexedMetrics} />
                 </Paper>
                 <div className={classes.formPartActions}>
                   <Button onClick={prevStage}>Previous</Button>

--- a/components/experiment-creation/Metrics.test.tsx
+++ b/components/experiment-creation/Metrics.test.tsx
@@ -3,9 +3,25 @@ import { Formik } from 'formik'
 import React from 'react'
 
 import { createNewExperiment } from '@/lib/experiments'
+import { MetricBare, MetricParameterType } from '@/lib/schemas'
 import { render } from '@/test-helpers/test-utils'
 
 import Metrics from './Metrics'
+
+const indexedMetrics: Record<number, MetricBare> = {
+  1: {
+    metricId: 1,
+    name: 'asdf_7d_refund',
+    description: 'string',
+    parameterType: MetricParameterType.Revenue,
+  },
+  2: {
+    metricId: 2,
+    name: 'registration_start',
+    description: 'string',
+    parameterType: MetricParameterType.Conversion,
+  },
+}
 
 test('renders as expected', () => {
   const { container } = render(
@@ -16,7 +32,7 @@ test('renders as expected', () => {
         () => undefined
       }
     >
-      {() => <Metrics />}
+      {() => <Metrics indexedMetrics={indexedMetrics} />}
     </Formik>,
   )
   expect(container).toMatchSnapshot()
@@ -31,7 +47,7 @@ test('allows adding, editing and removing a Metric Assignment', async () => {
         () => undefined
       }
     >
-      {() => <Metrics />}
+      {() => <Metrics indexedMetrics={indexedMetrics} />}
     </Formik>,
   )
   expect(container).toMatchSnapshot()
@@ -82,7 +98,10 @@ test('allows adding, editing and removing a Metric Assignment', async () => {
   fireEvent.click(metricSearchField)
   fireEvent.keyDown(metricSearchField, { key: 'Enter' })
   fireEvent.click(await screen.findByRole('option', { name: /registration_start/ }))
-  fireEvent.click(metricAddButton)
+  // eslint-disable-next-line @typescript-eslint/require-await
+  await act(async () => {
+    fireEvent.click(metricAddButton)
+  })
 
   expect(container).toMatchSnapshot()
 })

--- a/components/experiment-creation/Metrics.tsx
+++ b/components/experiment-creation/Metrics.tsx
@@ -26,21 +26,6 @@ import { AttributionWindowSecondsToHuman } from '@/lib/metric-assignments'
 import MoreMenu from '@/components/MoreMenu'
 import { Add } from '@material-ui/icons'
 
-const normalizedMetrics: Record<number, MetricBare> = {
-  1: {
-    metricId: 1,
-    name: 'asdf_7d_refund',
-    description: 'string',
-    parameterType: MetricParameterType.Revenue,
-  },
-  2: {
-    metricId: 2,
-    name: 'registration_start',
-    description: 'string',
-    parameterType: MetricParameterType.Conversion,
-  },
-}
-
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {},
@@ -93,7 +78,7 @@ const createMetricAssignment = (metric: MetricBare) => {
   }
 }
 
-const Metrics = () => {
+const Metrics = ({ indexedMetrics }: { indexedMetrics: Record<number, MetricBare> }) => {
   const classes = useStyles()
 
   const [metricAssignmentsField, _metricAssignmentsFieldMetaProps, metricAssignmentsFieldHelperProps] = useField<
@@ -124,7 +109,7 @@ const Metrics = () => {
         render={(arrayHelpers) => {
           const onAddMetric = () => {
             const metricId = parseInt(selectedMetricId, 10)
-            const metric = normalizedMetrics[metricId]
+            const metric = indexedMetrics[metricId]
             if (metricId) {
               const metricAssignment = createMetricAssignment(metric)
               arrayHelpers.push({
@@ -161,9 +146,9 @@ const Metrics = () => {
                       return (
                         <TableRow key={index}>
                           <TableCell>
-                            <Tooltip arrow title={normalizedMetrics[metricAssignment.metricId].description}>
+                            <Tooltip arrow title={indexedMetrics[metricAssignment.metricId].description}>
                               <span className={classes.metricName}>
-                                {normalizedMetrics[metricAssignment.metricId].name}
+                                {indexedMetrics[metricAssignment.metricId].name}
                               </span>
                             </Tooltip>
                             <br />
@@ -210,7 +195,7 @@ const Metrics = () => {
                               variant='outlined'
                               placeholder='-'
                               InputProps={
-                                normalizedMetrics[metricAssignment.metricId].parameterType ===
+                                indexedMetrics[metricAssignment.metricId].parameterType ===
                                 MetricParameterType.Conversion
                                   ? {
                                       endAdornment: (
@@ -263,7 +248,7 @@ const Metrics = () => {
                     <MenuItem value=''>
                       <span className={classes.addMetricPlaceholder}>Select a Metric</span>
                     </MenuItem>
-                    {Object.values(normalizedMetrics).map((metric) => (
+                    {Object.values(indexedMetrics).map((metric) => (
                       <MenuItem value={metric.metricId} key={metric.metricId}>
                         {metric.name}
                       </MenuItem>


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
Pretty straight forwardly populates the field from the server
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Part of a series on #9

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
- Manual testing with mock data (locally or on Vercel)
