### PR TITLE
Add config and refactor auth code

### DIFF
--- a/api/utils.ts
+++ b/api/utils.ts
@@ -1,10 +1,8 @@
+import { config } from '@/config'
 import { getExperimentsAuthInfo } from '@/utils/auth'
 
 import NotFoundError from './NotFoundError'
 import UnauthorizedError from './UnauthorizedError'
-
-const DEVELOPMENT_API_URL_ROOT = 'https://virtserver.swaggerhub.com/yanir/experiments/0.1.0'
-const PRODUCTION_API_URL_ROOT = 'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0'
 
 /**
  * Makes a request to the Experiment Platform's API with any necessary
@@ -17,11 +15,11 @@ const PRODUCTION_API_URL_ROOT = 'https://public-api.wordpress.com/wpcom/v2/exper
  */
 async function fetchApi(method: string, path: string, body: unknown | null = null) {
   /* istanbul ignore next; code branch not reachable in integration tests -- we don't hit production */
-  const apiUrlRoot = window.location.host === 'experiments.a8c.com' ? PRODUCTION_API_URL_ROOT : DEVELOPMENT_API_URL_ROOT
+  const apiUrlRoot = config.experimentApi.rootUrl
 
   const headers = new Headers()
   /* istanbul ignore next; code branch not reachable in integration tests -- we don't hit production */
-  if (apiUrlRoot === PRODUCTION_API_URL_ROOT) {
+  if (config.experimentApi.needsAuth) {
     const accessToken = getExperimentsAuthInfo()?.accessToken
     if (!accessToken) {
       throw new UnauthorizedError()

--- a/components/Layout.test.tsx
+++ b/components/Layout.test.tsx
@@ -19,35 +19,35 @@ test('renders layout with declared title and children', () => {
   // new links, are being tested.
   expect(headerElmt).toMatchInlineSnapshot(`
     <header
-      class="MuiPaper-root MuiAppBar-root MuiAppBar-positionRelative MuiAppBar-colorPrimary makeStyles-appBar-2 MuiPaper-elevation4"
+      class="MuiPaper-root MuiAppBar-root MuiAppBar-positionRelative MuiAppBar-colorPrimary makeStyles-appBar-3 MuiPaper-elevation4"
     >
       <div
-        class="makeStyles-appBarTop-4"
+        class="makeStyles-appBarTop-5"
       >
         <a
-          class="MuiContainer-root makeStyles-appLogotype-6 MuiContainer-maxWidthXl"
+          class="MuiContainer-root makeStyles-appLogotype-7 MuiContainer-maxWidthXl"
           href="/"
         >
           <img
             alt="logo"
-            class="makeStyles-appLogo-5"
+            class="makeStyles-appLogo-6"
             src="/img/logo.png"
           />
           <span
-            class="makeStyles-appName-7"
+            class="makeStyles-appName-8"
           >
             Abacus
           </span>
         </a>
       </div>
       <div
-        class="makeStyles-appBarBottom-3"
+        class="makeStyles-appBarBottom-4"
       >
         <div
           class="MuiContainer-root MuiContainer-maxWidthXl"
         >
           <nav
-            class="makeStyles-appNav-8"
+            class="makeStyles-appNav-9"
           >
             <a
               href="/experiments"
@@ -74,7 +74,7 @@ test('renders layout with declared title and children', () => {
   expect(footerElmt).not.toBeNull()
   expect(footerElmt).toMatchInlineSnapshot(`
     <footer
-      class="makeStyles-footer-11"
+      class="makeStyles-footer-12"
     >
       <div
         class="MuiContainer-root MuiContainer-maxWidthLg"

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -84,11 +84,14 @@ const Layout = ({ title, children }: { title: string; children?: ReactNode }) =>
         <meta name='viewport' content='initial-scale=1.0, width=device-width' />
       </Head>
       <AppBar position='relative' className={classes.appBar}>
-        {isTestingProductionConfigInDevelopment && (
-          <div className={classes.productionConfigInDevelopmentBar}>
-            <Typography variant='body1'> Using production config in development </Typography>
-          </div>
-        )}
+        {
+          // istanbul ignore next; Development only
+          isTestingProductionConfigInDevelopment && (
+            <div className={classes.productionConfigInDevelopmentBar}>
+              <Typography variant='body1'> Using production config in development </Typography>
+            </div>
+          )
+        }
         <div className={classes.appBarTop}>
           <Container maxWidth='xl' component='a' className={classes.appLogotype} href='/'>
             <img alt='logo' className={classes.appLogo} src='/img/logo.png' />

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -4,12 +4,23 @@ import Head from 'next/head'
 import Link from 'next/link'
 import React, { ReactNode } from 'react'
 
+import { isTestingProductionConfigInDevelopment } from '@/config'
+
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       display: 'flex',
       flexDirection: 'column',
       minHeight: '100vh',
+    },
+
+    productionConfigInDevelopmentBar: {
+      flexStretch: 0,
+      padding: theme.spacing(1, 0),
+      background: theme.palette.error.light,
+      color: theme.palette.error.contrastText,
+      textTransform: 'uppercase',
+      textAlign: 'center',
     },
 
     // AppBar
@@ -73,6 +84,11 @@ const Layout = ({ title, children }: { title: string; children?: ReactNode }) =>
         <meta name='viewport' content='initial-scale=1.0, width=device-width' />
       </Head>
       <AppBar position='relative' className={classes.appBar}>
+        {isTestingProductionConfigInDevelopment && (
+          <div className={classes.productionConfigInDevelopmentBar}>
+            <Typography variant='body1'> Using production config in development </Typography>
+          </div>
+        )}
         <div className={classes.appBarTop}>
           <Container maxWidth='xl' component='a' className={classes.appLogotype} href='/'>
             <img alt='logo' className={classes.appLogo} src='/img/logo.png' />

--- a/config.test.ts
+++ b/config.test.ts
@@ -1,0 +1,7 @@
+import { isTestingProductionConfigInDevelopment } from './config'
+
+describe('/config', () => {
+  it(`should not be using production config in development mode`, () => {
+    expect(isTestingProductionConfigInDevelopment).toBe(false)
+  })
+})

--- a/config.ts
+++ b/config.ts
@@ -20,4 +20,5 @@ export const isTestingProductionConfigInDevelopment = false
 
 const isProduction = false
 
+// istanbul ignore next; Development only
 export const config = isProduction || isTestingProductionConfigInDevelopment ? productionConfig : developmentConfig

--- a/config.ts
+++ b/config.ts
@@ -1,0 +1,23 @@
+const productionConfig = {
+  experimentApi: {
+    needsAuth: true,
+    authPath: 'https://public-api.wordpress.com/oauth2/authorize',
+    authClientId: 68795,
+    rootUrl: 'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0',
+  },
+}
+
+const developmentConfig = {
+  experimentApi: {
+    needsAuth: false,
+    authPath: null,
+    authClientId: 68797,
+    rootUrl: 'https://virtserver.swaggerhub.com/yanir/experiments/0.1.0',
+  },
+}
+
+export const isTestingProductionConfigInDevelopment = false
+
+const isProduction = false
+
+export const config = isProduction || isTestingProductionConfigInDevelopment ? productionConfig : developmentConfig

--- a/config.ts
+++ b/config.ts
@@ -18,7 +18,7 @@ const developmentConfig = {
 
 export const isTestingProductionConfigInDevelopment = false
 
-const isProduction = false
+const isProduction = process.env.NODE_ENV === 'production'
 
 // istanbul ignore next; Development only
 export const config = isProduction || isTestingProductionConfigInDevelopment ? productionConfig : developmentConfig

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,7 +8,7 @@ import * as yup from 'yup'
 import RenderErrorBoundary from '@/components/RenderErrorBoundary'
 import RenderErrorView from '@/components/RenderErrorView'
 import ThemeProvider from '@/styles/ThemeProvider'
-import { initializeExperimentsAuthentication } from '@/utils/auth'
+import { initializeExperimentsAuth } from '@/utils/auth'
 
 const debug = debugFactory('abacus:pages/_app.tsx')
 
@@ -91,7 +91,7 @@ const App = React.memo(function App(props: AppProps) {
     }
   }, [])
 
-  initializeExperimentsAuthentication()
+  initializeExperimentsAuth()
 
   return (
     <RenderErrorBoundary>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,14 +2,13 @@ import { makeStyles } from '@material-ui/core/styles'
 import debugFactory from 'debug'
 import { AppProps } from 'next/app'
 import { SnackbarProvider } from 'notistack'
-import qs from 'querystring'
 import React from 'react'
 import * as yup from 'yup'
 
 import RenderErrorBoundary from '@/components/RenderErrorBoundary'
 import RenderErrorView from '@/components/RenderErrorView'
 import ThemeProvider from '@/styles/ThemeProvider'
-import { getAuthClientId, getExperimentsAuthInfo, saveExperimentsAuthInfo } from '@/utils/auth'
+import { initializeExperimentsAuthentication } from '@/utils/auth'
 
 const debug = debugFactory('abacus:pages/_app.tsx')
 
@@ -92,33 +91,7 @@ const App = React.memo(function App(props: AppProps) {
     }
   }, [])
 
-  if (typeof window !== 'undefined') {
-    // Inject a fake auth token to skip authentication in non-production contexts.
-    // This is a temporary solution. Ideally, we should test the full authentication flow in every environment.
-    if (window.location.host !== 'experiments.a8c.com') {
-      saveExperimentsAuthInfo({
-        accessToken: 'fake_token',
-        expiresAt: Date.parse('2100-01-01'),
-        scope: 'global',
-        type: 'bearer',
-      })
-    }
-
-    // Prompt user for authorization if we don't have auth info.
-    const experimentsAuthInfo = getExperimentsAuthInfo()
-    if (!experimentsAuthInfo) {
-      const authPath = 'https://public-api.wordpress.com/oauth2/authorize'
-      const authQuery = {
-        client_id: getAuthClientId(window.location.host),
-        redirect_uri: `${window.location.origin}/auth`,
-        response_type: 'token',
-        scope: 'global',
-      }
-
-      const authUrl = `${authPath}?${qs.stringify(authQuery)}`
-      window.location.replace(authUrl)
-    }
-  }
+  initializeExperimentsAuthentication()
 
   return (
     <RenderErrorBoundary>

--- a/pages/auth.tsx
+++ b/pages/auth.tsx
@@ -1,9 +1,7 @@
 import debugFactory from 'debug'
-import { toInt } from 'qc-to_int'
-import qs from 'querystring'
 import React, { useEffect, useState } from 'react'
 
-import { saveExperimentsAuthInfo } from '@/utils/auth'
+import { AuthError, onExperimentAuthCallbackUrl } from '@/utils/auth'
 
 const debug = debugFactory('abacus:pages/auth.tsx')
 
@@ -17,33 +15,9 @@ const AuthPage = function AuthPage() {
   debug('AuthPage#render')
   const [error, setError] = useState<null | string>(null)
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      // If we have the hash with the authorization info, then extract the info, save
-      // it for later, and go to the "home" page.
-      //
-      // The hash should look something like the following upon success:
-      // #access_token=...&expires_in=#######&scope=global&site_id=0&token_type=bearer
-      // The hash should look something like the following upon failure:
-      // #error=access_denied&error_description=You+need+to+log+in+to+WordPress.com&state=
-      if (window.location.hash && window.location.hash.length > 1) {
-        const authInfo = qs.parse(window.location.hash.substring(1))
-        if (authInfo.access_token && authInfo.scope === 'global' && authInfo.token_type === 'bearer') {
-          const expiresInSeconds = toInt(authInfo.expires_in)
-          const experimentsAuthInfo = {
-            accessToken: authInfo.access_token as string,
-            expiresAt: typeof expiresInSeconds === 'number' ? Date.now() + expiresInSeconds * 1000 : null,
-            scope: 'global',
-            type: 'bearer',
-          }
-          saveExperimentsAuthInfo(experimentsAuthInfo)
-
-          window.location.replace(window.location.origin)
-        } else if (authInfo.error === 'access_denied') {
-          setError('Please log into WordPress.com and authorize Abacus - Testing to have access.')
-
-          saveExperimentsAuthInfo(null)
-        }
-      }
+    const error = onExperimentAuthCallbackUrl()
+    if (error === AuthError.AccessDenied) {
+      setError('Please log into WordPress.com and authorize Abacus - Testing to have access.')
     }
   }, [])
 

--- a/pages/auth.tsx
+++ b/pages/auth.tsx
@@ -1,3 +1,4 @@
+import { CircularProgress, Container, createStyles, makeStyles, Theme, Typography } from '@material-ui/core'
 import debugFactory from 'debug'
 import React, { useEffect, useState } from 'react'
 
@@ -5,14 +6,35 @@ import { AuthError, onExperimentAuthCallbackUrl } from '@/utils/auth'
 
 const debug = debugFactory('abacus:pages/auth.tsx')
 
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+      alignContent: 'center',
+      alignItems: 'center',
+      textAlign: 'center',
+      height: '100vh',
+    },
+    progress: {
+      marginTop: theme.spacing(3),
+    },
+  }),
+)
+
 /**
  * The authorization page.
+ *
+ * TODO: It is better to have this at /auth-callback
  *
  * Note: This relies upon the fact that `pages/_app.tsx` will redirect the user to
  * the OAuth authorize page.
  */
 const AuthPage = function AuthPage() {
   debug('AuthPage#render')
+  const classes = useStyles()
+
   const [error, setError] = useState<null | string>(null)
   useEffect(() => {
     const error = onExperimentAuthCallbackUrl()
@@ -32,21 +54,17 @@ const AuthPage = function AuthPage() {
   }, [])
 
   return (
-    <>
-      {/*
-      Note: This error message will only be shown briefly as the user is automatically
-      redirected to the OAuth authorize page.
-      */}
-      {error ? (
-        <>
-          <div>{error}</div>
-          <div>Redirecting...</div>
-          <div>TODO: Replace with nicer UI once auth foundation is in place.</div>
-        </>
-      ) : (
-        <div>TODO: Replace with a loading component.</div>
+    <Container className={classes.root}>
+      <Typography variant='h4' gutterBottom>
+        Authorizing
+      </Typography>
+      {error && (
+        <Typography variant='body1' gutterBottom>
+          <strong>Oops! Something went wrong:</strong> {error}
+        </Typography>
       )}
-    </>
+      <CircularProgress className={classes.progress} />
+    </Container>
   )
 }
 

--- a/pages/auth.tsx
+++ b/pages/auth.tsx
@@ -16,8 +16,18 @@ const AuthPage = function AuthPage() {
   const [error, setError] = useState<null | string>(null)
   useEffect(() => {
     const error = onExperimentAuthCallbackUrl()
-    if (error === AuthError.AccessDenied) {
-      setError('Please log into WordPress.com and authorize Abacus - Testing to have access.')
+    switch (error) {
+      case AuthError.AccessDenied: {
+        setError('Please log into WordPress.com and authorize Abacus - Testing to have access.')
+        break
+      }
+      case AuthError.UnknownError: {
+        setError('An unknown error has occured. Check the console for more information.')
+        break
+      }
+      default: {
+        return
+      }
     }
   }, [])
 

--- a/utils/auth.test.ts
+++ b/utils/auth.test.ts
@@ -1,21 +1,10 @@
 import addToDate from 'date-fns/add'
 
-import { getAuthClientId, getExperimentsAuthInfo, saveExperimentsAuthInfo } from './auth'
+import { getExperimentsAuthInfo, saveExperimentsAuthInfo } from './auth'
 
 describe('utils/auth.ts module', () => {
   afterEach(() => {
     window.localStorage.clear()
-  })
-
-  describe('getAuthClientId', () => {
-    it('should return 68795 for host experiments.a8c.com but 68797 for all other host', () => {
-      expect(getAuthClientId('experiments.a8c.com')).toBe(68795)
-      expect(getAuthClientId('http://a8c-abacus-local:3001')).toBe(68797)
-      expect(getAuthClientId('https://a8c-abacus-local:3001')).toBe(68797)
-      expect(getAuthClientId('http://localhost')).toBe(68797)
-      expect(getAuthClientId('http://localhost:3001')).toBe(68797)
-      expect(getAuthClientId('https://localhost')).toBe(68797)
-    })
   })
 
   describe('getExperimentsAuthInfo', () => {

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -3,7 +3,7 @@
  *
  * @param host
  */
-const getAuthClientId = (host: string) => {
+export const getAuthClientId = (host: string) => {
   return host === 'experiments.a8c.com' ? 68795 : 68797
 }
 
@@ -21,7 +21,7 @@ interface ExperimentsAuthInfo {
 /**
  * Returns the saved Experiments authorization info if available and has not expired.
  */
-const getExperimentsAuthInfo = (): ExperimentsAuthInfo | null => {
+export const getExperimentsAuthInfo = (): ExperimentsAuthInfo | null => {
   try {
     const experimentsAuthInfo = JSON.parse(localStorage.getItem('experiments_auth_info') || 'null')
     if (experimentsAuthInfo && experimentsAuthInfo.expiresAt > Date.now()) {
@@ -39,12 +39,10 @@ const getExperimentsAuthInfo = (): ExperimentsAuthInfo | null => {
  *
  * @param {ExperimentsAuthInfo} experimentsAuthInfo
  */
-const saveExperimentsAuthInfo = (experimentsAuthInfo: ExperimentsAuthInfo | null) => {
+export const saveExperimentsAuthInfo = (experimentsAuthInfo: ExperimentsAuthInfo | null) => {
   if (experimentsAuthInfo === null) {
     localStorage.removeItem('experiments_auth_info')
   } else {
     localStorage.setItem('experiments_auth_info', JSON.stringify(experimentsAuthInfo))
   }
 }
-
-export { getAuthClientId, getExperimentsAuthInfo, saveExperimentsAuthInfo }

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -1,3 +1,5 @@
+import qs from 'querystring'
+
 /**
  * Resolves the OAuth client ID based on the host.
  *
@@ -44,5 +46,35 @@ export const saveExperimentsAuthInfo = (experimentsAuthInfo: ExperimentsAuthInfo
     localStorage.removeItem('experiments_auth_info')
   } else {
     localStorage.setItem('experiments_auth_info', JSON.stringify(experimentsAuthInfo))
+  }
+}
+
+export function initializeExperimentsAuthentication() {
+  if (typeof window !== 'undefined') {
+    // Inject a fake auth token to skip authentication in non-production contexts.
+    // This is a temporary solution. Ideally, we should test the full authentication flow in every environment.
+    if (window.location.host !== 'experiments.a8c.com') {
+      saveExperimentsAuthInfo({
+        accessToken: 'fake_token',
+        expiresAt: Date.parse('2100-01-01'),
+        scope: 'global',
+        type: 'bearer',
+      })
+    }
+
+    // Prompt user for authorization if we don't have auth info.
+    const experimentsAuthInfo = getExperimentsAuthInfo()
+    if (!experimentsAuthInfo) {
+      const authPath = 'https://public-api.wordpress.com/oauth2/authorize'
+      const authQuery = {
+        client_id: getAuthClientId(window.location.host),
+        redirect_uri: `${window.location.origin}/auth`,
+        response_type: 'token',
+        scope: 'global',
+      }
+
+      const authUrl = `${authPath}?${qs.stringify(authQuery)}`
+      window.location.replace(authUrl)
+    }
   }
 }

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -43,8 +43,7 @@ export const saveExperimentsAuthInfo = (experimentsAuthInfo: ExperimentsAuthInfo
   }
 }
 
-/* istanbul ignore next; TODO: e2e test authorization */
-export function initializeExperimentsAuth() {
+export /* istanbul ignore next; TODO: e2e test authorization */ function initializeExperimentsAuth() {
   // This is needed because of server-side rendering
   if (typeof window === 'undefined') {
     console.warn('InitializeExperimentAuth: Could not find `window`')
@@ -80,8 +79,7 @@ export enum AuthError {
   UnknownError,
 }
 
-/* istanbul ignore next; TODO: e2e test authorization */
-export function onExperimentAuthCallbackUrl(): void | AuthError {
+export /* istanbul ignore next; TODO: e2e test authorization */ function onExperimentAuthCallbackUrl(): void | AuthError {
   if (typeof window === 'undefined') {
     console.warn('onExperimentAuthCallbackUrl: Could not find `window`')
     return

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -1,3 +1,4 @@
+import { toInt } from 'qc-to_int'
 import qs from 'querystring'
 
 import { config } from '../config'
@@ -72,4 +73,46 @@ export function initializeExperimentsAuth() {
   console.info('InitializeExperimentAuth: Could not find existing auth info, re-authing.')
   const authUrl = `${config.experimentApi.authPath}?${qs.stringify(authQuery)}`
   window.location.replace(authUrl)
+}
+
+export enum AuthError {
+  AccessDenied,
+}
+
+/* istanbul ignore next; TODO: e2e test authorization */
+export function onExperimentAuthCallbackUrl(): void | AuthError {
+  if (typeof window === 'undefined') {
+    console.warn('onExperimentAuthCallbackUrl: Could not find `window`')
+    return
+  }
+
+  if (!window.location.hash || window.location.hash.length === 0) {
+    throw new Error('Missing hash in auth callback url.')
+  }
+
+  // If we have the hash with the authorization info, then extract the info, save
+  // it for later, and go to the "home" page.
+  //
+  // The hash should look something like the following upon success:
+  // #access_token=...&expires_in=#######&scope=global&site_id=0&token_type=bearer
+  // The hash should look something like the following upon failure:
+  // #error=access_denied&error_description=You+need+to+log+in+to+WordPress.com&state=
+  const authInfo = qs.parse(window.location.hash.substring(1))
+  if (authInfo.error === 'access_denied') {
+    saveExperimentsAuthInfo(null)
+    return AuthError.AccessDenied
+  }
+
+  if (authInfo.access_token && authInfo.scope === 'global' && authInfo.token_type === 'bearer') {
+    const expiresInSeconds = toInt(authInfo.expires_in)
+    const experimentsAuthInfo = {
+      accessToken: authInfo.access_token as string,
+      expiresAt: typeof expiresInSeconds === 'number' ? Date.now() + expiresInSeconds * 1000 : null,
+      scope: 'global',
+      type: 'bearer',
+    }
+    saveExperimentsAuthInfo(experimentsAuthInfo)
+
+    window.location.replace(window.location.origin)
+  }
 }

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -77,6 +77,7 @@ export function initializeExperimentsAuth() {
 
 export enum AuthError {
   AccessDenied,
+  UnknownError,
 }
 
 /* istanbul ignore next; TODO: e2e test authorization */
@@ -87,7 +88,8 @@ export function onExperimentAuthCallbackUrl(): void | AuthError {
   }
 
   if (!window.location.hash || window.location.hash.length === 0) {
-    throw new Error('Missing hash in auth callback url.')
+    console.error('Authentication Error:', 'Missing hash in auth callback url.')
+    return AuthError.UnknownError
   }
 
   // If we have the hash with the authorization info, then extract the info, save
@@ -98,9 +100,18 @@ export function onExperimentAuthCallbackUrl(): void | AuthError {
   // The hash should look something like the following upon failure:
   // #error=access_denied&error_description=You+need+to+log+in+to+WordPress.com&state=
   const authInfo = qs.parse(window.location.hash.substring(1))
-  if (authInfo.error === 'access_denied') {
+
+  if (authInfo.error) {
+    console.error('Authentication Error:', authInfo.error, authInfo.error_description)
     saveExperimentsAuthInfo(null)
-    return AuthError.AccessDenied
+    switch (authInfo.error) {
+      case 'access_denied': {
+        return AuthError.AccessDenied
+      }
+      default: {
+        return AuthError.UnknownError
+      }
+    }
   }
 
   if (authInfo.access_token && authInfo.scope === 'global' && authInfo.token_type === 'bearer') {


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR refactors the code so we get a nice config object out of it:**
- Move config variables to `/config.ts`
- Add switch to change to Production config in development mode 
- Add warning banner for working with production.

While I was there I refactored the auth code:
- Centralise auth code in `/utils/auth.ts`
- Better error checking (It would miss anything other than `access_denied` before.)
- Styled the Auth page

Fixes #228 


I've seen some discussion about e2e testing auth flow with pbmo2S-kn-p2, it looks like it was never in use.
In the future we should add a third profile to config for testing auth.

<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with mock server
- Manual testing with production server