### PR TITLE
Disable '/' redirect testing

### DIFF
--- a/e2e/navigation.test.tsx
+++ b/e2e/navigation.test.tsx
@@ -5,7 +5,8 @@ export {}
 jest.setTimeout(30000)
 
 describe('Dashboard', () => {
-  it('should redirect to /experiments', async () => {
+  // This test is disabled as it is susceptible to race conditions
+  xit('should redirect to /experiments', async () => {
     await page.goto('http://a8c-abacus-local:3001')
 
     // Sometimes the redirect has not occurred yet. So, we need to wait.

--- a/e2e/smoke.test.tsx
+++ b/e2e/smoke.test.tsx
@@ -15,16 +15,9 @@ describe('Experiments', () => {
   })
 
   // In non-production contexts, we should see the main page immediately.
-  it('should skip authentication and show the main page.', async () => {
-    await page.goto('http://a8c-abacus-local:3001')
+  it('should skip authentication and show the experiments page.', async () => {
+    await page.goto('http://a8c-abacus-local:3001/experiments')
 
-    // Sometimes the redirect has not occurred yet. So, we need to wait.
-    if (new URL(page.url()).pathname === '/') {
-      await page.waitForNavigation({ timeout: 2000 })
-    }
-
-    // We should arrive at the '/experiments' list
-    expect(new URL(page.url()).pathname).toBe('/experiments')
     await expect(page.title()).resolves.toMatch('Experiments | Abacus')
     // TODO: make more interesting assertions once there is more content to display
   })


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR disables testing of the redirect from '/' to '/experiments'.**

As per https://github.com/Automattic/abacus/pull/253#issuecomment-668939333
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
- Automated tests that cover added/changed functionality
