### PR TITLE
Refactor experiment pages

### DIFF
--- a/components/ExperimentPageView.tsx
+++ b/components/ExperimentPageView.tsx
@@ -1,0 +1,92 @@
+// istanbul ignore file; Even though it sits with components this is a "page" component
+import { createStyles, LinearProgress, makeStyles, Theme } from '@material-ui/core'
+import _ from 'lodash'
+import React from 'react'
+
+import AnalysesApi from '@/api/AnalysesApi'
+import ExperimentsApi from '@/api/ExperimentsApi'
+import MetricsApi from '@/api/MetricsApi'
+import SegmentsApi from '@/api/SegmentsApi'
+import ExperimentResults from '@/components/experiment-results/ExperimentResults'
+import ExperimentDetails from '@/components/ExperimentDetails'
+import ExperimentTabs from '@/components/ExperimentTabs'
+import Layout from '@/components/Layout'
+import { Analysis, ExperimentFull } from '@/lib/schemas'
+import { useDataLoadingError, useDataSource } from '@/utils/data-loading'
+import { createUnresolvingPromise, or } from '@/utils/general'
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    viewTabs: {
+      marginBottom: theme.spacing(2),
+    },
+  }),
+)
+
+export enum ExperimentView {
+  Details = 'details',
+  Results = 'results',
+  Snippets = 'snippets',
+}
+
+export default function ExperimentPageView({
+  view,
+  experimentId,
+  debugMode,
+}: {
+  view: ExperimentView
+  experimentId: number
+  debugMode: boolean
+}) {
+  const classes = useStyles()
+
+  const { isLoading: experimentIsLoading, data: experiment, error: experimentError } = useDataSource(
+    () => (experimentId ? ExperimentsApi.findById(experimentId) : createUnresolvingPromise<ExperimentFull>()),
+    [experimentId],
+  )
+  useDataLoadingError(experimentError, 'Experiment')
+
+  const { isLoading: metricsIsLoading, data: metrics, error: metricsError } = useDataSource(
+    () => MetricsApi.findAll(),
+    [],
+  )
+  useDataLoadingError(metricsError, 'Metrics')
+
+  const { isLoading: segmentsIsLoading, data: segments, error: segmentsError } = useDataSource(
+    () => SegmentsApi.findAll(),
+    [],
+  )
+  useDataLoadingError(segmentsError, 'Segments')
+
+  const { isLoading: analysesIsLoading, data: analyses, error: analysesError } = useDataSource(
+    () => (experimentId ? AnalysesApi.findByExperimentId(experimentId) : createUnresolvingPromise<Analysis[]>()),
+    [experimentId],
+  )
+  useDataLoadingError(analysesError, 'Analyses')
+
+  const isLoading = or(experimentIsLoading, metricsIsLoading, segmentsIsLoading, analysesIsLoading)
+
+  return (
+    <Layout title={`Experiment: ${experiment?.name || ''}`}>
+      <>
+        {/* TODO: Inline this. */}
+        <ExperimentTabs experimentId={experimentId} tab={view} className={classes.viewTabs} />
+        {isLoading ? (
+          <LinearProgress />
+        ) : (
+          experiment &&
+          metrics &&
+          segments &&
+          analyses && (
+            <>
+              {view === ExperimentView.Details && <ExperimentDetails {...{ experiment, metrics, segments }} />}
+              {view === ExperimentView.Results && (
+                <ExperimentResults {...{ experiment, metrics, analyses, debugMode }} />
+              )}
+            </>
+          )
+        )}
+      </>
+    </Layout>
+  )
+}

--- a/components/ExperimentTabs.test.tsx
+++ b/components/ExperimentTabs.test.tsx
@@ -10,7 +10,7 @@ test('renders expected links', () => {
     metricAssignments: [],
     segmentAssignments: [],
   })
-  const { getByText } = render(<ExperimentTabs experiment={experiment} tab='details' />)
+  const { getByText } = render(<ExperimentTabs experimentId={experiment.experimentId} tab='details' />)
 
   expect(getByText('Details', { selector: '.MuiTab-wrapper' })).toBeInTheDocument()
   expect(getByText('Results', { selector: '.MuiTab-wrapper' })).toBeInTheDocument()

--- a/components/ExperimentTabs.tsx
+++ b/components/ExperimentTabs.tsx
@@ -4,8 +4,6 @@ import Tabs from '@material-ui/core/Tabs'
 import { useRouter } from 'next/router'
 import React, { ReactNode } from 'react'
 
-import { ExperimentFull } from '@/lib/schemas'
-
 const useStyles = makeStyles(() =>
   createStyles({
     tab: {
@@ -38,24 +36,24 @@ function LinkTab({ as, label, url, value }: { as?: string; label: ReactNode; url
  */
 export default function ExperimentTabs({
   className,
-  experiment,
+  experimentId,
   tab,
 }: {
   className?: string
-  experiment: ExperimentFull
+  experimentId: number
   tab: 'details' | 'results' | 'snippets'
 }) {
   return (
     <Tabs className={className} value={tab}>
-      <LinkTab as={`/experiments/${experiment.experimentId}`} label='Details' value='details' url='/experiments/[id]' />
+      <LinkTab as={`/experiments/${experimentId}`} label='Details' value='details' url='/experiments/[id]' />
       <LinkTab
-        as={`/experiments/${experiment.experimentId}/results`}
+        as={`/experiments/${experimentId}/results`}
         label='Results'
         value='results'
         url='/experiments/[id]/results'
       />
       <LinkTab
-        as={`/experiments/${experiment.experimentId}/snippets`}
+        as={`/experiments/${experimentId}/snippets`}
         label='Snippets'
         value='snippets'
         url='/experiments/[id]/snippets'

--- a/pages/experiments/[id].tsx
+++ b/pages/experiments/[id].tsx
@@ -1,70 +1,21 @@
-import { LinearProgress } from '@material-ui/core'
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import debugFactory from 'debug'
 import { useRouter } from 'next/router'
 import { toIntOrNull } from 'qc-to_int'
 import React from 'react'
 
-import ExperimentsApi from '@/api/ExperimentsApi'
-import MetricsApi from '@/api/MetricsApi'
-import SegmentsApi from '@/api/SegmentsApi'
-import ExperimentDetails from '@/components/ExperimentDetails'
-import ExperimentTabs from '@/components/ExperimentTabs'
-import Layout from '@/components/Layout'
-import { ExperimentFull } from '@/lib/schemas'
-import { useDataLoadingError, useDataSource } from '@/utils/data-loading'
-import { createUnresolvingPromise, or } from '@/utils/general'
+import ExperimentPageView, { ExperimentView } from '@/components/ExperimentPageView'
 
 const debug = debugFactory('abacus:pages/experiments/[id].tsx')
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    tabs: {
-      marginBottom: theme.spacing(2),
-    },
-  }),
-)
-
 export default function ExperimentPage() {
-  const classes = useStyles()
   const router = useRouter()
   const experimentId = toIntOrNull(router.query.id)
+  const debugMode = router.query.debug === 'true'
   debug(`ExperimentPage#render ${experimentId}`)
 
-  const { isLoading: experimentIsLoading, data: experiment, error: experimentError } = useDataSource(
-    () => (experimentId ? ExperimentsApi.findById(experimentId) : createUnresolvingPromise<ExperimentFull>()),
-    [experimentId],
-  )
-  useDataLoadingError(experimentError, 'Experiment')
+  if (!experimentId) {
+    return null
+  }
 
-  const { isLoading: metricsIsLoading, data: metrics, error: metricsError } = useDataSource(
-    () => MetricsApi.findAll(),
-    [],
-  )
-  useDataLoadingError(metricsError, 'Metrics')
-
-  const { isLoading: segmentsIsLoading, data: segments, error: segmentsError } = useDataSource(
-    () => SegmentsApi.findAll(),
-    [],
-  )
-  useDataLoadingError(segmentsError, 'Segments')
-
-  const isLoading = or(experimentIsLoading, metricsIsLoading, segmentsIsLoading)
-
-  return (
-    <Layout title={`Experiment: ${experiment?.name || ''}`}>
-      {isLoading ? (
-        <LinearProgress />
-      ) : (
-        experiment &&
-        metrics &&
-        segments && (
-          <>
-            <ExperimentTabs className={classes.tabs} experiment={experiment} tab='details' />
-            <ExperimentDetails experiment={experiment} metrics={metrics} segments={segments} />
-          </>
-        )
-      )}
-    </Layout>
-  )
+  return <ExperimentPageView {...{ experimentId, debugMode }} view={ExperimentView.Details} />
 }

--- a/pages/experiments/[id]/results.tsx
+++ b/pages/experiments/[id]/results.tsx
@@ -1,65 +1,21 @@
-import { LinearProgress } from '@material-ui/core'
 import debugFactory from 'debug'
 import { useRouter } from 'next/router'
 import { toIntOrNull } from 'qc-to_int'
 import React from 'react'
 
-import AnalysesApi from '@/api/AnalysesApi'
-import ExperimentsApi from '@/api/ExperimentsApi'
-import MetricsApi from '@/api/MetricsApi'
-import ExperimentResults from '@/components/experiment-results/ExperimentResults'
-import ExperimentTabs from '@/components/ExperimentTabs'
-import Layout from '@/components/Layout'
-import { Analysis, ExperimentFull } from '@/lib/schemas'
-import { useDataLoadingError, useDataSource } from '@/utils/data-loading'
-import { createUnresolvingPromise, or } from '@/utils/general'
+import ExperimentPageView, { ExperimentView } from '@/components/ExperimentPageView'
 
 const debug = debugFactory('abacus:pages/experiments/[id]/results.tsx')
 
 export default function ResultsPage() {
   const router = useRouter()
   const experimentId = toIntOrNull(router.query.id)
-  debug(`ResultPage#render ${experimentId}`)
+  const debugMode = router.query.debug === 'true'
+  debug(`ExperimentResultsPage#render ${experimentId}`)
 
-  const { isLoading: experimentIsLoading, data: experiment, error: experimentError } = useDataSource(
-    () => (experimentId ? ExperimentsApi.findById(experimentId) : createUnresolvingPromise<ExperimentFull>()),
-    [experimentId],
-  )
-  useDataLoadingError(experimentError, 'Experiment')
+  if (!experimentId) {
+    return null
+  }
 
-  const { isLoading: metricsIsLoading, data: metrics, error: metricsError } = useDataSource(
-    () => MetricsApi.findAll(),
-    [],
-  )
-  useDataLoadingError(metricsError, 'Metrics')
-
-  const { isLoading: analysesIsLoading, data: analyses, error: analysesError } = useDataSource(
-    () => (experimentId ? AnalysesApi.findByExperimentId(experimentId) : createUnresolvingPromise<Analysis[]>()),
-    [experimentId],
-  )
-  useDataLoadingError(analysesError, 'Analyses')
-
-  const isLoading = or(experimentIsLoading, metricsIsLoading, analysesIsLoading)
-
-  return (
-    <Layout title={`Experiment: ${experiment?.name || ''}`}>
-      {isLoading ? (
-        <LinearProgress />
-      ) : (
-        experiment &&
-        analyses &&
-        metrics && (
-          <>
-            <ExperimentTabs experiment={experiment} tab='results' />
-            <ExperimentResults
-              analyses={analyses}
-              experiment={experiment}
-              metrics={metrics}
-              debugMode={router.query.debug === 'true'}
-            />
-          </>
-        )
-      )}
-    </Layout>
-  )
+  return <ExperimentPageView {...{ experimentId, debugMode }} view={ExperimentView.Results} />
 }


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**We are duplicating a lot of code between the two experiment pages (soon to be 3 with snippets), this PR refactors them together.**

- Create ExperimentPageView
- Use ExperimentPageView in `/experiments/[id]` and `/experiments/[id]/results`

That the data needs to reload on every tab is a limitation of NextJS's router #212 

<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Exisiting Automated tests
- Manual testing with production data (locally)
- Manual testing with mock data (locally)
