### PR TITLE
Add metric CRUD buttons

### DIFF
--- a/components/MetricsTable.test.tsx
+++ b/components/MetricsTable.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, getByText, getDefaultNormalizer, waitFor } from '@testing-library/react'
+import { fireEvent, getByText, getDefaultNormalizer, waitFor, screen } from '@testing-library/react'
 import * as notistack from 'notistack'
 import React from 'react'
 
@@ -69,4 +69,15 @@ test('with some metrics, loads and opens metric details', async () => {
     // Close metric details
     fireEvent.click(getByText(container, /metric_1/))
   }
+})
+
+test('with some metrics and canEditMetrics can click on the edit button', () => {
+  const onEditMetric = jest.fn()
+  const { container: _container } = render(<MetricsTable metrics={Fixtures.createMetricBares(2)} canEditMetrics={true} onEditMetric={onEditMetric} />)
+
+  const edits = screen.getAllByRole('button', { name: 'Edit Metric' })
+
+  fireEvent.click(edits[0])
+
+  expect(onEditMetric.mock.calls.length).toBe(1)
 })

--- a/components/MetricsTable.test.tsx
+++ b/components/MetricsTable.test.tsx
@@ -74,7 +74,7 @@ test('with some metrics, loads and opens metric details', async () => {
 test('with some metrics and canEditMetrics can click on the edit button', () => {
   const onEditMetric = jest.fn()
   const { container: _container } = render(
-    <MetricsTable metrics={Fixtures.createMetricBares(2)} canEditMetrics={true} onEditMetric={onEditMetric} />,
+    <MetricsTable metrics={Fixtures.createMetricBares(2)} onEditMetric={onEditMetric} />,
   )
 
   const edits = screen.getAllByRole('button', { name: 'Edit Metric' })

--- a/components/MetricsTable.test.tsx
+++ b/components/MetricsTable.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, getByText, getDefaultNormalizer, waitFor, screen } from '@testing-library/react'
+import { fireEvent, getByText, getDefaultNormalizer, screen, waitFor } from '@testing-library/react'
 import * as notistack from 'notistack'
 import React from 'react'
 
@@ -73,7 +73,9 @@ test('with some metrics, loads and opens metric details', async () => {
 
 test('with some metrics and canEditMetrics can click on the edit button', () => {
   const onEditMetric = jest.fn()
-  const { container: _container } = render(<MetricsTable metrics={Fixtures.createMetricBares(2)} canEditMetrics={true} onEditMetric={onEditMetric} />)
+  const { container: _container } = render(
+    <MetricsTable metrics={Fixtures.createMetricBares(2)} canEditMetrics={true} onEditMetric={onEditMetric} />,
+  )
 
   const edits = screen.getAllByRole('button', { name: 'Edit Metric' })
 

--- a/components/MetricsTable.tsx
+++ b/components/MetricsTable.tsx
@@ -93,9 +93,16 @@ const MetricDetail = ({ metricBare }: { metricBare: MetricBare }) => {
 /**
  * Renders a table of "bare" metric information.
  */
-const MetricsTable = ({ metrics, canEditMetrics, onEditMetric }: { metrics: MetricBare[], canEditMetrics?: boolean, onEditMetric?: (metricId: number) => void }) => {
+const MetricsTable = ({
+  metrics,
+  canEditMetrics,
+  onEditMetric,
+}: {
+  metrics: MetricBare[]
+  canEditMetrics?: boolean
+  onEditMetric?: (metricId: number) => void
+}) => {
   debug('MetricsTable#render')
-
 
   const theme = useTheme()
   const tableColumns = [
@@ -125,17 +132,23 @@ const MetricsTable = ({ metrics, canEditMetrics, onEditMetric }: { metrics: Metr
 
   return (
     <MaterialTable
-      actions={canEditMetrics ? [{
-        icon: 'edit',
-        tooltip: 'Edit Metric',
-        onClick: (_event, rowData) => {
-          // istanbul ignore next; this should never happen
-          if (!onEditMetric) {
-            throw new Error('Missing onEditMetric while canEditMetrics = true')
-          }
-          onEditMetric((rowData as MetricBare).metricId)
-        }
-      }] : undefined}
+      actions={
+        canEditMetrics
+          ? [
+              {
+                icon: 'edit',
+                tooltip: 'Edit Metric',
+                onClick: (_event, rowData) => {
+                  // istanbul ignore next; this should never happen
+                  if (!onEditMetric) {
+                    throw new Error('Missing onEditMetric while canEditMetrics = true')
+                  }
+                  onEditMetric((rowData as MetricBare).metricId)
+                },
+              },
+            ]
+          : undefined
+      }
       columns={tableColumns}
       data={metrics}
       onRowClick={(_event, _rowData, togglePanel) => togglePanel && togglePanel()}

--- a/components/MetricsTable.tsx
+++ b/components/MetricsTable.tsx
@@ -93,8 +93,9 @@ const MetricDetail = ({ metricBare }: { metricBare: MetricBare }) => {
 /**
  * Renders a table of "bare" metric information.
  */
-const MetricsTable = ({ metrics, canEditMetrics, onEditMetric }: { metrics: MetricBare[], canEditMetrics: boolean, onEditMetric: (metricId: number) => void }) => {
+const MetricsTable = ({ metrics, canEditMetrics, onEditMetric }: { metrics: MetricBare[], canEditMetrics?: boolean, onEditMetric?: (metricId: number) => void }) => {
   debug('MetricsTable#render')
+
 
   const theme = useTheme()
   const tableColumns = [
@@ -128,6 +129,10 @@ const MetricsTable = ({ metrics, canEditMetrics, onEditMetric }: { metrics: Metr
         icon: 'edit',
         tooltip: 'Edit Metric',
         onClick: (_event, rowData) => {
+          // istanbul ignore next; this should never happen
+          if (!onEditMetric) {
+            throw new Error('Missing onEditMetric while canEditMetrics = true')
+          }
           onEditMetric((rowData as MetricBare).metricId)
         }
       }] : undefined}

--- a/components/MetricsTable.tsx
+++ b/components/MetricsTable.tsx
@@ -93,7 +93,7 @@ const MetricDetail = ({ metricBare }: { metricBare: MetricBare }) => {
 /**
  * Renders a table of "bare" metric information.
  */
-const MetricsTable = ({ metrics }: { metrics: MetricBare[] }) => {
+const MetricsTable = ({ metrics, canEditMetrics, onEditMetric }: { metrics: MetricBare[], canEditMetrics: boolean, onEditMetric: (metricId: number) => void }) => {
   debug('MetricsTable#render')
 
   const theme = useTheme()
@@ -124,10 +124,20 @@ const MetricsTable = ({ metrics }: { metrics: MetricBare[] }) => {
 
   return (
     <MaterialTable
+      actions={canEditMetrics ? [{
+        icon: 'edit',
+        tooltip: 'Edit Metric',
+        onClick: (_event, rowData) => {
+          onEditMetric((rowData as MetricBare).metricId)
+        }
+      }] : undefined}
       columns={tableColumns}
       data={metrics}
       onRowClick={(_event, _rowData, togglePanel) => togglePanel && togglePanel()}
-      options={defaultTableOptions}
+      options={{
+        ...defaultTableOptions,
+        actionsColumnIndex: 3,
+      }}
       detailPanel={(rowData) => <MetricDetail metricBare={rowData} />}
     />
   )

--- a/components/MetricsTable.tsx
+++ b/components/MetricsTable.tsx
@@ -92,14 +92,14 @@ const MetricDetail = ({ metricBare }: { metricBare: MetricBare }) => {
 
 /**
  * Renders a table of "bare" metric information.
+ *
+ * @param onEditMetric A Callback. Setting this will show the edit action in the table.
  */
 const MetricsTable = ({
   metrics,
-  canEditMetrics,
   onEditMetric,
 }: {
   metrics: MetricBare[]
-  canEditMetrics?: boolean
   onEditMetric?: (metricId: number) => void
 }) => {
   debug('MetricsTable#render')
@@ -133,16 +133,12 @@ const MetricsTable = ({
   return (
     <MaterialTable
       actions={
-        canEditMetrics
+        onEditMetric
           ? [
               {
                 icon: 'edit',
                 tooltip: 'Edit Metric',
                 onClick: (_event, rowData) => {
-                  // istanbul ignore next; this should never happen
-                  if (!onEditMetric) {
-                    throw new Error('Missing onEditMetric while canEditMetrics = true')
-                  }
                   onEditMetric((rowData as MetricBare).metricId)
                 },
               },

--- a/pages/metrics/index.tsx
+++ b/pages/metrics/index.tsx
@@ -39,7 +39,7 @@ const MetricsIndexPage = () => {
         <LinearProgress />
       ) : (
         <>
-          <MetricsTable metrics={metrics || []} onEditMetric={debugMode && onEditMetric} />
+          <MetricsTable metrics={metrics || []} onEditMetric={debugMode ? onEditMetric : undefined} />
           {debugMode && (
             <div className={classes.actions}>
               <Button variant='contained' color='secondary' onClick={onAddMetric}>

--- a/pages/metrics/index.tsx
+++ b/pages/metrics/index.tsx
@@ -40,11 +40,13 @@ const MetricsIndexPage = () => {
       ) : (
         <>
           <MetricsTable canEditMetrics={debugMode} metrics={metrics || []} onEditMetric={onEditMetric} />
-          <div className={classes.actions}>
-            <Button variant='contained' color='secondary' onClick={onAddMetric}>
-              Add Metric
-            </Button>
-          </div>
+          {debugMode && (
+            <div className={classes.actions}>
+              <Button variant='contained' color='secondary' onClick={onAddMetric}>
+                Add Metric
+              </Button>
+            </div>
+          )}
         </>
       )}
     </Layout>

--- a/pages/metrics/index.tsx
+++ b/pages/metrics/index.tsx
@@ -39,7 +39,7 @@ const MetricsIndexPage = () => {
         <LinearProgress />
       ) : (
         <>
-          <MetricsTable canEditMetrics={debugMode} metrics={metrics || []} onEditMetric={onEditMetric} />
+          <MetricsTable metrics={metrics || []} onEditMetric={onEditMetric} />
           {debugMode && (
             <div className={classes.actions}>
               <Button variant='contained' color='secondary' onClick={onAddMetric}>

--- a/pages/metrics/index.tsx
+++ b/pages/metrics/index.tsx
@@ -1,4 +1,4 @@
-import { LinearProgress } from '@material-ui/core'
+import { LinearProgress, Button, createStyles, makeStyles, Theme } from '@material-ui/core'
 import debugFactory from 'debug'
 import React from 'react'
 
@@ -10,26 +10,42 @@ import { useRouter } from 'next/router'
 
 const debug = debugFactory('abacus:pages/metrics/index.tsx')
 
+const useStyles = makeStyles((theme: Theme) => createStyles({
+  actions: {
+    marginTop: theme.spacing(2),
+    display: 'flex',
+    justifyContent: 'flex-end',
+  },
+}))
+
 const MetricsIndexPage = () => {
   debug('MetricsIndexPage#render')
+  const classes = useStyles()
+
   const { isLoading, data: metrics, error } = useDataSource(() => MetricsApi.findAll(), [])
+  useDataLoadingError(error, 'Metrics')
+
   const router = useRouter()
   const debugMode = router.query.debug === 'true'
 
-  useDataLoadingError(error, 'Metrics')
-
   const onEditMetric = (metricId: number) => alert(metricId)
+  const onAddMetric = () => alert('add metric')
 
   return (
     <Layout title='Metrics'>
       {isLoading
         ? <LinearProgress />
-        : <MetricsTable
-          canEditMetrics={debugMode}
-          metrics={metrics || []}
-          onEditMetric={onEditMetric}
-        />}
-    </Layout>
+        : <>
+          <MetricsTable
+            canEditMetrics={debugMode}
+            metrics={metrics || []}
+            onEditMetric={onEditMetric}
+          />
+          <div className={classes.actions}>
+            <Button variant="contained" color="secondary" onClick={onAddMetric}>Add Metric</Button>
+          </div>
+        </>}
+    </Layout >
   )
 }
 

--- a/pages/metrics/index.tsx
+++ b/pages/metrics/index.tsx
@@ -39,7 +39,7 @@ const MetricsIndexPage = () => {
         <LinearProgress />
       ) : (
         <>
-          <MetricsTable metrics={metrics || []} onEditMetric={onEditMetric} />
+          <MetricsTable metrics={metrics || []} onEditMetric={debugMode && onEditMetric} />
           {debugMode && (
             <div className={classes.actions}>
               <Button variant='contained' color='secondary' onClick={onAddMetric}>

--- a/pages/metrics/index.tsx
+++ b/pages/metrics/index.tsx
@@ -1,22 +1,24 @@
-import { LinearProgress, Button, createStyles, makeStyles, Theme } from '@material-ui/core'
+import { Button, createStyles, LinearProgress, makeStyles, Theme } from '@material-ui/core'
 import debugFactory from 'debug'
+import { useRouter } from 'next/router'
 import React from 'react'
 
 import MetricsApi from '@/api/MetricsApi'
 import Layout from '@/components/Layout'
 import MetricsTable from '@/components/MetricsTable'
 import { useDataLoadingError, useDataSource } from '@/utils/data-loading'
-import { useRouter } from 'next/router'
 
 const debug = debugFactory('abacus:pages/metrics/index.tsx')
 
-const useStyles = makeStyles((theme: Theme) => createStyles({
-  actions: {
-    marginTop: theme.spacing(2),
-    display: 'flex',
-    justifyContent: 'flex-end',
-  },
-}))
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    actions: {
+      marginTop: theme.spacing(2),
+      display: 'flex',
+      justifyContent: 'flex-end',
+    },
+  }),
+)
 
 const MetricsIndexPage = () => {
   debug('MetricsIndexPage#render')
@@ -33,19 +35,19 @@ const MetricsIndexPage = () => {
 
   return (
     <Layout title='Metrics'>
-      {isLoading
-        ? <LinearProgress />
-        : <>
-          <MetricsTable
-            canEditMetrics={debugMode}
-            metrics={metrics || []}
-            onEditMetric={onEditMetric}
-          />
+      {isLoading ? (
+        <LinearProgress />
+      ) : (
+        <>
+          <MetricsTable canEditMetrics={debugMode} metrics={metrics || []} onEditMetric={onEditMetric} />
           <div className={classes.actions}>
-            <Button variant="contained" color="secondary" onClick={onAddMetric}>Add Metric</Button>
+            <Button variant='contained' color='secondary' onClick={onAddMetric}>
+              Add Metric
+            </Button>
           </div>
-        </>}
-    </Layout >
+        </>
+      )}
+    </Layout>
   )
 }
 

--- a/pages/metrics/index.tsx
+++ b/pages/metrics/index.tsx
@@ -6,16 +6,31 @@ import MetricsApi from '@/api/MetricsApi'
 import Layout from '@/components/Layout'
 import MetricsTable from '@/components/MetricsTable'
 import { useDataLoadingError, useDataSource } from '@/utils/data-loading'
+import { useRouter } from 'next/router'
 
 const debug = debugFactory('abacus:pages/metrics/index.tsx')
 
 const MetricsIndexPage = () => {
   debug('MetricsIndexPage#render')
   const { isLoading, data: metrics, error } = useDataSource(() => MetricsApi.findAll(), [])
+  const router = useRouter()
+  const debugMode = router.query.debug === 'true'
 
   useDataLoadingError(error, 'Metrics')
 
-  return <Layout title='Metrics'>{isLoading ? <LinearProgress /> : <MetricsTable metrics={metrics || []} />}</Layout>
+  const onEditMetric = (metricId: number) => alert(metricId)
+
+  return (
+    <Layout title='Metrics'>
+      {isLoading
+        ? <LinearProgress />
+        : <MetricsTable
+          canEditMetrics={debugMode}
+          metrics={metrics || []}
+          onEditMetric={onEditMetric}
+        />}
+    </Layout>
+  )
 }
 
 export default MetricsIndexPage


### PR DESCRIPTION
_Part of a series on #13. I am using metric add/edit as a simpler and low-stakes model to demonstrate how the other modals will work._

<!-- Describe your changes in detail. -->
**This PR adds buttons to edit metrics.**

<img width="787" alt="Screen Shot 2020-08-20 at 4 11 47 pm" src="https://user-images.githubusercontent.com/971886/90752758-5c8acd80-e30a-11ea-9aad-1a1c64e25d19.png">

<!-- Remember to include context: Why is this change required? What problem does it solve? -->

To try it out visit `/metrics?debug=true`

<!-- If it fixes an open issue, please link to the issue here. -->

Part of a series on #13 

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with mock data (locally)
- Full testing coming later