### PR TITLE
Rename experiment details to experiment overview

### DIFF
--- a/components/ExperimentPageView.tsx
+++ b/components/ExperimentPageView.tsx
@@ -26,7 +26,7 @@ const useStyles = makeStyles((theme: Theme) =>
 )
 
 export enum ExperimentView {
-  Details = 'details',
+  Overview = 'overview',
   Results = 'results',
   CodeSetup = 'code-setup',
 }
@@ -81,7 +81,7 @@ export default function ExperimentPageView({
           segments &&
           analyses && (
             <>
-              {view === ExperimentView.Details && <ExperimentDetails {...{ experiment, metrics, segments }} />}
+              {view === ExperimentView.Overview && <ExperimentDetails {...{ experiment, metrics, segments }} />}
               {view === ExperimentView.Results && (
                 <ExperimentResults {...{ experiment, metrics, analyses, debugMode }} />
               )}

--- a/components/ExperimentTabs.test.tsx
+++ b/components/ExperimentTabs.test.tsx
@@ -11,9 +11,9 @@ test('renders expected links', () => {
     metricAssignments: [],
     segmentAssignments: [],
   })
-  const { getByText } = render(<ExperimentTabs experimentId={experiment.experimentId} tab={ExperimentView.Details} />)
+  const { getByText } = render(<ExperimentTabs experimentId={experiment.experimentId} tab={ExperimentView.Overview} />)
 
-  expect(getByText('Details', { selector: '.MuiTab-wrapper' })).toBeInTheDocument()
+  expect(getByText('Overview', { selector: '.MuiTab-wrapper' })).toBeInTheDocument()
   expect(getByText('Results', { selector: '.MuiTab-wrapper' })).toBeInTheDocument()
   expect(getByText('Code Setup', { selector: '.MuiTab-wrapper' })).toBeInTheDocument()
 })

--- a/components/ExperimentTabs.tsx
+++ b/components/ExperimentTabs.tsx
@@ -48,8 +48,8 @@ export default function ExperimentTabs({
   return (
     <Tabs className={className} value={tab}>
       <LinkTab
-        label='Details'
-        value={ExperimentView.Details}
+        label='Overview'
+        value={ExperimentView.Overview}
         url='/experiments/[id]'
         as={`/experiments/${experimentId}`}
       />

--- a/pages/experiments/[id].tsx
+++ b/pages/experiments/[id].tsx
@@ -17,5 +17,5 @@ export default function ExperimentPage() {
     return null
   }
 
-  return <ExperimentPageView {...{ experimentId, debugMode }} view={ExperimentView.Details} />
+  return <ExperimentPageView {...{ experimentId, debugMode }} view={ExperimentView.Overview} />
 }


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
I was finding 'Details' and 'Results' a bit too similar, both imply 'zoomed-in' versions of an experiment.
**This PR suggests 'Overview' instead, best seen in pictures:**

Before:

<img width="1301" alt="Screen Shot 2020-08-11 at 10 05 31 pm" src="https://user-images.githubusercontent.com/971886/89907115-d3470d00-dc1e-11ea-9dd9-641bffdd7bb8.png">

After:

<img width="1307" alt="Screen Shot 2020-08-11 at 10 03 42 pm" src="https://user-images.githubusercontent.com/971886/89906916-89f6bd80-dc1e-11ea-885a-39171d80728b.png">



<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with mock data (locally)
