### PR TITLE
Use Normalized data in ExperimentDetails

### DIFF
--- a/components/AudiencePanel.test.tsx
+++ b/components/AudiencePanel.test.tsx
@@ -9,11 +9,11 @@ import { render } from '@/test-helpers/test-utils'
 import AudiencePanel from './AudiencePanel'
 
 test('renders as expected with no segment assignments', () => {
-  const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(Fixtures.createExperimentFull())
+  const [normalizedExperiment, normalizedExperimentEntities] = normalizeExperiment(Fixtures.createExperimentFull())
   const segments: Segment[] = []
   const indexedSegments = indexSegments(segments)
   const { container } = render(
-    <AudiencePanel {...{ normalizedExperiment, normalizedExperimentData, indexedSegments }} />,
+    <AudiencePanel {...{ normalizedExperiment, normalizedExperimentEntities, indexedSegments }} />,
   )
 
   expect(container).toMatchSnapshot()
@@ -23,11 +23,11 @@ test('renders as expected with existing users allowed', () => {
   const experiment = Fixtures.createExperimentFull({
     existingUsersAllowed: true,
   })
-  const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
+  const [normalizedExperiment, normalizedExperimentEntities] = normalizeExperiment(experiment)
   const segments: Segment[] = []
   const indexedSegments = indexSegments(segments)
   const { container } = render(
-    <AudiencePanel {...{ normalizedExperiment, normalizedExperimentData, indexedSegments }} />,
+    <AudiencePanel {...{ normalizedExperiment, normalizedExperimentEntities, indexedSegments }} />,
   )
 
   expect(container).toMatchSnapshot()
@@ -44,9 +44,9 @@ test('renders as expected with all segments resolvable', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 104, segmentId: 4 }),
     ],
   })
-  const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
+  const [normalizedExperiment, normalizedExperimentEntities] = normalizeExperiment(experiment)
   const { container } = render(
-    <AudiencePanel {...{ normalizedExperiment, normalizedExperimentData, indexedSegments }} />,
+    <AudiencePanel {...{ normalizedExperiment, normalizedExperimentEntities, indexedSegments }} />,
   )
 
   expect(container).toMatchSnapshot()
@@ -64,7 +64,7 @@ test('throws an error when some segments not resolvable', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 110, segmentId: 10 }),
     ],
   })
-  const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
+  const [normalizedExperiment, normalizedExperimentEntities] = normalizeExperiment(experiment)
 
   // Note: This console.error spy is mainly used to suppress the output that the
   // `render` function outputs.
@@ -73,7 +73,7 @@ test('throws an error when some segments not resolvable', () => {
   try {
     render(
       <RenderErrorBoundary>
-        {() => <AudiencePanel {...{ normalizedExperiment, normalizedExperimentData, indexedSegments }} />}
+        {() => <AudiencePanel {...{ normalizedExperiment, normalizedExperimentEntities, indexedSegments }} />}
       </RenderErrorBoundary>,
     )
     expect(false).toBe(true) // Should never be reached

--- a/components/AudiencePanel.test.tsx
+++ b/components/AudiencePanel.test.tsx
@@ -5,10 +5,14 @@ import Fixtures from '@/test-helpers/fixtures'
 import { render } from '@/test-helpers/test-utils'
 
 import AudiencePanel from './AudiencePanel'
+import { normalizeExperiment, indexSegments } from '@/lib/normalizers'
+import { Segment } from '@/lib/schemas'
 
 test('renders as expected with no segment assignments', () => {
-  const experiment = Fixtures.createExperimentFull()
-  const { container } = render(<AudiencePanel experiment={experiment} segments={[]} />)
+  const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(Fixtures.createExperimentFull())
+  const segments: Segment[] = []
+  const indexedSegments = indexSegments(segments)
+  const { container } = render(<AudiencePanel {...{ normalizedExperiment, normalizedExperimentData, indexedSegments }} />)
 
   expect(container).toMatchSnapshot()
 })
@@ -17,13 +21,17 @@ test('renders as expected with existing users allowed', () => {
   const experiment = Fixtures.createExperimentFull({
     existingUsersAllowed: true,
   })
-  const { container } = render(<AudiencePanel experiment={experiment} segments={[]} />)
+  const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
+  const segments: Segment[] = []
+  const indexedSegments = indexSegments(segments)
+  const { container } = render(<AudiencePanel {...{ normalizedExperiment, normalizedExperimentData, indexedSegments }} />)
 
   expect(container).toMatchSnapshot()
 })
 
 test('renders as expected with all segments resolvable', () => {
   const segments = Fixtures.createSegments(5)
+  const indexedSegments = indexSegments(segments)
   const experiment = Fixtures.createExperimentFull({
     segmentAssignments: [
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 101, segmentId: 1 }),
@@ -32,13 +40,15 @@ test('renders as expected with all segments resolvable', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 104, segmentId: 4 }),
     ],
   })
-  const { container } = render(<AudiencePanel experiment={experiment} segments={segments} />)
+  const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
+  const { container } = render(<AudiencePanel {...{ normalizedExperiment, normalizedExperimentData, indexedSegments }} />)
 
   expect(container).toMatchSnapshot()
 })
 
 test('throws an error when some segments not resolvable', () => {
   const segments = Fixtures.createSegments(5)
+  const indexedSegments = indexSegments(segments)
   const experiment = Fixtures.createExperimentFull({
     segmentAssignments: [
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 101, segmentId: 1 }),
@@ -48,14 +58,15 @@ test('throws an error when some segments not resolvable', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 110, segmentId: 10 }),
     ],
   })
+  const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
 
   // Note: This console.error spy is mainly used to suppress the output that the
   // `render` function outputs.
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  const consoleErrorSpy = jest.spyOn(global.console, 'error').mockImplementation(() => {})
+  const consoleErrorSpy = jest.spyOn(global.console, 'error').mockImplementation(() => { })
   try {
     render(
-      <RenderErrorBoundary>{() => <AudiencePanel experiment={experiment} segments={segments} />}</RenderErrorBoundary>,
+      <RenderErrorBoundary>{() => <AudiencePanel {...{ normalizedExperiment, normalizedExperimentData, indexedSegments }} />}</RenderErrorBoundary>,
     )
     expect(false).toBe(true) // Should never be reached
   } catch (err) {

--- a/components/AudiencePanel.test.tsx
+++ b/components/AudiencePanel.test.tsx
@@ -1,18 +1,20 @@
 import React from 'react'
 
 import RenderErrorBoundary from '@/components/RenderErrorBoundary'
+import { indexSegments, normalizeExperiment } from '@/lib/normalizers'
+import { Segment } from '@/lib/schemas'
 import Fixtures from '@/test-helpers/fixtures'
 import { render } from '@/test-helpers/test-utils'
 
 import AudiencePanel from './AudiencePanel'
-import { normalizeExperiment, indexSegments } from '@/lib/normalizers'
-import { Segment } from '@/lib/schemas'
 
 test('renders as expected with no segment assignments', () => {
   const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(Fixtures.createExperimentFull())
   const segments: Segment[] = []
   const indexedSegments = indexSegments(segments)
-  const { container } = render(<AudiencePanel {...{ normalizedExperiment, normalizedExperimentData, indexedSegments }} />)
+  const { container } = render(
+    <AudiencePanel {...{ normalizedExperiment, normalizedExperimentData, indexedSegments }} />,
+  )
 
   expect(container).toMatchSnapshot()
 })
@@ -24,7 +26,9 @@ test('renders as expected with existing users allowed', () => {
   const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
   const segments: Segment[] = []
   const indexedSegments = indexSegments(segments)
-  const { container } = render(<AudiencePanel {...{ normalizedExperiment, normalizedExperimentData, indexedSegments }} />)
+  const { container } = render(
+    <AudiencePanel {...{ normalizedExperiment, normalizedExperimentData, indexedSegments }} />,
+  )
 
   expect(container).toMatchSnapshot()
 })
@@ -41,7 +45,9 @@ test('renders as expected with all segments resolvable', () => {
     ],
   })
   const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
-  const { container } = render(<AudiencePanel {...{ normalizedExperiment, normalizedExperimentData, indexedSegments }} />)
+  const { container } = render(
+    <AudiencePanel {...{ normalizedExperiment, normalizedExperimentData, indexedSegments }} />,
+  )
 
   expect(container).toMatchSnapshot()
 })
@@ -63,10 +69,12 @@ test('throws an error when some segments not resolvable', () => {
   // Note: This console.error spy is mainly used to suppress the output that the
   // `render` function outputs.
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  const consoleErrorSpy = jest.spyOn(global.console, 'error').mockImplementation(() => { })
+  const consoleErrorSpy = jest.spyOn(global.console, 'error').mockImplementation(() => {})
   try {
     render(
-      <RenderErrorBoundary>{() => <AudiencePanel {...{ normalizedExperiment, normalizedExperimentData, indexedSegments }} />}</RenderErrorBoundary>,
+      <RenderErrorBoundary>
+        {() => <AudiencePanel {...{ normalizedExperiment, normalizedExperimentData, indexedSegments }} />}
+      </RenderErrorBoundary>,
     )
     expect(false).toBe(true) // Should never be reached
   } catch (err) {

--- a/components/AudiencePanel.tsx
+++ b/components/AudiencePanel.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import LabelValuePanel from '@/components/LabelValuePanel'
 import SegmentsTable from '@/components/SegmentsTable'
 import VariationsTable from '@/components/VariationsTable'
-import { Segment, SegmentType, ExperimentFullNormalized, ExperimentFullNormalizedData } from '@/lib/schemas'
+import { ExperimentFullNormalized, ExperimentFullNormalizedData, Segment, SegmentType } from '@/lib/schemas'
 import * as Variations from '@/lib/variations'
 
 /**
@@ -15,18 +15,32 @@ import * as Variations from '@/lib/variations'
  * @param props.segments - The segments to look up (aka resolve) the segment IDs
  *   of the experiment's segment assignments.
  */
-function AudiencePanel({ normalizedExperiment, normalizedExperimentData, indexedSegments }: { normalizedExperiment: ExperimentFullNormalized; normalizedExperimentData: ExperimentFullNormalizedData; indexedSegments: Record<number, Segment> }) {
-  const segmentAssignmentsWithSegments = Object.values(normalizedExperimentData.entities.segmentAssignments)
-    .map(segmentAssignment => ({ segmentAssignment, segment: indexedSegments[segmentAssignment.segmentId] }))
+function AudiencePanel({
+  normalizedExperiment,
+  normalizedExperimentData,
+  indexedSegments,
+}: {
+  normalizedExperiment: ExperimentFullNormalized
+  normalizedExperimentData: ExperimentFullNormalizedData
+  indexedSegments: Record<number, Segment>
+}) {
+  const segmentAssignmentsWithSegments = Object.values(
+    normalizedExperimentData.entities.segmentAssignments,
+  ).map((segmentAssignment) => ({ segmentAssignment, segment: indexedSegments[segmentAssignment.segmentId] }))
   const segmentAssignmentsWithSegmentsByType = _.groupBy(segmentAssignmentsWithSegments, _.property('segment.type'))
 
   const data = [
     { label: 'Platform', value: normalizedExperiment.platform },
-    { label: 'User Type', value: normalizedExperiment.existingUsersAllowed ? 'All users (new + existing)' : 'New users only' },
+    {
+      label: 'User Type',
+      value: normalizedExperiment.existingUsersAllowed ? 'All users (new + existing)' : 'New users only',
+    },
     {
       label: 'Variations',
       padding: 'none' as TableCellProps['padding'],
-      value: <VariationsTable variations={Variations.sort(Object.values(normalizedExperimentData.entities.variations))} />,
+      value: (
+        <VariationsTable variations={Variations.sort(Object.values(normalizedExperimentData.entities.variations))} />
+      ),
     },
     {
       label: 'Segments',

--- a/components/AudiencePanel.tsx
+++ b/components/AudiencePanel.tsx
@@ -24,9 +24,17 @@ function AudiencePanel({
   normalizedExperimentData: ExperimentFullNormalizedData
   indexedSegments: Record<number, Segment>
 }) {
-  const segmentAssignmentsWithSegments = Object.values(
-    normalizedExperimentData.entities.segmentAssignments,
-  ).map((segmentAssignment) => ({ segmentAssignment, segment: indexedSegments[segmentAssignment.segmentId] }))
+  const segmentAssignmentsWithSegments = normalizedExperimentData.entities.segmentAssignments
+    ? Object.values(normalizedExperimentData.entities.segmentAssignments).map((segmentAssignment) => {
+        const segment = indexedSegments[segmentAssignment.segmentId]
+        if (!segment) {
+          throw new Error(
+            `Could not find metric corresponding to segmentAssignment. segmentAssignmentId: '${segmentAssignment.segmentAssignmentId}'`,
+          )
+        }
+        return { segmentAssignment, segment }
+      })
+    : []
   const segmentAssignmentsWithSegmentsByType = _.groupBy(segmentAssignmentsWithSegments, _.property('segment.type'))
 
   const data = [

--- a/components/AudiencePanel.tsx
+++ b/components/AudiencePanel.tsx
@@ -5,36 +5,32 @@ import React from 'react'
 import LabelValuePanel from '@/components/LabelValuePanel'
 import SegmentsTable from '@/components/SegmentsTable'
 import VariationsTable from '@/components/VariationsTable'
-import { ExperimentFullNormalized, ExperimentFullNormalizedData, Segment, SegmentType } from '@/lib/schemas'
+import { ExperimentFullNormalized, ExperimentFullNormalizedEntities, Segment, SegmentType } from '@/lib/schemas'
 import * as Variations from '@/lib/variations'
 
 /**
  * Renders the audience information of an experiment in a panel component.
- *
- * @param props.experiment - The experiment with the audience information.
- * @param props.segments - The segments to look up (aka resolve) the segment IDs
- *   of the experiment's segment assignments.
  */
 function AudiencePanel({
   normalizedExperiment,
-  normalizedExperimentData,
+  normalizedExperimentEntities,
   indexedSegments,
 }: {
   normalizedExperiment: ExperimentFullNormalized
-  normalizedExperimentData: ExperimentFullNormalizedData
+  normalizedExperimentEntities: ExperimentFullNormalizedEntities
   indexedSegments: Record<number, Segment>
 }) {
-  const segmentAssignmentsWithSegments = normalizedExperimentData.entities.segmentAssignments
-    ? Object.values(normalizedExperimentData.entities.segmentAssignments).map((segmentAssignment) => {
-        const segment = indexedSegments[segmentAssignment.segmentId]
-        if (!segment) {
-          throw new Error(
-            `Could not find metric corresponding to segmentAssignment. segmentAssignmentId: '${segmentAssignment.segmentAssignmentId}'`,
-          )
-        }
-        return { segmentAssignment, segment }
-      })
-    : []
+  const segmentAssignmentsWithSegments = Object.values(normalizedExperimentEntities.segmentAssignments).map(
+    (segmentAssignment) => {
+      const segment = indexedSegments[segmentAssignment.segmentId]
+      if (!segment) {
+        throw new Error(
+          `Could not find segment corresponding to segmentAssignment. segmentAssignmentId: '${segmentAssignment.segmentAssignmentId}'`,
+        )
+      }
+      return { segmentAssignment, segment }
+    },
+  )
   const segmentAssignmentsWithSegmentsByType = _.groupBy(segmentAssignmentsWithSegments, _.property('segment.type'))
 
   const data = [
@@ -46,9 +42,7 @@ function AudiencePanel({
     {
       label: 'Variations',
       padding: 'none' as TableCellProps['padding'],
-      value: (
-        <VariationsTable variations={Variations.sort(Object.values(normalizedExperimentData.entities.variations))} />
-      ),
+      value: <VariationsTable variations={Variations.sort(Object.values(normalizedExperimentEntities.variations))} />,
     },
     {
       label: 'Segments',

--- a/components/ConclusionsPanel.test.tsx
+++ b/components/ConclusionsPanel.test.tsx
@@ -4,6 +4,7 @@ import Fixtures from '@/test-helpers/fixtures'
 import { render } from '@/test-helpers/test-utils'
 
 import ConclusionsPanel from './ConclusionsPanel'
+import { normalizeExperiment } from '@/lib/normalizers'
 
 test('renders as expected with complete conclusion data', () => {
   const experiment = Fixtures.createExperimentFull({
@@ -11,7 +12,8 @@ test('renders as expected with complete conclusion data', () => {
     deployedVariationId: 2,
     endReason: 'Ran its course.',
   })
-  const { container } = render(<ConclusionsPanel experiment={experiment} />)
+  const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
+  const { container } = render(<ConclusionsPanel {...{ normalizedExperiment, normalizedExperimentData }} />)
 
   expect(container).toMatchInlineSnapshot(`
     <div>
@@ -96,7 +98,8 @@ test('renders as expected without deployed variation', () => {
     deployedVariationId: null,
     endReason: 'Ran its course.',
   })
-  const { container } = render(<ConclusionsPanel experiment={experiment} />)
+  const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
+  const { container } = render(<ConclusionsPanel {...{ normalizedExperiment, normalizedExperimentData }} />)
 
   expect(container).toMatchInlineSnapshot(`
     <div>

--- a/components/ConclusionsPanel.test.tsx
+++ b/components/ConclusionsPanel.test.tsx
@@ -12,8 +12,8 @@ test('renders as expected with complete conclusion data', () => {
     deployedVariationId: 2,
     endReason: 'Ran its course.',
   })
-  const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
-  const { container } = render(<ConclusionsPanel {...{ normalizedExperiment, normalizedExperimentData }} />)
+  const [normalizedExperiment, normalizedExperimentEntities] = normalizeExperiment(experiment)
+  const { container } = render(<ConclusionsPanel {...{ normalizedExperiment, normalizedExperimentEntities }} />)
 
   expect(container).toMatchInlineSnapshot(`
     <div>
@@ -98,8 +98,8 @@ test('renders as expected without deployed variation', () => {
     deployedVariationId: null,
     endReason: 'Ran its course.',
   })
-  const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
-  const { container } = render(<ConclusionsPanel {...{ normalizedExperiment, normalizedExperimentData }} />)
+  const [normalizedExperiment, normalizedExperimentEntities] = normalizeExperiment(experiment)
+  const { container } = render(<ConclusionsPanel {...{ normalizedExperiment, normalizedExperimentEntities }} />)
 
   expect(container).toMatchInlineSnapshot(`
     <div>

--- a/components/ConclusionsPanel.test.tsx
+++ b/components/ConclusionsPanel.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 
+import { normalizeExperiment } from '@/lib/normalizers'
 import Fixtures from '@/test-helpers/fixtures'
 import { render } from '@/test-helpers/test-utils'
 
 import ConclusionsPanel from './ConclusionsPanel'
-import { normalizeExperiment } from '@/lib/normalizers'
 
 test('renders as expected with complete conclusion data', () => {
   const experiment = Fixtures.createExperimentFull({

--- a/components/ConclusionsPanel.tsx
+++ b/components/ConclusionsPanel.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
 import _ from 'lodash'
+import React from 'react'
 
 import LabelValuePanel from '@/components/LabelValuePanel'
 import { ExperimentFullNormalized, ExperimentFullNormalizedData } from '@/lib/schemas'
@@ -9,9 +9,16 @@ import { ExperimentFullNormalized, ExperimentFullNormalizedData } from '@/lib/sc
  *
  * @param props.experiment - The experiment with the conclusion information.
  */
-function ConclusionsPanel({ normalizedExperiment, normalizedExperimentData }: { normalizedExperiment: ExperimentFullNormalized, normalizedExperimentData: ExperimentFullNormalizedData }) {
-  const deployedVariation = _.isNumber(normalizedExperiment.deployedVariationId) ? normalizedExperimentData.entities.variations[normalizedExperiment.deployedVariationId] : null
-
+function ConclusionsPanel({
+  normalizedExperiment,
+  normalizedExperimentData,
+}: {
+  normalizedExperiment: ExperimentFullNormalized
+  normalizedExperimentData: ExperimentFullNormalizedData
+}) {
+  const deployedVariation = _.isNumber(normalizedExperiment.deployedVariationId)
+    ? normalizedExperimentData.entities.variations[normalizedExperiment.deployedVariationId]
+    : null
 
   const data = [
     { label: 'Reason the experiment ended', value: normalizedExperiment.endReason },

--- a/components/ConclusionsPanel.tsx
+++ b/components/ConclusionsPanel.tsx
@@ -1,23 +1,25 @@
 import React from 'react'
+import _ from 'lodash'
 
 import LabelValuePanel from '@/components/LabelValuePanel'
-import * as Experiments from '@/lib/experiments'
-import { ExperimentFull } from '@/lib/schemas'
+import { ExperimentFullNormalized, ExperimentFullNormalizedData } from '@/lib/schemas'
 
 /**
  * Renders the conclusion information of an experiment in a panel component.
  *
  * @param props.experiment - The experiment with the conclusion information.
  */
-function ConclusionsPanel({ experiment }: { experiment: ExperimentFull }) {
-  const deployedVariation = Experiments.getDeployedVariation(experiment)
+function ConclusionsPanel({ normalizedExperiment, normalizedExperimentData }: { normalizedExperiment: ExperimentFullNormalized, normalizedExperimentData: ExperimentFullNormalizedData }) {
+  const deployedVariation = _.isNumber(normalizedExperiment.deployedVariationId) ? normalizedExperimentData.entities.variations[normalizedExperiment.deployedVariationId] : null
+
+
   const data = [
-    { label: 'Reason the experiment ended', value: experiment.endReason },
+    { label: 'Reason the experiment ended', value: normalizedExperiment.endReason },
     {
       label: 'Conclusion URL',
-      value: !!experiment.conclusionUrl && (
-        <a href={experiment.conclusionUrl} rel='noopener noreferrer' target='_blank'>
-          {experiment.conclusionUrl}
+      value: !!normalizedExperiment.conclusionUrl && (
+        <a href={normalizedExperiment.conclusionUrl} rel='noopener noreferrer' target='_blank'>
+          {normalizedExperiment.conclusionUrl}
         </a>
       ),
     },

--- a/components/ConclusionsPanel.tsx
+++ b/components/ConclusionsPanel.tsx
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import React from 'react'
 
 import LabelValuePanel from '@/components/LabelValuePanel'
-import { ExperimentFullNormalized, ExperimentFullNormalizedData } from '@/lib/schemas'
+import { ExperimentFullNormalized, ExperimentFullNormalizedEntities } from '@/lib/schemas'
 
 /**
  * Renders the conclusion information of an experiment in a panel component.
@@ -11,13 +11,13 @@ import { ExperimentFullNormalized, ExperimentFullNormalizedData } from '@/lib/sc
  */
 function ConclusionsPanel({
   normalizedExperiment,
-  normalizedExperimentData,
+  normalizedExperimentEntities,
 }: {
   normalizedExperiment: ExperimentFullNormalized
-  normalizedExperimentData: ExperimentFullNormalizedData
+  normalizedExperimentEntities: ExperimentFullNormalizedEntities
 }) {
   const deployedVariation = _.isNumber(normalizedExperiment.deployedVariationId)
-    ? normalizedExperimentData.entities.variations[normalizedExperiment.deployedVariationId]
+    ? normalizedExperimentEntities.variations[normalizedExperiment.deployedVariationId]
     : null
 
   const data = [

--- a/components/ExperimentDetails.test.tsx
+++ b/components/ExperimentDetails.test.tsx
@@ -31,13 +31,10 @@ test('renders as expected at large width', () => {
   const { container } = render(
     <ExperimentDetails
       {...{
-        experiment,
         normalizedExperiment,
         normalizedExperimentData,
         indexedMetrics,
         indexedSegments,
-        metrics,
-        segments,
       }}
     />,
   )
@@ -61,13 +58,10 @@ test('renders as expected at small width', () => {
   const { container } = render(
     <ExperimentDetails
       {...{
-        experiment,
         normalizedExperiment,
         normalizedExperimentData,
         indexedMetrics,
         indexedSegments,
-        metrics,
-        segments,
       }}
     />,
   )
@@ -93,13 +87,10 @@ test('renders as expected with conclusion data', () => {
   const { container } = render(
     <ExperimentDetails
       {...{
-        experiment,
         normalizedExperiment,
         normalizedExperimentData,
         indexedMetrics,
         indexedSegments,
-        metrics,
-        segments,
       }}
     />,
   )
@@ -122,13 +113,10 @@ test('renders as expected without conclusion data', () => {
   const { container } = render(
     <ExperimentDetails
       {...{
-        experiment,
         normalizedExperiment,
         normalizedExperimentData,
         indexedMetrics,
         indexedSegments,
-        metrics,
-        segments,
       }}
     />,
   )

--- a/components/ExperimentDetails.test.tsx
+++ b/components/ExperimentDetails.test.tsx
@@ -5,6 +5,7 @@ import Fixtures from '@/test-helpers/fixtures'
 import { createMatchMedia, render } from '@/test-helpers/test-utils'
 
 import ExperimentDetails from './ExperimentDetails'
+import { normalizeExperiment } from '@/lib/normalizers'
 
 MockDate.set('2020-07-21')
 
@@ -24,7 +25,8 @@ test('renders as expected at large width', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 102, segmentId: 2, isExcluded: true }),
     ],
   })
-  const { container } = render(<ExperimentDetails experiment={experiment} metrics={metrics} segments={segments} />)
+  const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
+  const { container } = render(<ExperimentDetails {...{ experiment, normalizedExperiment, normalizedExperimentData, metrics, segments }} />)
 
   expect(container).toMatchSnapshot()
 })
@@ -39,7 +41,8 @@ test('renders as expected at small width', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 102, segmentId: 2, isExcluded: true }),
     ],
   })
-  const { container } = render(<ExperimentDetails experiment={experiment} metrics={metrics} segments={segments} />)
+  const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
+  const { container } = render(<ExperimentDetails {...{ experiment, normalizedExperiment, normalizedExperimentData, metrics, segments }} />)
 
   expect(container).toMatchSnapshot()
 })
@@ -56,7 +59,8 @@ test('renders as expected with conclusion data', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 102, segmentId: 2, isExcluded: true }),
     ],
   })
-  const { container } = render(<ExperimentDetails experiment={experiment} metrics={metrics} segments={segments} />)
+  const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
+  const { container } = render(<ExperimentDetails {...{ experiment, normalizedExperiment, normalizedExperimentData, metrics, segments }} />)
 
   expect(container).toMatchSnapshot()
 })
@@ -70,7 +74,8 @@ test('renders as expected without conclusion data', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 102, segmentId: 2, isExcluded: true }),
     ],
   })
-  const { container } = render(<ExperimentDetails experiment={experiment} metrics={metrics} segments={segments} />)
+  const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
+  const { container } = render(<ExperimentDetails {...{ experiment, normalizedExperiment, normalizedExperimentData, metrics, segments }} />)
 
   expect(container).toMatchSnapshot()
 })

--- a/components/ExperimentDetails.test.tsx
+++ b/components/ExperimentDetails.test.tsx
@@ -27,12 +27,12 @@ test('renders as expected at large width', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 102, segmentId: 2, isExcluded: true }),
     ],
   })
-  const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
+  const [normalizedExperiment, normalizedExperimentEntities] = normalizeExperiment(experiment)
   const { container } = render(
     <ExperimentDetails
       {...{
         normalizedExperiment,
-        normalizedExperimentData,
+        normalizedExperimentEntities,
         indexedMetrics,
         indexedSegments,
       }}
@@ -54,12 +54,12 @@ test('renders as expected at small width', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 102, segmentId: 2, isExcluded: true }),
     ],
   })
-  const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
+  const [normalizedExperiment, normalizedExperimentEntities] = normalizeExperiment(experiment)
   const { container } = render(
     <ExperimentDetails
       {...{
         normalizedExperiment,
-        normalizedExperimentData,
+        normalizedExperimentEntities,
         indexedMetrics,
         indexedSegments,
       }}
@@ -83,12 +83,12 @@ test('renders as expected with conclusion data', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 102, segmentId: 2, isExcluded: true }),
     ],
   })
-  const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
+  const [normalizedExperiment, normalizedExperimentEntities] = normalizeExperiment(experiment)
   const { container } = render(
     <ExperimentDetails
       {...{
         normalizedExperiment,
-        normalizedExperimentData,
+        normalizedExperimentEntities,
         indexedMetrics,
         indexedSegments,
       }}
@@ -109,12 +109,12 @@ test('renders as expected without conclusion data', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 102, segmentId: 2, isExcluded: true }),
     ],
   })
-  const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
+  const [normalizedExperiment, normalizedExperimentEntities] = normalizeExperiment(experiment)
   const { container } = render(
     <ExperimentDetails
       {...{
         normalizedExperiment,
-        normalizedExperimentData,
+        normalizedExperimentEntities,
         indexedMetrics,
         indexedSegments,
       }}

--- a/components/ExperimentDetails.test.tsx
+++ b/components/ExperimentDetails.test.tsx
@@ -5,7 +5,7 @@ import Fixtures from '@/test-helpers/fixtures'
 import { createMatchMedia, render } from '@/test-helpers/test-utils'
 
 import ExperimentDetails from './ExperimentDetails'
-import { normalizeExperiment } from '@/lib/normalizers'
+import { normalizeExperiment, indexMetrics, indexSegments } from '@/lib/normalizers'
 
 MockDate.set('2020-07-21')
 
@@ -19,6 +19,8 @@ test('renders as expected at large width', () => {
 
   const metrics = Fixtures.createMetricBares()
   const segments = Fixtures.createSegments(5)
+  const indexedMetrics = indexMetrics(metrics)
+  const indexedSegments = indexSegments(segments)
   const experiment = Fixtures.createExperimentFull({
     segmentAssignments: [
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 101, segmentId: 1 }),
@@ -26,7 +28,7 @@ test('renders as expected at large width', () => {
     ],
   })
   const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
-  const { container } = render(<ExperimentDetails {...{ experiment, normalizedExperiment, normalizedExperimentData, metrics, segments }} />)
+  const { container } = render(<ExperimentDetails {...{ experiment, normalizedExperiment, normalizedExperimentData, indexedMetrics, indexedSegments, metrics, segments }} />)
 
   expect(container).toMatchSnapshot()
 })
@@ -35,6 +37,8 @@ test('renders as expected at small width', () => {
   window.matchMedia = createMatchMedia(600)
   const metrics = Fixtures.createMetricBares()
   const segments = Fixtures.createSegments(5)
+  const indexedMetrics = indexMetrics(metrics)
+  const indexedSegments = indexSegments(segments)
   const experiment = Fixtures.createExperimentFull({
     segmentAssignments: [
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 101, segmentId: 1 }),
@@ -42,7 +46,7 @@ test('renders as expected at small width', () => {
     ],
   })
   const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
-  const { container } = render(<ExperimentDetails {...{ experiment, normalizedExperiment, normalizedExperimentData, metrics, segments }} />)
+  const { container } = render(<ExperimentDetails {...{ experiment, normalizedExperiment, normalizedExperimentData, indexedMetrics, indexedSegments, metrics, segments }} />)
 
   expect(container).toMatchSnapshot()
 })
@@ -50,6 +54,8 @@ test('renders as expected at small width', () => {
 test('renders as expected with conclusion data', () => {
   const metrics = Fixtures.createMetricBares()
   const segments = Fixtures.createSegments(5)
+  const indexedMetrics = indexMetrics(metrics)
+  const indexedSegments = indexSegments(segments)
   const experiment = Fixtures.createExperimentFull({
     conclusionUrl: 'https://betterexperiments.wordpress.com/experiment_1/conclusion',
     deployedVariationId: 2,
@@ -60,7 +66,7 @@ test('renders as expected with conclusion data', () => {
     ],
   })
   const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
-  const { container } = render(<ExperimentDetails {...{ experiment, normalizedExperiment, normalizedExperimentData, metrics, segments }} />)
+  const { container } = render(<ExperimentDetails {...{ experiment, normalizedExperiment, normalizedExperimentData, indexedMetrics, indexedSegments, metrics, segments }} />)
 
   expect(container).toMatchSnapshot()
 })
@@ -68,6 +74,8 @@ test('renders as expected with conclusion data', () => {
 test('renders as expected without conclusion data', () => {
   const metrics = Fixtures.createMetricBares()
   const segments = Fixtures.createSegments(5)
+  const indexedMetrics = indexMetrics(metrics)
+  const indexedSegments = indexSegments(segments)
   const experiment = Fixtures.createExperimentFull({
     segmentAssignments: [
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 101, segmentId: 1 }),
@@ -75,7 +83,7 @@ test('renders as expected without conclusion data', () => {
     ],
   })
   const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
-  const { container } = render(<ExperimentDetails {...{ experiment, normalizedExperiment, normalizedExperimentData, metrics, segments }} />)
+  const { container } = render(<ExperimentDetails {...{ experiment, normalizedExperiment, normalizedExperimentData, indexedMetrics, indexedSegments, metrics, segments }} />)
 
   expect(container).toMatchSnapshot()
 })

--- a/components/ExperimentDetails.test.tsx
+++ b/components/ExperimentDetails.test.tsx
@@ -1,11 +1,11 @@
 import MockDate from 'mockdate'
 import React from 'react'
 
+import { indexMetrics, indexSegments, normalizeExperiment } from '@/lib/normalizers'
 import Fixtures from '@/test-helpers/fixtures'
 import { createMatchMedia, render } from '@/test-helpers/test-utils'
 
 import ExperimentDetails from './ExperimentDetails'
-import { normalizeExperiment, indexMetrics, indexSegments } from '@/lib/normalizers'
 
 MockDate.set('2020-07-21')
 
@@ -28,7 +28,19 @@ test('renders as expected at large width', () => {
     ],
   })
   const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
-  const { container } = render(<ExperimentDetails {...{ experiment, normalizedExperiment, normalizedExperimentData, indexedMetrics, indexedSegments, metrics, segments }} />)
+  const { container } = render(
+    <ExperimentDetails
+      {...{
+        experiment,
+        normalizedExperiment,
+        normalizedExperimentData,
+        indexedMetrics,
+        indexedSegments,
+        metrics,
+        segments,
+      }}
+    />,
+  )
 
   expect(container).toMatchSnapshot()
 })
@@ -46,7 +58,19 @@ test('renders as expected at small width', () => {
     ],
   })
   const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
-  const { container } = render(<ExperimentDetails {...{ experiment, normalizedExperiment, normalizedExperimentData, indexedMetrics, indexedSegments, metrics, segments }} />)
+  const { container } = render(
+    <ExperimentDetails
+      {...{
+        experiment,
+        normalizedExperiment,
+        normalizedExperimentData,
+        indexedMetrics,
+        indexedSegments,
+        metrics,
+        segments,
+      }}
+    />,
+  )
 
   expect(container).toMatchSnapshot()
 })
@@ -66,7 +90,19 @@ test('renders as expected with conclusion data', () => {
     ],
   })
   const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
-  const { container } = render(<ExperimentDetails {...{ experiment, normalizedExperiment, normalizedExperimentData, indexedMetrics, indexedSegments, metrics, segments }} />)
+  const { container } = render(
+    <ExperimentDetails
+      {...{
+        experiment,
+        normalizedExperiment,
+        normalizedExperimentData,
+        indexedMetrics,
+        indexedSegments,
+        metrics,
+        segments,
+      }}
+    />,
+  )
 
   expect(container).toMatchSnapshot()
 })
@@ -83,7 +119,19 @@ test('renders as expected without conclusion data', () => {
     ],
   })
   const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
-  const { container } = render(<ExperimentDetails {...{ experiment, normalizedExperiment, normalizedExperimentData, indexedMetrics, indexedSegments, metrics, segments }} />)
+  const { container } = render(
+    <ExperimentDetails
+      {...{
+        experiment,
+        normalizedExperiment,
+        normalizedExperimentData,
+        indexedMetrics,
+        indexedSegments,
+        metrics,
+        segments,
+      }}
+    />,
+  )
 
   expect(container).toMatchSnapshot()
 })

--- a/components/ExperimentDetails.tsx
+++ b/components/ExperimentDetails.tsx
@@ -9,7 +9,7 @@ import ConclusionsPanel from '@/components/ConclusionsPanel'
 import GeneralPanel from '@/components/GeneralPanel'
 import MetricAssignmentsPanel from '@/components/MetricAssignmentsPanel'
 import * as Experiments from '@/lib/experiments'
-import { ExperimentFull, MetricBare, Segment } from '@/lib/schemas'
+import { ExperimentFull, MetricBare, Segment, ExperimentFullNormalized, ExperimentFullNormalizedData } from '@/lib/schemas'
 
 const debug = debugFactory('abacus:components/ExperimentDetails.tsx')
 
@@ -17,10 +17,14 @@ const debug = debugFactory('abacus:components/ExperimentDetails.tsx')
  * Renders the main details of an experiment.
  */
 function ExperimentDetails({
+  normalizedExperiment,
+  normalizedExperimentData,
   experiment,
   metrics,
   segments,
 }: {
+  normalizedExperiment: ExperimentFullNormalized,
+  normalizedExperimentData: ExperimentFullNormalizedData,
   experiment: ExperimentFull
   metrics: MetricBare[]
   segments: Segment[]

--- a/components/ExperimentDetails.tsx
+++ b/components/ExperimentDetails.tsx
@@ -38,7 +38,7 @@ function ExperimentDetails({
       <Grid item xs={12} lg={7}>
         <Grid container direction='column' spacing={2}>
           <Grid item>
-            <GeneralPanel experiment={experiment} />
+            <GeneralPanel {...{ normalizedExperiment }} />
           </Grid>
           {isMdDown && (
             <Grid item>

--- a/components/ExperimentDetails.tsx
+++ b/components/ExperimentDetails.tsx
@@ -19,12 +19,16 @@ const debug = debugFactory('abacus:components/ExperimentDetails.tsx')
 function ExperimentDetails({
   normalizedExperiment,
   normalizedExperimentData,
+  indexedMetrics,
+  indexedSegments,
   experiment,
   metrics,
   segments,
 }: {
   normalizedExperiment: ExperimentFullNormalized,
   normalizedExperimentData: ExperimentFullNormalizedData,
+  indexedMetrics: Record<number, MetricBare>,
+  indexedSegments: Record<number, Segment>,
   experiment: ExperimentFull
   metrics: MetricBare[]
   segments: Segment[]

--- a/components/ExperimentDetails.tsx
+++ b/components/ExperimentDetails.tsx
@@ -9,7 +9,7 @@ import ConclusionsPanel from '@/components/ConclusionsPanel'
 import GeneralPanel from '@/components/GeneralPanel'
 import MetricAssignmentsPanel from '@/components/MetricAssignmentsPanel'
 import * as Experiments from '@/lib/experiments'
-import { ExperimentFull, MetricBare, Segment, ExperimentFullNormalized, ExperimentFullNormalizedData } from '@/lib/schemas'
+import { MetricBare, Segment, ExperimentFullNormalized, ExperimentFullNormalizedData } from '@/lib/schemas'
 
 const debug = debugFactory('abacus:components/ExperimentDetails.tsx')
 
@@ -21,17 +21,11 @@ function ExperimentDetails({
   normalizedExperimentData,
   indexedMetrics,
   indexedSegments,
-  experiment,
-  metrics,
-  segments,
 }: {
   normalizedExperiment: ExperimentFullNormalized,
   normalizedExperimentData: ExperimentFullNormalizedData,
   indexedMetrics: Record<number, MetricBare>,
   indexedSegments: Record<number, Segment>,
-  experiment: ExperimentFull
-  metrics: MetricBare[]
-  segments: Segment[]
 }) {
   debug('ExperimentDetails#render')
   const theme = useTheme()

--- a/components/ExperimentDetails.tsx
+++ b/components/ExperimentDetails.tsx
@@ -48,7 +48,7 @@ function ExperimentDetails({
           <Grid item>
             <MetricAssignmentsPanel experiment={experiment} metrics={metrics} />
           </Grid>
-          {Experiments.hasConclusionData(experiment) && (
+          {Experiments.hasConclusionData(normalizedExperiment) && (
             <Grid item>
               <ConclusionsPanel experiment={experiment} />
             </Grid>

--- a/components/ExperimentDetails.tsx
+++ b/components/ExperimentDetails.tsx
@@ -50,7 +50,7 @@ function ExperimentDetails({
             </Grid>
           )}
           <Grid item>
-            <MetricAssignmentsPanel experiment={experiment} metrics={metrics} />
+            <MetricAssignmentsPanel metricAssignments={Object.values(normalizedExperimentData.entities.metricAssignments)} indexedMetrics={indexedMetrics} />
           </Grid>
           {Experiments.hasConclusionData(normalizedExperiment) && (
             <Grid item>

--- a/components/ExperimentDetails.tsx
+++ b/components/ExperimentDetails.tsx
@@ -46,7 +46,7 @@ function ExperimentDetails({
           </Grid>
           {isMdDown && (
             <Grid item>
-              <AudiencePanel experiment={experiment} segments={segments} />
+              <AudiencePanel {...{ normalizedExperiment, normalizedExperimentData, indexedSegments }} />
             </Grid>
           )}
           <Grid item>
@@ -61,7 +61,7 @@ function ExperimentDetails({
       </Grid>
       {!isMdDown && (
         <Grid item lg={5}>
-          <AudiencePanel experiment={experiment} segments={segments} />
+          <AudiencePanel {...{ normalizedExperiment, normalizedExperimentData, indexedSegments }} />
         </Grid>
       )}
     </Grid>

--- a/components/ExperimentDetails.tsx
+++ b/components/ExperimentDetails.tsx
@@ -9,7 +9,7 @@ import ConclusionsPanel from '@/components/ConclusionsPanel'
 import GeneralPanel from '@/components/GeneralPanel'
 import MetricAssignmentsPanel from '@/components/MetricAssignmentsPanel'
 import * as Experiments from '@/lib/experiments'
-import { MetricBare, Segment, ExperimentFullNormalized, ExperimentFullNormalizedData } from '@/lib/schemas'
+import { ExperimentFullNormalized, ExperimentFullNormalizedData, MetricBare, Segment } from '@/lib/schemas'
 
 const debug = debugFactory('abacus:components/ExperimentDetails.tsx')
 
@@ -22,10 +22,10 @@ function ExperimentDetails({
   indexedMetrics,
   indexedSegments,
 }: {
-  normalizedExperiment: ExperimentFullNormalized,
-  normalizedExperimentData: ExperimentFullNormalizedData,
-  indexedMetrics: Record<number, MetricBare>,
-  indexedSegments: Record<number, Segment>,
+  normalizedExperiment: ExperimentFullNormalized
+  normalizedExperimentData: ExperimentFullNormalizedData
+  indexedMetrics: Record<number, MetricBare>
+  indexedSegments: Record<number, Segment>
 }) {
   debug('ExperimentDetails#render')
   const theme = useTheme()
@@ -44,7 +44,10 @@ function ExperimentDetails({
             </Grid>
           )}
           <Grid item>
-            <MetricAssignmentsPanel metricAssignments={Object.values(normalizedExperimentData.entities.metricAssignments)} indexedMetrics={indexedMetrics} />
+            <MetricAssignmentsPanel
+              metricAssignments={Object.values(normalizedExperimentData.entities.metricAssignments)}
+              indexedMetrics={indexedMetrics}
+            />
           </Grid>
           {Experiments.hasConclusionData(normalizedExperiment) && (
             <Grid item>

--- a/components/ExperimentDetails.tsx
+++ b/components/ExperimentDetails.tsx
@@ -54,7 +54,7 @@ function ExperimentDetails({
           </Grid>
           {Experiments.hasConclusionData(normalizedExperiment) && (
             <Grid item>
-              <ConclusionsPanel experiment={experiment} />
+              <ConclusionsPanel {...{ normalizedExperiment, normalizedExperimentData }} />
             </Grid>
           )}
         </Grid>

--- a/components/ExperimentDetails.tsx
+++ b/components/ExperimentDetails.tsx
@@ -9,7 +9,7 @@ import ConclusionsPanel from '@/components/ConclusionsPanel'
 import GeneralPanel from '@/components/GeneralPanel'
 import MetricAssignmentsPanel from '@/components/MetricAssignmentsPanel'
 import * as Experiments from '@/lib/experiments'
-import { ExperimentFullNormalized, ExperimentFullNormalizedData, MetricBare, Segment } from '@/lib/schemas'
+import { ExperimentFullNormalized, ExperimentFullNormalizedEntities, MetricBare, Segment } from '@/lib/schemas'
 
 const debug = debugFactory('abacus:components/ExperimentDetails.tsx')
 
@@ -18,12 +18,12 @@ const debug = debugFactory('abacus:components/ExperimentDetails.tsx')
  */
 function ExperimentDetails({
   normalizedExperiment,
-  normalizedExperimentData,
+  normalizedExperimentEntities,
   indexedMetrics,
   indexedSegments,
 }: {
   normalizedExperiment: ExperimentFullNormalized
-  normalizedExperimentData: ExperimentFullNormalizedData
+  normalizedExperimentEntities: ExperimentFullNormalizedEntities
   indexedMetrics: Record<number, MetricBare>
   indexedSegments: Record<number, Segment>
 }) {
@@ -40,25 +40,25 @@ function ExperimentDetails({
           </Grid>
           {isMdDown && (
             <Grid item>
-              <AudiencePanel {...{ normalizedExperiment, normalizedExperimentData, indexedSegments }} />
+              <AudiencePanel {...{ normalizedExperiment, normalizedExperimentEntities, indexedSegments }} />
             </Grid>
           )}
           <Grid item>
             <MetricAssignmentsPanel
-              metricAssignments={Object.values(normalizedExperimentData.entities.metricAssignments)}
+              metricAssignments={Object.values(normalizedExperimentEntities.metricAssignments)}
               indexedMetrics={indexedMetrics}
             />
           </Grid>
           {Experiments.hasConclusionData(normalizedExperiment) && (
             <Grid item>
-              <ConclusionsPanel {...{ normalizedExperiment, normalizedExperimentData }} />
+              <ConclusionsPanel {...{ normalizedExperiment, normalizedExperimentEntities }} />
             </Grid>
           )}
         </Grid>
       </Grid>
       {!isMdDown && (
         <Grid item lg={5}>
-          <AudiencePanel {...{ normalizedExperiment, normalizedExperimentData, indexedSegments }} />
+          <AudiencePanel {...{ normalizedExperiment, normalizedExperimentEntities, indexedSegments }} />
         </Grid>
       )}
     </Grid>

--- a/components/ExperimentPageView.tsx
+++ b/components/ExperimentPageView.tsx
@@ -99,7 +99,7 @@ export default function ExperimentPageView({
             segments &&
             analyses && (
               <>
-                {view === ExperimentView.Details && <ExperimentDetails {...{ experiment, normalizedExperiment, normalizedExperimentData, indexedMetrics, indexedSegments, metrics, segments }} />}
+                {view === ExperimentView.Details && <ExperimentDetails {...{ normalizedExperiment, normalizedExperimentData, indexedMetrics, indexedSegments }} />}
                 {view === ExperimentView.Results && (
                   <ExperimentResults {...{ experiment, metrics, analyses, debugMode }} />
                 )}

--- a/components/ExperimentPageView.tsx
+++ b/components/ExperimentPageView.tsx
@@ -11,7 +11,7 @@ import ExperimentResults from '@/components/experiment-results/ExperimentResults
 import ExperimentDetails from '@/components/ExperimentDetails'
 import ExperimentTabs from '@/components/ExperimentTabs'
 import Layout from '@/components/Layout'
-import { normalizeExperiment, indexMetrics, indexSegments } from '@/lib/normalizers'
+import { indexMetrics, indexSegments, normalizeExperiment } from '@/lib/normalizers'
 import { Analysis, ExperimentFull, ExperimentFullNormalized, ExperimentFullNormalizedData } from '@/lib/schemas'
 import { useDataLoadingError, useDataSource } from '@/utils/data-loading'
 import { createUnresolvingPromise, or } from '@/utils/general'
@@ -90,22 +90,26 @@ export default function ExperimentPageView({
         {isLoading ? (
           <LinearProgress />
         ) : (
-            experiment &&
-            normalizedExperiment &&
-            normalizedExperimentData &&
-            indexedMetrics &&
-            indexedSegments &&
-            metrics &&
-            segments &&
-            analyses && (
-              <>
-                {view === ExperimentView.Details && <ExperimentDetails {...{ normalizedExperiment, normalizedExperimentData, indexedMetrics, indexedSegments }} />}
-                {view === ExperimentView.Results && (
-                  <ExperimentResults {...{ experiment, metrics, analyses, debugMode }} />
-                )}
-              </>
-            )
-          )}
+          experiment &&
+          normalizedExperiment &&
+          normalizedExperimentData &&
+          indexedMetrics &&
+          indexedSegments &&
+          metrics &&
+          segments &&
+          analyses && (
+            <>
+              {view === ExperimentView.Details && (
+                <ExperimentDetails
+                  {...{ normalizedExperiment, normalizedExperimentData, indexedMetrics, indexedSegments }}
+                />
+              )}
+              {view === ExperimentView.Results && (
+                <ExperimentResults {...{ experiment, metrics, analyses, debugMode }} />
+              )}
+            </>
+          )
+        )}
       </>
     </Layout>
   )

--- a/components/ExperimentPageView.tsx
+++ b/components/ExperimentPageView.tsx
@@ -12,7 +12,7 @@ import ExperimentDetails from '@/components/ExperimentDetails'
 import ExperimentTabs from '@/components/ExperimentTabs'
 import Layout from '@/components/Layout'
 import { indexMetrics, indexSegments, normalizeExperiment } from '@/lib/normalizers'
-import { Analysis, ExperimentFull, ExperimentFullNormalized, ExperimentFullNormalizedData } from '@/lib/schemas'
+import { Analysis, ExperimentFull, ExperimentFullNormalized, ExperimentFullNormalizedEntities } from '@/lib/schemas'
 import { useDataLoadingError, useDataSource } from '@/utils/data-loading'
 import { createUnresolvingPromise, or } from '@/utils/general'
 
@@ -45,19 +45,19 @@ export default function ExperimentPageView({
     isLoading: experimentIsLoading,
     data: experimentData,
     error: experimentError,
-  } = useDataSource(async (): Promise<[ExperimentFull, ExperimentFullNormalized, ExperimentFullNormalizedData]> => {
+  } = useDataSource(async (): Promise<[ExperimentFull, ExperimentFullNormalized, ExperimentFullNormalizedEntities]> => {
     if (!experimentId) {
-      return createUnresolvingPromise<[ExperimentFull, ExperimentFullNormalized, ExperimentFullNormalizedData]>()
+      return createUnresolvingPromise<[ExperimentFull, ExperimentFullNormalized, ExperimentFullNormalizedEntities]>()
     }
 
     const experiment = await ExperimentsApi.findById(experimentId)
-    const [normalizedExperiment, normalizedExperimentData] = normalizeExperiment(experiment)
-    return [experiment, normalizedExperiment, normalizedExperimentData]
+    const [normalizedExperiment, normalizedExperimentEntities] = normalizeExperiment(experiment)
+    return [experiment, normalizedExperiment, normalizedExperimentEntities]
   }, [experimentId])
   useDataLoadingError(experimentError, 'Experiment')
-  let experiment, normalizedExperiment, normalizedExperimentData
+  let experiment, normalizedExperiment, normalizedExperimentEntities
   if (experimentData) {
-    ;[experiment, normalizedExperiment, normalizedExperimentData] = experimentData
+    ;[experiment, normalizedExperiment, normalizedExperimentEntities] = experimentData
   }
 
   const { isLoading: metricsIsLoading, data: indexedMetrics, error: metricsError } = useDataSource(
@@ -92,7 +92,7 @@ export default function ExperimentPageView({
         ) : (
           experiment &&
           normalizedExperiment &&
-          normalizedExperimentData &&
+          normalizedExperimentEntities &&
           indexedMetrics &&
           indexedSegments &&
           metrics &&
@@ -101,7 +101,7 @@ export default function ExperimentPageView({
             <>
               {view === ExperimentView.Details && (
                 <ExperimentDetails
-                  {...{ normalizedExperiment, normalizedExperimentData, indexedMetrics, indexedSegments }}
+                  {...{ normalizedExperiment, normalizedExperimentEntities, indexedMetrics, indexedSegments }}
                 />
               )}
               {view === ExperimentView.Results && (

--- a/components/ExperimentPageView.tsx
+++ b/components/ExperimentPageView.tsx
@@ -88,20 +88,20 @@ export default function ExperimentPageView({
         {isLoading ? (
           <LinearProgress />
         ) : (
-          experiment &&
-          normalizedExperiment &&
-          normalizedExperimentData &&
-          metrics &&
-          segments &&
-          analyses && (
-            <>
-              {view === ExperimentView.Details && <ExperimentDetails {...{ experiment, metrics, segments }} />}
-              {view === ExperimentView.Results && (
-                <ExperimentResults {...{ experiment, metrics, analyses, debugMode }} />
-              )}
-            </>
-          )
-        )}
+            experiment &&
+            normalizedExperiment &&
+            normalizedExperimentData &&
+            metrics &&
+            segments &&
+            analyses && (
+              <>
+                {view === ExperimentView.Details && <ExperimentDetails {...{ experiment, normalizedExperiment, normalizedExperimentData, metrics, segments }} />}
+                {view === ExperimentView.Results && (
+                  <ExperimentResults {...{ experiment, metrics, analyses, debugMode }} />
+                )}
+              </>
+            )
+          )}
       </>
     </Layout>
   )

--- a/components/ExperimentPageView.tsx
+++ b/components/ExperimentPageView.tsx
@@ -99,7 +99,7 @@ export default function ExperimentPageView({
             segments &&
             analyses && (
               <>
-                {view === ExperimentView.Details && <ExperimentDetails {...{ experiment, normalizedExperiment, normalizedExperimentData, metrics, segments }} />}
+                {view === ExperimentView.Details && <ExperimentDetails {...{ experiment, normalizedExperiment, normalizedExperimentData, indexedMetrics, indexedSegments, metrics, segments }} />}
                 {view === ExperimentView.Results && (
                   <ExperimentResults {...{ experiment, metrics, analyses, debugMode }} />
                 )}

--- a/components/GeneralPanel.test.tsx
+++ b/components/GeneralPanel.test.tsx
@@ -5,12 +5,13 @@ import Fixtures from '@/test-helpers/fixtures'
 import { render } from '@/test-helpers/test-utils'
 
 import GeneralPanel from './GeneralPanel'
+import { normalizeExperiment } from '@/lib/normalizers'
 
 MockDate.set('2020-07-21')
 
 test('renders as expected', () => {
   const experiment = Fixtures.createExperimentFull()
-  const { container } = render(<GeneralPanel experiment={experiment} />)
+  const { container } = render(<GeneralPanel normalizedExperiment={normalizeExperiment(experiment)[0]} />)
 
   expect(container).toMatchInlineSnapshot(`
     <div>

--- a/components/GeneralPanel.test.tsx
+++ b/components/GeneralPanel.test.tsx
@@ -1,11 +1,11 @@
 import MockDate from 'mockdate'
 import React from 'react'
 
+import { normalizeExperiment } from '@/lib/normalizers'
 import Fixtures from '@/test-helpers/fixtures'
 import { render } from '@/test-helpers/test-utils'
 
 import GeneralPanel from './GeneralPanel'
-import { normalizeExperiment } from '@/lib/normalizers'
 
 MockDate.set('2020-07-21')
 

--- a/components/GeneralPanel.tsx
+++ b/components/GeneralPanel.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 import DatetimeText from '@/components/DatetimeText'
 import LabelValuePanel from '@/components/LabelValuePanel'
-import { ExperimentFull } from '@/lib/schemas'
+import { ExperimentFullNormalized } from '@/lib/schemas'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -19,15 +19,15 @@ const useStyles = makeStyles((theme: Theme) =>
  *
  * @param props.experiment - The experiment with the general information.
  */
-function GeneralPanel({ experiment }: { experiment: ExperimentFull }) {
+function GeneralPanel({ normalizedExperiment }: { normalizedExperiment: ExperimentFullNormalized }) {
   const classes = useStyles()
   const data = [
-    { label: 'Description', value: experiment.description },
+    { label: 'Description', value: normalizedExperiment.description },
     {
       label: 'P2 Link',
       value: (
-        <a href={experiment.p2Url} rel='noopener noreferrer' target='_blank'>
-          {experiment.p2Url}
+        <a href={normalizedExperiment.p2Url} rel='noopener noreferrer' target='_blank'>
+          {normalizedExperiment.p2Url}
         </a>
       ),
     },
@@ -35,13 +35,13 @@ function GeneralPanel({ experiment }: { experiment: ExperimentFull }) {
       label: 'Dates',
       value: (
         <>
-          <DatetimeText datetime={experiment.startDatetime} excludeTime />
+          <DatetimeText datetime={normalizedExperiment.startDatetime} excludeTime />
           <span className={classes.to}>to</span>
-          <DatetimeText datetime={experiment.endDatetime} excludeTime />
+          <DatetimeText datetime={normalizedExperiment.endDatetime} excludeTime />
         </>
       ),
     },
-    { label: 'Owner', value: experiment.ownerLogin },
+    { label: 'Owner', value: normalizedExperiment.ownerLogin },
   ]
   return <LabelValuePanel data={data} title='General' />
 }

--- a/components/MetricAssignmentsPanel.test.tsx
+++ b/components/MetricAssignmentsPanel.test.tsx
@@ -4,11 +4,12 @@ import Fixtures from '@/test-helpers/fixtures'
 import { render } from '@/test-helpers/test-utils'
 
 import MetricAssignmentsPanel from './MetricAssignmentsPanel'
+import { indexMetrics } from '@/lib/normalizers'
 
 test('renders as expected with all metrics resolvable', () => {
-  const metrics = Fixtures.createMetricBares()
+  const indexedMetrics = indexMetrics(Fixtures.createMetricBares())
   const experiment = Fixtures.createExperimentFull()
-  const { container } = render(<MetricAssignmentsPanel experiment={experiment} metrics={metrics} />)
+  const { container } = render(<MetricAssignmentsPanel metricAssignments={experiment.metricAssignments} indexedMetrics={indexedMetrics} />)
 
   expect(container).toMatchInlineSnapshot(`
     <div>
@@ -179,15 +180,15 @@ test('renders as expected with all metrics resolvable', () => {
 })
 
 test('throws an error when some metrics not resolvable', () => {
-  const metrics = Fixtures.createMetricBares(1)
+  const indexedMetrics = indexMetrics(Fixtures.createMetricBares(1))
   const experiment = Fixtures.createExperimentFull()
 
   // Note: This console.error spy is mainly used to suppress the output that the
   // `render` function outputs.
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  const consoleErrorSpy = jest.spyOn(global.console, 'error').mockImplementation(() => {})
+  const consoleErrorSpy = jest.spyOn(global.console, 'error').mockImplementation(() => { })
   try {
-    render(<MetricAssignmentsPanel experiment={experiment} metrics={metrics} />)
+    render(<MetricAssignmentsPanel metricAssignments={experiment.metricAssignments} indexedMetrics={indexedMetrics} />)
     expect(false).toBe(true) // Should never be reached
   } catch (err) {
     expect(consoleErrorSpy).toHaveBeenCalled()

--- a/components/MetricAssignmentsPanel.test.tsx
+++ b/components/MetricAssignmentsPanel.test.tsx
@@ -1,15 +1,17 @@
 import React from 'react'
 
+import { indexMetrics } from '@/lib/normalizers'
 import Fixtures from '@/test-helpers/fixtures'
 import { render } from '@/test-helpers/test-utils'
 
 import MetricAssignmentsPanel from './MetricAssignmentsPanel'
-import { indexMetrics } from '@/lib/normalizers'
 
 test('renders as expected with all metrics resolvable', () => {
   const indexedMetrics = indexMetrics(Fixtures.createMetricBares())
   const experiment = Fixtures.createExperimentFull()
-  const { container } = render(<MetricAssignmentsPanel metricAssignments={experiment.metricAssignments} indexedMetrics={indexedMetrics} />)
+  const { container } = render(
+    <MetricAssignmentsPanel metricAssignments={experiment.metricAssignments} indexedMetrics={indexedMetrics} />,
+  )
 
   expect(container).toMatchInlineSnapshot(`
     <div>
@@ -186,7 +188,7 @@ test('throws an error when some metrics not resolvable', () => {
   // Note: This console.error spy is mainly used to suppress the output that the
   // `render` function outputs.
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  const consoleErrorSpy = jest.spyOn(global.console, 'error').mockImplementation(() => { })
+  const consoleErrorSpy = jest.spyOn(global.console, 'error').mockImplementation(() => {})
   try {
     render(<MetricAssignmentsPanel metricAssignments={experiment.metricAssignments} indexedMetrics={indexedMetrics} />)
     expect(false).toBe(true) // Should never be reached

--- a/components/MetricAssignmentsPanel.tsx
+++ b/components/MetricAssignmentsPanel.tsx
@@ -6,7 +6,7 @@ import TableCell from '@material-ui/core/TableCell'
 import TableHead from '@material-ui/core/TableHead'
 import TableRow from '@material-ui/core/TableRow'
 import Typography from '@material-ui/core/Typography'
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import Label from '@/components/Label'
 import { AttributionWindowSecondsToHuman } from '@/lib/metric-assignments'
@@ -28,9 +28,18 @@ const useStyles = makeStyles((theme: Theme) =>
 /**
  * Renders the assigned metric information of an experiment in a panel component.
  */
-function MetricAssignmentsPanel({ metricAssignments, indexedMetrics }: { metricAssignments: MetricAssignment[]; indexedMetrics: Record<number, MetricBare> }) {
+function MetricAssignmentsPanel({
+  metricAssignments,
+  indexedMetrics,
+}: {
+  metricAssignments: MetricAssignment[]
+  indexedMetrics: Record<number, MetricBare>
+}) {
   const classes = useStyles()
-  const sortedMetricAssignmentsWithMetrics = MetricAssignments.sort(metricAssignments).map(metricAssignment => ({ metricAssignment, metric: indexedMetrics[metricAssignment.metricAssignmentId] }))
+  const sortedMetricAssignmentsWithMetrics = MetricAssignments.sort(metricAssignments).map((metricAssignment) => ({
+    metricAssignment,
+    metric: indexedMetrics[metricAssignment.metricAssignmentId],
+  }))
 
   return (
     <Paper>
@@ -61,9 +70,7 @@ function MetricAssignmentsPanel({ metricAssignments, indexedMetrics }: { metricA
                 {metric.name}
                 {metricAssignment.isPrimary && <Label className={classes.primary} text='Primary' />}
               </TableCell>
-              <TableCell>
-                {AttributionWindowSecondsToHuman[metricAssignment.attributionWindowSeconds]}
-              </TableCell>
+              <TableCell>{AttributionWindowSecondsToHuman[metricAssignment.attributionWindowSeconds]}</TableCell>
               <TableCell>{formatBoolean(metricAssignment.changeExpected)}</TableCell>
               <TableCell>
                 <span>

--- a/components/MetricAssignmentsPanel.tsx
+++ b/components/MetricAssignmentsPanel.tsx
@@ -36,10 +36,15 @@ function MetricAssignmentsPanel({
   indexedMetrics: Record<number, MetricBare>
 }) {
   const classes = useStyles()
-  const sortedMetricAssignmentsWithMetrics = MetricAssignments.sort(metricAssignments).map((metricAssignment) => ({
-    metricAssignment,
-    metric: indexedMetrics[metricAssignment.metricAssignmentId],
-  }))
+  const sortedMetricAssignmentsWithMetrics = MetricAssignments.sort(metricAssignments).map((metricAssignment) => {
+    const metric = indexedMetrics[metricAssignment.metricId]
+    if (!metric) {
+      throw new Error(
+        `Could not find metric corresponding to metricAssignment. metricAssignmentId: '${metricAssignment.metricAssignmentId}'`,
+      )
+    }
+    return { metricAssignment, metric }
+  })
 
   return (
     <Paper>

--- a/components/SegmentsTable.test.tsx
+++ b/components/SegmentsTable.test.tsx
@@ -1,17 +1,17 @@
 import React from 'react'
 
-import { Segment, SegmentType } from '@/lib/schemas'
+import { Segment, SegmentType, SegmentAssignment } from '@/lib/schemas'
 import { render } from '@/test-helpers/test-utils'
 
 import SegmentsTable from './SegmentsTable'
 
 test('renders as expected with segment names not in order', () => {
-  const resolvedSegmentAssignments: Array<{ segment: Segment; isExcluded: boolean }> = [
-    { segment: { segmentId: 1, name: 'foo', type: SegmentType.Country }, isExcluded: false },
-    { segment: { segmentId: 2, name: 'bar', type: SegmentType.Country }, isExcluded: true },
+  const segmentAssignmentsWithSegments: Array<{ segment: Segment; segmentAssignment: SegmentAssignment }> = [
+    { segment: { segmentId: 1, name: 'foo', type: SegmentType.Country }, segmentAssignment: { segmentAssignmentId: 0, segmentId: 1, isExcluded: false } },
+    { segment: { segmentId: 2, name: 'bar', type: SegmentType.Country }, segmentAssignment: { segmentAssignmentId: 1, segmentId: 2, isExcluded: true } },
   ]
   const { container } = render(
-    <SegmentsTable resolvedSegmentAssignments={resolvedSegmentAssignments} type={SegmentType.Country} />,
+    <SegmentsTable segmentAssignmentsWithSegments={segmentAssignmentsWithSegments} type={SegmentType.Country} />,
   )
 
   expect(container).toMatchInlineSnapshot(`

--- a/components/SegmentsTable.test.tsx
+++ b/components/SegmentsTable.test.tsx
@@ -1,14 +1,20 @@
 import React from 'react'
 
-import { Segment, SegmentType, SegmentAssignment } from '@/lib/schemas'
+import { Segment, SegmentAssignment, SegmentType } from '@/lib/schemas'
 import { render } from '@/test-helpers/test-utils'
 
 import SegmentsTable from './SegmentsTable'
 
 test('renders as expected with segment names not in order', () => {
   const segmentAssignmentsWithSegments: Array<{ segment: Segment; segmentAssignment: SegmentAssignment }> = [
-    { segment: { segmentId: 1, name: 'foo', type: SegmentType.Country }, segmentAssignment: { segmentAssignmentId: 0, segmentId: 1, isExcluded: false } },
-    { segment: { segmentId: 2, name: 'bar', type: SegmentType.Country }, segmentAssignment: { segmentAssignmentId: 1, segmentId: 2, isExcluded: true } },
+    {
+      segment: { segmentId: 1, name: 'foo', type: SegmentType.Country },
+      segmentAssignment: { segmentAssignmentId: 0, segmentId: 1, isExcluded: false },
+    },
+    {
+      segment: { segmentId: 2, name: 'bar', type: SegmentType.Country },
+      segmentAssignment: { segmentAssignmentId: 1, segmentId: 2, isExcluded: true },
+    },
   ]
   const { container } = render(
     <SegmentsTable segmentAssignmentsWithSegments={segmentAssignmentsWithSegments} type={SegmentType.Country} />,

--- a/components/SegmentsTable.tsx
+++ b/components/SegmentsTable.tsx
@@ -5,10 +5,10 @@ import TableCell from '@material-ui/core/TableCell'
 import TableHead from '@material-ui/core/TableHead'
 import TableRow from '@material-ui/core/TableRow'
 import _ from 'lodash'
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import Label from '@/components/Label'
-import { Segment, SegmentType, SegmentAssignment } from '@/lib/schemas'
+import { Segment, SegmentAssignment, SegmentType } from '@/lib/schemas'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -60,18 +60,20 @@ function SegmentsTable({
             <TableCell>All {type === SegmentType.Country ? 'countries' : 'locales'} included</TableCell>
           </TableRow>
         ) : (
-            sortedSegmentAssignmentsWithSegments.map(
-              (resolvedSegmentAssignment) =>
-                resolvedSegmentAssignment.segment && (
-                  <TableRow key={resolvedSegmentAssignment.segment.segmentId}>
-                    <TableCell>
-                      {resolvedSegmentAssignment.segment.name}
-                      {resolvedSegmentAssignment.segmentAssignment.isExcluded && <Label className={classes.excluded} text='Excluded' />}
-                    </TableCell>
-                  </TableRow>
-                ),
-            )
-          )}
+          sortedSegmentAssignmentsWithSegments.map(
+            (resolvedSegmentAssignment) =>
+              resolvedSegmentAssignment.segment && (
+                <TableRow key={resolvedSegmentAssignment.segment.segmentId}>
+                  <TableCell>
+                    {resolvedSegmentAssignment.segment.name}
+                    {resolvedSegmentAssignment.segmentAssignment.isExcluded && (
+                      <Label className={classes.excluded} text='Excluded' />
+                    )}
+                  </TableCell>
+                </TableRow>
+              ),
+          )
+        )}
       </TableBody>
     </Table>
   )

--- a/components/SegmentsTable.tsx
+++ b/components/SegmentsTable.tsx
@@ -8,7 +8,7 @@ import _ from 'lodash'
 import React, { useMemo } from 'react'
 
 import Label from '@/components/Label'
-import { Segment, SegmentType } from '@/lib/schemas'
+import { Segment, SegmentType, SegmentAssignment } from '@/lib/schemas'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -29,24 +29,21 @@ const SegmentTypeToHeading = {
 /**
  * Renders the segments of a particular type.
  *
- * @param props.resolvedSegmentAssignments - The segment assignments with the
- *   segment IDs resolved to the actual segment.
+ * @param props.segmentAssignmentsWithSegments - SegmentAssignments left joined with Segments
  * @param props.type - The segment type the segment assignments represent.
  */
 function SegmentsTable({
-  resolvedSegmentAssignments,
+  segmentAssignmentsWithSegments: segmentAssignmentsWithSegments,
   type,
 }: {
-  resolvedSegmentAssignments: {
+  segmentAssignmentsWithSegments: {
     segment: Segment
-    isExcluded: boolean
+    segmentAssignment: SegmentAssignment
   }[]
   type: SegmentType
 }) {
-  const sortedResolvedSegmentAssignments = useMemo(
-    () => _.orderBy(resolvedSegmentAssignments, [_.property('segment.name')]),
-    [resolvedSegmentAssignments],
-  )
+  const sortedSegmentAssignmentsWithSegments = _.orderBy(segmentAssignmentsWithSegments, [_.property('segment.name')])
+
   const classes = useStyles()
   return (
     <Table>
@@ -58,23 +55,23 @@ function SegmentsTable({
         </TableRow>
       </TableHead>
       <TableBody>
-        {resolvedSegmentAssignments.length === 0 ? (
+        {segmentAssignmentsWithSegments.length === 0 ? (
           <TableRow>
             <TableCell>All {type === SegmentType.Country ? 'countries' : 'locales'} included</TableCell>
           </TableRow>
         ) : (
-          sortedResolvedSegmentAssignments.map(
-            (resolvedSegmentAssignment) =>
-              resolvedSegmentAssignment.segment && (
-                <TableRow key={resolvedSegmentAssignment.segment.segmentId}>
-                  <TableCell>
-                    {resolvedSegmentAssignment.segment.name}
-                    {resolvedSegmentAssignment.isExcluded && <Label className={classes.excluded} text='Excluded' />}
-                  </TableCell>
-                </TableRow>
-              ),
-          )
-        )}
+            sortedSegmentAssignmentsWithSegments.map(
+              (resolvedSegmentAssignment) =>
+                resolvedSegmentAssignment.segment && (
+                  <TableRow key={resolvedSegmentAssignment.segment.segmentId}>
+                    <TableCell>
+                      {resolvedSegmentAssignment.segment.name}
+                      {resolvedSegmentAssignment.segmentAssignment.isExcluded && <Label className={classes.excluded} text='Excluded' />}
+                    </TableCell>
+                  </TableRow>
+                ),
+            )
+          )}
       </TableBody>
     </Table>
   )

--- a/lib/experiments.test.ts
+++ b/lib/experiments.test.ts
@@ -1,8 +1,8 @@
 import Fixtures from '@/test-helpers/fixtures'
 
 import * as Experiments from './experiments'
-import { AnalysisStrategy } from './schemas'
 import { normalizeExperiment } from './normalizers'
+import { AnalysisStrategy } from './schemas'
 
 describe('lib/experiments.ts module', () => {
   describe('getPrimaryMetricAssignmentId', () => {
@@ -28,8 +28,16 @@ describe('lib/experiments.ts module', () => {
           )[0],
         ),
       ).toBe(true)
-      expect(Experiments.hasConclusionData(normalizeExperiment(Fixtures.createExperimentFull({ deployedVariationId: 1 }))[0])).toBe(true)
-      expect(Experiments.hasConclusionData(normalizeExperiment(Fixtures.createExperimentFull({ endReason: 'Ran its course.' }))[0])).toBe(true)
+      expect(
+        Experiments.hasConclusionData(
+          normalizeExperiment(Fixtures.createExperimentFull({ deployedVariationId: 1 }))[0],
+        ),
+      ).toBe(true)
+      expect(
+        Experiments.hasConclusionData(
+          normalizeExperiment(Fixtures.createExperimentFull({ endReason: 'Ran its course.' }))[0],
+        ),
+      ).toBe(true)
     })
 
     it('should return false if no conclusion data is set', () => {

--- a/lib/experiments.test.ts
+++ b/lib/experiments.test.ts
@@ -5,27 +5,6 @@ import { AnalysisStrategy } from './schemas'
 import { normalizeExperiment } from './normalizers'
 
 describe('lib/experiments.ts module', () => {
-  describe('getDeployedVariation', () => {
-    it('should return null when no deployed variation declared', () => {
-      expect(Experiments.getDeployedVariation(Fixtures.createExperimentFull())).toBeNull()
-    })
-
-    it('should return the deployed variation when declared', () => {
-      expect(Experiments.getDeployedVariation(Fixtures.createExperimentFull({ deployedVariationId: 1 }))).toEqual({
-        variationId: 1,
-        name: 'control',
-        isDefault: true,
-        allocatedPercentage: 60,
-      })
-    })
-
-    it('should throw an error when deployed variation is declared but cannot be resolved', () => {
-      expect(() => {
-        Experiments.getDeployedVariation(Fixtures.createExperimentFull({ deployedVariationId: 0 }))
-      }).toThrowError()
-    })
-  })
-
   describe('getPrimaryMetricAssignmentId', () => {
     it('returns the primary assignment ID when it exists', () => {
       expect(Experiments.getPrimaryMetricAssignmentId(Fixtures.createExperimentFull())).toBe(123)

--- a/lib/experiments.test.ts
+++ b/lib/experiments.test.ts
@@ -2,6 +2,7 @@ import Fixtures from '@/test-helpers/fixtures'
 
 import * as Experiments from './experiments'
 import { AnalysisStrategy } from './schemas'
+import { normalizeExperiment } from './normalizers'
 
 describe('lib/experiments.ts module', () => {
   describe('getDeployedVariation', () => {
@@ -41,17 +42,19 @@ describe('lib/experiments.ts module', () => {
     it('should return true if at least one piece of conclusion data is set', () => {
       expect(
         Experiments.hasConclusionData(
-          Fixtures.createExperimentFull({
-            conclusionUrl: 'https://betterexperiments.wordpress.com/experiment_1/conclusion',
-          }),
+          normalizeExperiment(
+            Fixtures.createExperimentFull({
+              conclusionUrl: 'https://betterexperiments.wordpress.com/experiment_1/conclusion',
+            }),
+          )[0],
         ),
       ).toBe(true)
-      expect(Experiments.hasConclusionData(Fixtures.createExperimentFull({ deployedVariationId: 1 }))).toBe(true)
-      expect(Experiments.hasConclusionData(Fixtures.createExperimentFull({ endReason: 'Ran its course.' }))).toBe(true)
+      expect(Experiments.hasConclusionData(normalizeExperiment(Fixtures.createExperimentFull({ deployedVariationId: 1 }))[0])).toBe(true)
+      expect(Experiments.hasConclusionData(normalizeExperiment(Fixtures.createExperimentFull({ endReason: 'Ran its course.' }))[0])).toBe(true)
     })
 
     it('should return false if no conclusion data is set', () => {
-      expect(Experiments.hasConclusionData(Fixtures.createExperimentFull())).toBe(false)
+      expect(Experiments.hasConclusionData(normalizeExperiment(Fixtures.createExperimentFull())[0])).toBe(false)
     })
   })
 

--- a/lib/experiments.ts
+++ b/lib/experiments.ts
@@ -1,4 +1,4 @@
-import { AnalysisStrategy, ExperimentFull, Platform, Variation, ExperimentFullNormalized } from './schemas'
+import { AnalysisStrategy, ExperimentFull, ExperimentFullNormalized, Platform } from './schemas'
 
 /**
  * Return the primary metric assignment ID for this experiment if one exists.
@@ -11,7 +11,11 @@ export function getPrimaryMetricAssignmentId(experiment: ExperimentFull): number
  * Determines whether conclusion data has been entered for this experiment.
  */
 export function hasConclusionData(normalizedExperiment: ExperimentFullNormalized): boolean {
-  return !!normalizedExperiment.endReason || !!normalizedExperiment.conclusionUrl || typeof normalizedExperiment.deployedVariationId === 'number'
+  return (
+    !!normalizedExperiment.endReason ||
+    !!normalizedExperiment.conclusionUrl ||
+    typeof normalizedExperiment.deployedVariationId === 'number'
+  )
 }
 
 /**

--- a/lib/experiments.ts
+++ b/lib/experiments.ts
@@ -1,30 +1,6 @@
 import { AnalysisStrategy, ExperimentFull, Platform, Variation, ExperimentFullNormalized } from './schemas'
 
 /**
- * Return the deployed variation if one has been selected, otherwise `null`.
- *
- * @throws {Error} If a `deployedVariationId` is set but cannot be found in the
- *   variations.
- */
-export function getDeployedVariation(experiment: ExperimentFull): null | Variation {
-  let deployedVariation = null
-
-  if (typeof experiment.deployedVariationId === 'number') {
-    deployedVariation = experiment.variations.find(
-      (variation) => experiment.deployedVariationId === variation.variationId,
-    )
-
-    if (!deployedVariation) {
-      throw Error(
-        `Failed to resolve the deployed variation with ID ${experiment.deployedVariationId} for experiment with ID ${experiment.experimentId}.`,
-      )
-    }
-  }
-
-  return deployedVariation
-}
-
-/**
  * Return the primary metric assignment ID for this experiment if one exists.
  */
 export function getPrimaryMetricAssignmentId(experiment: ExperimentFull): number | null {

--- a/lib/experiments.ts
+++ b/lib/experiments.ts
@@ -1,4 +1,4 @@
-import { AnalysisStrategy, ExperimentFull, Platform, Variation } from './schemas'
+import { AnalysisStrategy, ExperimentFull, Platform, Variation, ExperimentFullNormalized } from './schemas'
 
 /**
  * Return the deployed variation if one has been selected, otherwise `null`.
@@ -34,8 +34,8 @@ export function getPrimaryMetricAssignmentId(experiment: ExperimentFull): number
 /**
  * Determines whether conclusion data has been entered for this experiment.
  */
-export function hasConclusionData(experiment: ExperimentFull): boolean {
-  return !!experiment.endReason || !!experiment.conclusionUrl || typeof experiment.deployedVariationId === 'number'
+export function hasConclusionData(normalizedExperiment: ExperimentFullNormalized): boolean {
+  return !!normalizedExperiment.endReason || !!normalizedExperiment.conclusionUrl || typeof normalizedExperiment.deployedVariationId === 'number'
 }
 
 /**

--- a/lib/normalizers.test.ts
+++ b/lib/normalizers.test.ts
@@ -24,4 +24,21 @@ describe('lib/normalizers.ts module', () => {
       expect(Normalizers.indexSegments(segments)).toEqual({ 1: segments[0], 2: segments[1] })
     })
   })
+
+  describe('normalizeExperiment', () => {
+    it('normalizes an empty experiment', () => {
+      const experiment = { experimentId: 0 }
+      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+      // @ts-ignore; This is just for minimal testing
+      expect(Normalizers.normalizeExperiment(experiment)).toEqual([
+        experiment,
+        {
+          experiments: { 0: experiment },
+          metricAssignments: {},
+          segmentAssignments: {},
+          variations: {},
+        },
+      ])
+    })
+  })
 })

--- a/lib/normalizers.ts
+++ b/lib/normalizers.ts
@@ -3,7 +3,6 @@ import { normalize, schema } from 'normalizr'
 import {
   ExperimentFull,
   ExperimentFullNormalized,
-  ExperimentFullNormalizedData,
   ExperimentFullNormalizedEntities,
   experimentFullNormalizrSchema,
   MetricBare,
@@ -30,15 +29,21 @@ export function indexSegments(segments: Segment[]): Record<number, Segment> {
 }
 
 /**
- * Returns a tuple of normalizedExperiment and normalizedExperimentData (normalizr format, includes all nested entities).
+ * Returns a tuple of normalizedExperiment and normalizedExperimentEntities (all the entities in experiment including experiment itself).
  */
 export function normalizeExperiment(
   experiment: ExperimentFull,
-): [ExperimentFullNormalized, ExperimentFullNormalizedData] {
+): [ExperimentFullNormalized, ExperimentFullNormalizedEntities] {
   const normalizedExperimentData = normalize<ExperimentFull, ExperimentFullNormalizedEntities>(
     experiment,
     experimentFullNormalizrSchema,
   )
   const normalizedExperiment = normalizedExperimentData.entities.experiments[normalizedExperimentData.result]
-  return [normalizedExperiment, normalizedExperimentData]
+  const entities = {
+    experiments: normalizedExperimentData.entities.experiments,
+    metricAssignments: normalizedExperimentData.entities.metricAssignments || {},
+    segmentAssignments: normalizedExperimentData.entities.segmentAssignments || {},
+    variations: normalizedExperimentData.entities.variations || {},
+  }
+  return [normalizedExperiment, entities]
 }

--- a/lib/normalizers.ts
+++ b/lib/normalizers.ts
@@ -1,6 +1,13 @@
 import { normalize, schema } from 'normalizr'
 
-import { MetricBare, MetricFull, Segment } from './schemas'
+import {
+  ExperimentFull,
+  ExperimentFullNormalizedEntities,
+  experimentFullNormalizrSchema,
+  MetricBare,
+  MetricFull,
+  Segment,
+} from './schemas'
 
 const metricNormalizrSchema = new schema.Entity<MetricBare | MetricFull>('metrics', {}, { idAttribute: 'metricId' })
 
@@ -18,4 +25,16 @@ const segmentNormalizrSchema = new schema.Entity<Segment>('segments', {}, { idAt
  */
 export function indexSegments(segments: Segment[]): Record<number, Segment> {
   return normalize<Segment>(segments, [segmentNormalizrSchema]).entities.segments || {}
+}
+
+/**
+ * Returns a tuple of normalizedExperiment and normalizedExperimentData (normalizr format, includes all nested entities).
+ */
+export function normalizeExperiment(experiment: ExperimentFull) {
+  const normalizedExperimentData = normalize<ExperimentFull, ExperimentFullNormalizedEntities>(
+    experiment,
+    experimentFullNormalizrSchema,
+  )
+  const normalizedExperiment = normalizedExperimentData.entities.experiments[normalizedExperimentData.result]
+  return [normalizedExperiment, normalizedExperimentData]
 }

--- a/lib/normalizers.ts
+++ b/lib/normalizers.ts
@@ -2,6 +2,8 @@ import { normalize, schema } from 'normalizr'
 
 import {
   ExperimentFull,
+  ExperimentFullNormalized,
+  ExperimentFullNormalizedData,
   ExperimentFullNormalizedEntities,
   experimentFullNormalizrSchema,
   MetricBare,
@@ -30,7 +32,9 @@ export function indexSegments(segments: Segment[]): Record<number, Segment> {
 /**
  * Returns a tuple of normalizedExperiment and normalizedExperimentData (normalizr format, includes all nested entities).
  */
-export function normalizeExperiment(experiment: ExperimentFull) {
+export function normalizeExperiment(
+  experiment: ExperimentFull,
+): [ExperimentFullNormalized, ExperimentFullNormalizedData] {
   const normalizedExperimentData = normalize<ExperimentFull, ExperimentFullNormalizedEntities>(
     experiment,
     experimentFullNormalizrSchema,

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -232,7 +232,7 @@ export type ExperimentFull = yup.InferType<typeof experimentFullSchema>
 export const experimentFullNormalizrSchema = new normalizr.schema.Entity<ExperimentFull>(
   'experiments',
   {
-    metricsAssignments: [metricAssignmentNormalizrSchema],
+    metricAssignments: [metricAssignmentNormalizrSchema],
     segmentAssignments: [segmentAssignmentNormalizrSchema],
     variations: [variationNormalizrSchema],
   },

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -2,9 +2,9 @@
 // https://app.swaggerhub.com/apis/yanir/experiments/0.1.0
 
 import * as dateFns from 'date-fns'
+import _ from 'lodash'
 import * as normalizr from 'normalizr'
 import * as yup from 'yup'
-import _ from 'lodash'
 
 const idSchema = yup.number().integer().positive()
 const nameSchema = yup
@@ -225,14 +225,16 @@ export const experimentFullSchema = experimentBareSchema
     exposureEvents: yup.array<Event>(eventSchema).nullable(),
     metricAssignments: yup.array(metricAssignmentSchema).defined().min(1),
     segmentAssignments: yup.array(segmentAssignmentSchema).defined(),
-    variations: yup.array<Variation>(variationSchema).defined().min(2)
+    variations: yup.array<Variation>(variationSchema).defined().min(2),
   })
   .test(
     'deployedVariationId-variation-check',
     'Could not find variation matching deployedVariationId.',
-    async (experiment) => {
-      return _.isNumber(experiment.deployedVariationId) ? experiment.variations.some((variation: Variation) => variation.variationId === experiment.deployedVariationId) : true
-    }
+    (experiment) => {
+      return _.isNumber(experiment.deployedVariationId)
+        ? experiment.variations.some((variation: Variation) => variation.variationId === experiment.deployedVariationId)
+        : true
+    },
   )
   .defined()
   .camelCase()

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -4,6 +4,7 @@
 import * as dateFns from 'date-fns'
 import * as normalizr from 'normalizr'
 import * as yup from 'yup'
+import _ from 'lodash'
 
 const idSchema = yup.number().integer().positive()
 const nameSchema = yup
@@ -224,8 +225,15 @@ export const experimentFullSchema = experimentBareSchema
     exposureEvents: yup.array<Event>(eventSchema).nullable(),
     metricAssignments: yup.array(metricAssignmentSchema).defined().min(1),
     segmentAssignments: yup.array(segmentAssignmentSchema).defined(),
-    variations: yup.array<Variation>(variationSchema).defined().min(2),
+    variations: yup.array<Variation>(variationSchema).defined().min(2)
   })
+  .test(
+    'deployedVariationId-variation-check',
+    'Could not find variation matching deployedVariationId.',
+    async (experiment) => {
+      return _.isNumber(experiment.deployedVariationId) ? experiment.variations.some((variation: Variation) => variation.variationId === experiment.deployedVariationId) : true
+    }
+  )
   .defined()
   .camelCase()
 export type ExperimentFull = yup.InferType<typeof experimentFullSchema>

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -232,9 +232,8 @@ export const experimentFullSchema = experimentBareSchema
     'Could not find variation matching deployedVariationId.',
     /* istanbul ignore next; this is a data validation test itself */
     (experiment) => {
-      return _.isNumber(experiment.deployedVariationId)
-        ? experiment.variations.some((variation: Variation) => variation.variationId === experiment.deployedVariationId)
-        : true
+      return _.isNull(experiment.deployedVariation) ||
+        experiment.variations.some((variation: Variation) => variation.variationId === experiment.deployedVariationId)
     },
   )
   .defined()

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -252,6 +252,7 @@ export interface ExperimentFullNormalizedEntities {
   segmentAssignments: Record<number, SegmentAssignment>
   variations: Record<number, Variation>
 }
+export type ExperimentFullNormalizedData = normalizr.NormalizedSchema<ExperimentFullNormalizedEntities, number>
 
 const now = new Date()
 export const experimentFullNewSchema = experimentFullSchema.shape({

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -238,6 +238,20 @@ export const experimentFullNormalizrSchema = new normalizr.schema.Entity<Experim
   },
   { idAttribute: 'experimentId' },
 )
+export type ExperimentFullNormalized = Omit<
+  ExperimentFull,
+  'metricAssignments' | 'segmentAssignments' | 'variations'
+> & {
+  metricAssignments: number[]
+  segmentAssignments: number[]
+  variations: number[]
+}
+export interface ExperimentFullNormalizedEntities {
+  experiments: Record<number, ExperimentFullNormalized>
+  metricAssignments: Record<number, MetricAssignment>
+  segmentAssignments: Record<number, SegmentAssignment>
+  variations: Record<number, Variation>
+}
 
 const now = new Date()
 export const experimentFullNewSchema = experimentFullSchema.shape({

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -230,6 +230,7 @@ export const experimentFullSchema = experimentBareSchema
   .test(
     'deployedVariationId-variation-check',
     'Could not find variation matching deployedVariationId.',
+    /* istanbul ignore next; this is a data validation test itself */
     (experiment) => {
       return _.isNumber(experiment.deployedVariationId)
         ? experiment.variations.some((variation: Variation) => variation.variationId === experiment.deployedVariationId)
@@ -262,7 +263,6 @@ export interface ExperimentFullNormalizedEntities {
   segmentAssignments: Record<number, SegmentAssignment>
   variations: Record<number, Variation>
 }
-export type ExperimentFullNormalizedData = normalizr.NormalizedSchema<ExperimentFullNormalizedEntities, number>
 
 const now = new Date()
 export const experimentFullNewSchema = experimentFullSchema.shape({

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -2,6 +2,7 @@
 // https://app.swaggerhub.com/apis/yanir/experiments/0.1.0
 
 import * as dateFns from 'date-fns'
+import * as normalizr from 'normalizr'
 import * as yup from 'yup'
 
 const idSchema = yup.number().integer().positive()
@@ -116,6 +117,11 @@ export const metricAssignmentSchema = metricAssignmentNewSchema
   .defined()
   .camelCase()
 export type MetricAssignment = yup.InferType<typeof metricAssignmentSchema>
+export const metricAssignmentNormalizrSchema = new normalizr.schema.Entity<MetricAssignment>(
+  'metricAssignments',
+  {},
+  { idAttribute: 'metricAssignmentId' },
+)
 
 export enum SegmentType {
   Country = 'country',
@@ -149,6 +155,11 @@ export const segmentAssignmentSchema = segmentAssignmentNewSchema
   .defined()
   .camelCase()
 export type SegmentAssignment = yup.InferType<typeof segmentAssignmentSchema>
+export const segmentAssignmentNormalizrSchema = new normalizr.schema.Entity<SegmentAssignment>(
+  'segmentAssignments',
+  {},
+  { idAttribute: 'segmentAssignmentId' },
+)
 
 export const variationNewSchema = yup
   .object({
@@ -168,6 +179,11 @@ export const variationSchema = variationNewSchema
   .defined()
   .camelCase()
 export type Variation = yup.InferType<typeof variationSchema>
+export const variationNormalizrSchema = new normalizr.schema.Entity<Variation>(
+  'variations',
+  {},
+  { idAttribute: 'variationId' },
+)
 
 export enum Platform {
   Calypso = 'calypso',
@@ -213,6 +229,15 @@ export const experimentFullSchema = experimentBareSchema
   .defined()
   .camelCase()
 export type ExperimentFull = yup.InferType<typeof experimentFullSchema>
+export const experimentFullNormalizrSchema = new normalizr.schema.Entity<ExperimentFull>(
+  'experiments',
+  {
+    metricsAssignments: [metricAssignmentNormalizrSchema],
+    segmentAssignments: [segmentAssignmentNormalizrSchema],
+    variations: [variationNormalizrSchema],
+  },
+  { idAttribute: 'experimentId' },
+)
 
 const now = new Date()
 export const experimentFullNewSchema = experimentFullSchema.shape({


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR adds normalized data usage in ExperimentDetails:**
- Adds `normalizr` schemas for experiment
- Adds `normalizeExperiment` function
- Removes `Experiments.getDeployedVariation` as it is no longer necessary
   - Add data test for `deployedVariationId` - this will check on outgoing data as well as incoming. 
- Removes `resolveMetricAssignments` in MetricsPanel
- Removes `resolveSegmentAssignments` from SegmentsPanel

Looks like a lot but isn't too much:
- 7 of the files are test files where we just change them to use normalized data.
- Other than the above removal we are just adding and threading the normalized data through.

This is part 2/3 of #236 and should be done before we do further work in ExperimentDetails for the CRUD.
- A departure is that I am using `normalizedXEntities` instead of `normalizedXData` as it makes things simpler.

See also part 1/3 at #240.

<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with mock data (locally)
