### PR TITLE
Allow a wider max width for long metric names

### DIFF
--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -101,7 +101,7 @@ const useStyles = makeStyles((theme: Theme) =>
       padding: theme.spacing(2, 1),
     },
     formPartActions: {
-      maxWidth: 800,
+      maxWidth: 950,
       display: 'flex',
       justifyContent: 'flex-end',
       '& .MuiButton-root': {
@@ -109,7 +109,7 @@ const useStyles = makeStyles((theme: Theme) =>
       },
     },
     paper: {
-      maxWidth: 800,
+      maxWidth: 950,
       padding: theme.spacing(3, 4),
       marginBottom: theme.spacing(2),
     },


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**In production there are some very long metric names, this PR allows the form to widen further.**
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
