### PR TITLE
Add experiment creation exposure events

### DIFF
--- a/__tests__/api/ExperimentsApi.test.ts
+++ b/__tests__/api/ExperimentsApi.test.ts
@@ -1,11 +1,118 @@
 import { format } from 'date-fns'
 
 import ExperimentsApi from '@/api/ExperimentsApi'
-import { experimentFullNewSchema, ExperimentFullNew } from '@/lib/schemas'
+import { experimentFullNewSchema, ExperimentFullNew, experimentFullNewOutboundSchema } from '@/lib/schemas'
 import { validationErrorDisplayer } from '@/test-helpers/test-utils'
 
 describe('ExperimentsApi.ts module', () => {
   describe('create', () => {
+    it('should transform a new experiment into a valid outbound form', async () => {
+      // We need to make some dates relative to today since mocking the schema to work with MockDate is a pain!
+      const now = new Date()
+      now.setDate(now.getDate() + 1)
+      const nextWeek = new Date()
+      nextWeek.setDate(now.getDate() + 7)
+      const rawNewExperiment = {
+        p2Url: 'http://example.com/',
+        name: 'test_experiment_name',
+        description: 'experiment description',
+        startDatetime: format(now, 'yyyy-MM-dd'),
+        endDatetime: format(nextWeek, 'yyyy-MM-dd'),
+        ownerLogin: 'owner-nickname',
+        platform: 'wpcom',
+        existingUsersAllowed: 'true',
+        exposureEvents: [
+          {
+            event: 'event_name',
+            props: [
+              {
+                key: 'key',
+                value: 'value',
+              },
+            ],
+          },
+        ],
+        segmentAssignments: [
+          {
+            isExcluded: false,
+            segmentId: 3,
+          },
+        ],
+        variations: [
+          {
+            allocatedPercentage: 50,
+            isDefault: true,
+            name: 'control',
+          },
+          {
+            allocatedPercentage: 50,
+            isDefault: false,
+            name: 'treatment',
+          },
+        ],
+        metricAssignments: [
+          {
+            attributionWindowSeconds: '86400',
+            changeExpected: false,
+            isPrimary: true,
+            metricId: 10,
+            minDifference: 0.01,
+          },
+        ],
+      }
+
+      const newExperiment = experimentFullNewOutboundSchema.cast(rawNewExperiment)
+
+      expect(newExperiment).toMatchInlineSnapshot(`
+        Object {
+          "description": "experiment description",
+          "end_datetime": "2020-09-03",
+          "existing_users_allowed": "true",
+          "exposure_events": Array [
+            Object {
+              "event": "event_name",
+              "props": Object {
+                "key": "value",
+              },
+            },
+          ],
+          "metric_assignments": Array [
+            Object {
+              "attribution_window_seconds": "86400",
+              "change_expected": false,
+              "is_primary": true,
+              "metric_id": 10,
+              "min_difference": 0.01,
+            },
+          ],
+          "name": "test_experiment_name",
+          "owner_login": "owner-nickname",
+          "p2_url": "http://example.com/",
+          "p_2_url": undefined,
+          "platform": "wpcom",
+          "segment_assignments": Array [
+            Object {
+              "is_excluded": false,
+              "segment_id": 3,
+            },
+          ],
+          "start_datetime": "2020-08-27",
+          "variations": Array [
+            Object {
+              "allocated_percentage": 50,
+              "is_default": true,
+              "name": "control",
+            },
+            Object {
+              "allocated_percentage": 50,
+              "is_default": false,
+              "name": "treatment",
+            },
+          ],
+        }
+      `)
+    })
+
     it('should create a new experiment', async () => {
       // We need to make some dates relative to today since mocking the schema to work with MockDate is a pain!
       const now = new Date()
@@ -60,7 +167,9 @@ describe('ExperimentsApi.ts module', () => {
           },
         ],
       }
-      const returnedExperiment = await validationErrorDisplayer(ExperimentsApi.create(rawNewExperiment as unknown as ExperimentFullNew))
+      const returnedExperiment = await validationErrorDisplayer(
+        ExperimentsApi.create((rawNewExperiment as unknown) as ExperimentFullNew),
+      )
       expect(returnedExperiment.experimentId).toBeGreaterThan(0)
     })
   })

--- a/__tests__/api/ExperimentsApi.test.ts
+++ b/__tests__/api/ExperimentsApi.test.ts
@@ -63,54 +63,52 @@ describe('ExperimentsApi.ts module', () => {
 
       const newExperiment = experimentFullNewOutboundSchema.cast(rawNewExperiment)
 
-      expect(newExperiment).toMatchInlineSnapshot(`
-        Object {
-          "description": "experiment description",
-          "end_datetime": "2020-09-03",
-          "existing_users_allowed": "true",
-          "exposure_events": Array [
-            Object {
-              "event": "event_name",
-              "props": Object {
-                "key": "value",
-              },
+      expect(newExperiment).toEqual({
+        description: 'experiment description',
+        end_datetime: format(nextWeek, 'yyyy-MM-dd'),
+        existing_users_allowed: 'true',
+        exposure_events: [
+          {
+            event: 'event_name',
+            props: {
+              key: 'value',
             },
-          ],
-          "metric_assignments": Array [
-            Object {
-              "attribution_window_seconds": "86400",
-              "change_expected": false,
-              "is_primary": true,
-              "metric_id": 10,
-              "min_difference": 0.01,
-            },
-          ],
-          "name": "test_experiment_name",
-          "owner_login": "owner-nickname",
-          "p2_url": "http://example.com/",
-          "p_2_url": undefined,
-          "platform": "wpcom",
-          "segment_assignments": Array [
-            Object {
-              "is_excluded": false,
-              "segment_id": 3,
-            },
-          ],
-          "start_datetime": "2020-08-27",
-          "variations": Array [
-            Object {
-              "allocated_percentage": 50,
-              "is_default": true,
-              "name": "control",
-            },
-            Object {
-              "allocated_percentage": 50,
-              "is_default": false,
-              "name": "treatment",
-            },
-          ],
-        }
-      `)
+          },
+        ],
+        metric_assignments: [
+          {
+            attribution_window_seconds: '86400',
+            change_expected: false,
+            is_primary: true,
+            metric_id: 10,
+            min_difference: 0.01,
+          },
+        ],
+        name: 'test_experiment_name',
+        owner_login: 'owner-nickname',
+        p2_url: 'http://example.com/',
+        p_2_url: undefined,
+        platform: 'wpcom',
+        segment_assignments: [
+          {
+            is_excluded: false,
+            segment_id: 3,
+          },
+        ],
+        start_datetime: format(now, 'yyyy-MM-dd'),
+        variations: [
+          {
+            allocated_percentage: 50,
+            is_default: true,
+            name: 'control',
+          },
+          {
+            allocated_percentage: 50,
+            is_default: false,
+            name: 'treatment',
+          },
+        ],
+      })
     })
 
     it('should create a new experiment', async () => {

--- a/__tests__/api/ExperimentsApi.test.ts
+++ b/__tests__/api/ExperimentsApi.test.ts
@@ -1,12 +1,12 @@
 import { format } from 'date-fns'
 
 import ExperimentsApi from '@/api/ExperimentsApi'
-import { experimentFullNewSchema, ExperimentFullNew, experimentFullNewOutboundSchema } from '@/lib/schemas'
+import { ExperimentFullNew, experimentFullNewOutboundSchema } from '@/lib/schemas'
 import { validationErrorDisplayer } from '@/test-helpers/test-utils'
 
 describe('ExperimentsApi.ts module', () => {
   describe('create', () => {
-    it('should transform a new experiment into a valid outbound form', async () => {
+    it('should transform a new experiment into a valid outbound form', () => {
       // We need to make some dates relative to today since mocking the schema to work with MockDate is a pain!
       const now = new Date()
       now.setDate(now.getDate() + 1)

--- a/__tests__/api/ExperimentsApi.test.ts
+++ b/__tests__/api/ExperimentsApi.test.ts
@@ -1,12 +1,67 @@
+import { format } from 'date-fns'
+
 import ExperimentsApi from '@/api/ExperimentsApi'
-import Fixtures from '@/test-helpers/fixtures'
+import { experimentFullNewSchema, ExperimentFullNew } from '@/lib/schemas'
 import { validationErrorDisplayer } from '@/test-helpers/test-utils'
 
 describe('ExperimentsApi.ts module', () => {
   describe('create', () => {
     it('should create a new experiment', async () => {
-      const experiment = await validationErrorDisplayer(ExperimentsApi.create(Fixtures.createExperimentFullNew()))
-      expect(experiment.experimentId).toBeGreaterThan(0)
+      // We need to make some dates relative to today since mocking the schema to work with MockDate is a pain!
+      const now = new Date()
+      now.setDate(now.getDate() + 1)
+      const nextWeek = new Date()
+      nextWeek.setDate(now.getDate() + 7)
+      const rawNewExperiment = {
+        p2Url: 'http://example.com/',
+        name: 'test_experiment_name',
+        description: 'experiment description',
+        startDatetime: format(now, 'yyyy-MM-dd'),
+        endDatetime: format(nextWeek, 'yyyy-MM-dd'),
+        ownerLogin: 'owner-nickname',
+        platform: 'wpcom',
+        existingUsersAllowed: 'true',
+        exposureEvents: [
+          {
+            event: 'event_name',
+            props: [
+              {
+                key: 'key',
+                value: 'value',
+              },
+            ],
+          },
+        ],
+        segmentAssignments: [
+          {
+            isExcluded: false,
+            segmentId: 3,
+          },
+        ],
+        variations: [
+          {
+            allocatedPercentage: 50,
+            isDefault: true,
+            name: 'control',
+          },
+          {
+            allocatedPercentage: 50,
+            isDefault: false,
+            name: 'treatment',
+          },
+        ],
+        metricAssignments: [
+          {
+            attributionWindowSeconds: '86400',
+            changeExpected: false,
+            isPrimary: true,
+            metricId: 10,
+            minDifference: 0.01,
+          },
+        ],
+      }
+      const returnedExperiment = await validationErrorDisplayer(ExperimentsApi.create(rawNewExperiment as unknown as ExperimentFullNew))
+      expect(returnedExperiment.experimentId).toBeGreaterThan(0)
     })
   })
 

--- a/components/experiment-creation/ExperimentForm.test.tsx
+++ b/components/experiment-creation/ExperimentForm.test.tsx
@@ -364,6 +364,29 @@ test('form submits with valid fields', async () => {
 
   await changeFieldByRole('spinbutton', /Min difference/, '0.01')
 
+  // #### Exposure Events
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /Add exposure event/ }))
+  })
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /Add Property/ }))
+  })
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /Remove exposure event property/ }))
+  })
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /Remove exposure event/ }))
+  })
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /Add exposure event/ }))
+  })
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /Add Property/ }))
+  })
+  await changeFieldByRole('textbox', /Event Name/, 'event_name')
+  await changeFieldByRole('textbox', /Property Key/, 'key')
+  await changeFieldByRole('textbox', /Property Value/, 'value')
+
   await act(async () => {
     fireEvent.click(screen.getByRole('button', { name: /Next/ }))
   })
@@ -393,6 +416,17 @@ test('form submits with valid fields', async () => {
       ownerLogin: 'owner-nickname',
       platform: 'wpcom',
       existingUsersAllowed: 'true',
+      exposureEvents: [
+        {
+          event: 'event_name',
+          props: [
+            {
+              key: 'key',
+              value: 'value',
+            }
+          ],
+        },
+      ],
       segmentAssignments: [
         {
           isExcluded: false,

--- a/components/experiment-creation/ExperimentForm.test.tsx
+++ b/components/experiment-creation/ExperimentForm.test.tsx
@@ -423,7 +423,7 @@ test('form submits with valid fields', async () => {
             {
               key: 'key',
               value: 'value',
-            }
+            },
           ],
         },
       ],

--- a/components/experiment-creation/ExperimentForm.test.tsx
+++ b/components/experiment-creation/ExperimentForm.test.tsx
@@ -14,7 +14,7 @@ import { render } from '@/test-helpers/test-utils'
 
 import ExperimentForm from './ExperimentForm'
 
-jest.setTimeout(20000)
+jest.setTimeout(30000)
 
 jest.mock('notistack')
 const mockedNotistack = notistack as jest.Mocked<typeof notistack>
@@ -369,19 +369,19 @@ test('form submits with valid fields', async () => {
     fireEvent.click(screen.getByRole('button', { name: /Add exposure event/ }))
   })
   await act(async () => {
-    fireEvent.click(screen.getByRole('button', { name: /Add Property/ }))
+    fireEvent.click(await screen.findByRole('button', { name: /Add Property/ }))
   })
   await act(async () => {
-    fireEvent.click(screen.getByRole('button', { name: /Remove exposure event property/ }))
+    fireEvent.click(await screen.findByRole('button', { name: /Remove exposure event property/ }))
   })
   await act(async () => {
-    fireEvent.click(screen.getByRole('button', { name: /Remove exposure event/ }))
+    fireEvent.click(await screen.findByRole('button', { name: /Remove exposure event/ }))
   })
   await act(async () => {
     fireEvent.click(screen.getByRole('button', { name: /Add exposure event/ }))
   })
   await act(async () => {
-    fireEvent.click(screen.getByRole('button', { name: /Add Property/ }))
+    fireEvent.click(await screen.findByRole('button', { name: /Add Property/ }))
   })
   await changeFieldByRole('textbox', /Event Name/, 'event_name')
   await changeFieldByRole('textbox', /Property Key/, 'key')

--- a/components/experiment-creation/ExperimentForm.test.tsx
+++ b/components/experiment-creation/ExperimentForm.test.tsx
@@ -14,7 +14,7 @@ import { render } from '@/test-helpers/test-utils'
 
 import ExperimentForm from './ExperimentForm'
 
-jest.setTimeout(30000)
+jest.setTimeout(40000)
 
 jest.mock('notistack')
 const mockedNotistack = notistack as jest.Mocked<typeof notistack>

--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -67,10 +67,7 @@ const stages: Stage[] = [
   {
     id: StageId.Metrics,
     title: 'Metrics',
-    validatableFields: [
-      'experiment.metricAssignments',
-      'experiment.exposureEvents',
-    ],
+    validatableFields: ['experiment.metricAssignments', 'experiment.exposureEvents'],
   },
   {
     id: StageId.Submit,

--- a/components/experiment-creation/ExperimentForm.tsx
+++ b/components/experiment-creation/ExperimentForm.tsx
@@ -67,7 +67,10 @@ const stages: Stage[] = [
   {
     id: StageId.Metrics,
     title: 'Metrics',
-    validatableFields: ['experiment.metricAssignments'],
+    validatableFields: [
+      'experiment.metricAssignments',
+      'experiment.exposureEvents',
+    ],
   },
   {
     id: StageId.Submit,

--- a/components/experiment-creation/Metrics.tsx
+++ b/components/experiment-creation/Metrics.tsx
@@ -228,21 +228,21 @@ const Metrics = ({ indexedMetrics }: { indexedMetrics: Record<number, MetricBare
                               }}
                               InputProps={
                                 indexedMetrics[metricAssignment.metricId].parameterType ===
-                                  MetricParameterType.Conversion
+                                MetricParameterType.Conversion
                                   ? {
-                                    endAdornment: (
-                                      <InputAdornment position='end'>
-                                        <Tooltip title='Percentage Points'>
-                                          <Typography variant='body1' color='textSecondary'>
-                                            pp
+                                      endAdornment: (
+                                        <InputAdornment position='end'>
+                                          <Tooltip title='Percentage Points'>
+                                            <Typography variant='body1' color='textSecondary'>
+                                              pp
                                             </Typography>
-                                        </Tooltip>
-                                      </InputAdornment>
-                                    ),
-                                  }
+                                          </Tooltip>
+                                        </InputAdornment>
+                                      ),
+                                    }
                                   : {
-                                    startAdornment: <InputAdornment position='start'>$</InputAdornment>,
-                                  }
+                                      startAdornment: <InputAdornment position='start'>$</InputAdornment>,
+                                    }
                               }
                             />
                           </TableCell>

--- a/components/experiment-creation/Metrics.tsx
+++ b/components/experiment-creation/Metrics.tsx
@@ -15,16 +15,17 @@ import {
   Button,
   InputAdornment,
   Tooltip,
+  IconButton,
 } from '@material-ui/core'
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import React, { useState } from 'react'
 import { FieldArray, useField, Field } from 'formik'
-import { MetricAssignment, MetricBare, MetricParameterType, AttributionWindowSeconds } from '@/lib/schemas'
+import { MetricAssignment, MetricBare, MetricParameterType, AttributionWindowSeconds, Event } from '@/lib/schemas'
 import { TextField, Select, Switch } from 'formik-material-ui'
 
 import { AttributionWindowSecondsToHuman } from '@/lib/metric-assignments'
 import MoreMenu from '@/components/MoreMenu'
-import { Add } from '@material-ui/icons'
+import { Add, Clear } from '@material-ui/icons'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -65,6 +66,23 @@ const useStyles = makeStyles((theme: Theme) =>
     changeExpected: {
       textAlign: 'center',
     },
+    exposureEventsTitle: {
+      marginTop: theme.spacing(6),
+      marginBottom: theme.spacing(4),
+    },
+    exposureEventsEventNameCell: {
+      display: 'flex',
+      alignItems: 'center',
+    },
+    exposureEventsEventName: {
+      flexGrow: 1,
+    },
+    exposureEventsEventRemoveButton: {
+      marginLeft: theme.spacing(1),
+    },
+    exposureEventsEventNoProperties: {
+      marginTop: theme.spacing(3),
+    },
   }),
 )
 
@@ -81,6 +99,7 @@ const createMetricAssignment = (metric: MetricBare) => {
 const Metrics = ({ indexedMetrics }: { indexedMetrics: Record<number, MetricBare> }) => {
   const classes = useStyles()
 
+  // Metric Assignments
   const [metricAssignmentsField, _metricAssignmentsFieldMetaProps, metricAssignmentsFieldHelperProps] = useField<
     MetricAssignment[]
   >('experiment.metricAssignments')
@@ -97,6 +116,11 @@ const Metrics = ({ indexedMetrics }: { indexedMetrics: Record<number, MetricBare
       })),
     )
   }
+
+  // ### Exposure Events
+  const [exposureEventsField, _exposureEventsFieldMetaProps, exposureEventsFieldHelperProps] = useField<
+    Event[]
+  >('experiment.exposureEvents')
 
   return (
     <div className={classes.root}>
@@ -202,21 +226,21 @@ const Metrics = ({ indexedMetrics }: { indexedMetrics: Record<number, MetricBare
                               }}
                               InputProps={
                                 indexedMetrics[metricAssignment.metricId].parameterType ===
-                                MetricParameterType.Conversion
+                                  MetricParameterType.Conversion
                                   ? {
-                                      endAdornment: (
-                                        <InputAdornment position='end'>
-                                          <Tooltip title='Percentage Points'>
-                                            <Typography variant='body1' color='textSecondary'>
-                                              pp
+                                    endAdornment: (
+                                      <InputAdornment position='end'>
+                                        <Tooltip title='Percentage Points'>
+                                          <Typography variant='body1' color='textSecondary'>
+                                            pp
                                             </Typography>
-                                          </Tooltip>
-                                        </InputAdornment>
-                                      ),
-                                    }
+                                        </Tooltip>
+                                      </InputAdornment>
+                                    ),
+                                  }
                                   : {
-                                      startAdornment: <InputAdornment position='start'>$</InputAdornment>,
-                                    }
+                                    startAdornment: <InputAdornment position='start'>$</InputAdornment>,
+                                  }
                               }
                             />
                           </TableCell>
@@ -263,6 +287,92 @@ const Metrics = ({ indexedMetrics }: { indexedMetrics: Record<number, MetricBare
                 </FormControl>
                 <Button variant='contained' disableElevation size='small' onClick={onAddMetric} aria-label='Add metric'>
                   Assign
+                </Button>
+              </div>
+            </>
+          )
+        }}
+      />
+
+      <Typography variant='h4' gutterBottom className={classes.exposureEventsTitle}>
+        Exposure Events (Optional)
+      </Typography>
+
+      <FieldArray
+        name='experiment.exposureEvents'
+        render={(arrayHelpers) => {
+          const onAddExposureEvent = () => {
+            arrayHelpers.push({
+              event: '',
+              props: {},
+            })
+          }
+          return (
+            <>
+              <TableContainer>
+                <Table>
+                  <TableBody>
+                    {exposureEventsField.value.map((exposureEvent, index) => {
+                      const onRemoveExposureEvent = () => {
+                        arrayHelpers.remove(index)
+                      }
+                      const exposureEventPropEntries = exposureEvent.props && Object.entries(exposureEvent.props)
+
+                      return (
+                        <TableRow key={index}>
+                          <TableCell>
+                            <div className={classes.exposureEventsEventNameCell}>
+                              <Field
+                                component={TextField}
+                                name={`experiment.exposureEvents[${index}].event`}
+                                className={classes.exposureEventsEventName}
+                                id={`experiment.exposureEvents[${index}].event`}
+                                type='text'
+                                variant='outlined'
+                                placeholder='event_name'
+                                label='Event'
+                                inputProps={{
+                                  'aria-label': 'Event Name',
+                                }}
+                                InputLabelProps={{
+                                  shrink: true,
+                                }}
+                              />
+                              <IconButton className={classes.exposureEventsEventRemoveButton} onClick={onRemoveExposureEvent} aria-label='Remove exposure event'>
+                                <Clear />
+                              </IconButton>
+                            </div>
+                            <div>
+                              {exposureEventPropEntries && exposureEventPropEntries.length > 0 && (
+                                null
+                              )}
+                              <div className={classes.addMetric}>
+                                <Add className={classes.addMetricAddSymbol} />
+                                <Button variant='contained' disableElevation size='small' aria-label='Add Property'>
+                                  Add Property
+                                </Button>
+                              </div>
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      )
+                    })}
+                    {exposureEventsField.value.length === 0 && (
+                      <TableRow>
+                        <TableCell colSpan={1}>
+                          <Typography variant='body1' align='center'>
+                            You don't have any exposure events.
+                          </Typography>
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+              <div className={classes.addMetric}>
+                <Add className={classes.addMetricAddSymbol} />
+                <Button variant='contained' disableElevation size='small' onClick={onAddExposureEvent} aria-label='Add exposure event'>
+                  Add Event
                 </Button>
               </div>
             </>

--- a/components/experiment-creation/Metrics.tsx
+++ b/components/experiment-creation/Metrics.tsx
@@ -1,31 +1,29 @@
-/* eslint-disable */
-import _ from 'lodash'
 import {
-  Typography,
-  TableContainer,
+  Button,
+  FormControl,
+  IconButton,
+  InputAdornment,
+  MenuItem,
+  Select as MuiSelect,
   Table,
+  TableBody,
+  TableCell,
+  TableContainer,
   TableHead,
   TableRow,
-  TableCell,
-  TableBody,
-  Select as MuiSelect,
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Button,
-  InputAdornment,
   Tooltip,
-  IconButton,
+  Typography,
 } from '@material-ui/core'
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
-import React, { useState } from 'react'
-import { FieldArray, useField, Field } from 'formik'
-import { MetricAssignment, MetricBare, MetricParameterType, AttributionWindowSeconds, Event } from '@/lib/schemas'
-import { TextField, Select, Switch } from 'formik-material-ui'
-
-import { AttributionWindowSecondsToHuman } from '@/lib/metric-assignments'
-import MoreMenu from '@/components/MoreMenu'
 import { Add, Clear } from '@material-ui/icons'
+import { Field, FieldArray, useField } from 'formik'
+import { Select, Switch, TextField } from 'formik-material-ui'
+import _ from 'lodash'
+import React, { useState } from 'react'
+
+import MoreMenu from '@/components/MoreMenu'
+import { AttributionWindowSecondsToHuman } from '@/lib/metric-assignments'
+import { Event, MetricAssignment, MetricBare, MetricParameterType } from '@/lib/schemas'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -80,8 +78,12 @@ const useStyles = makeStyles((theme: Theme) =>
     exposureEventsEventRemoveButton: {
       marginLeft: theme.spacing(1),
     },
-    exposureEventsEventNoProperties: {
+    exposureEventsEventPropertiesRow: {
       marginTop: theme.spacing(3),
+      marginLeft: theme.spacing(3),
+    },
+    exposureEventsEventPropertiesKey: {
+      marginRight: theme.spacing(1),
     },
   }),
 )
@@ -118,9 +120,9 @@ const Metrics = ({ indexedMetrics }: { indexedMetrics: Record<number, MetricBare
   }
 
   // ### Exposure Events
-  const [exposureEventsField, _exposureEventsFieldMetaProps, exposureEventsFieldHelperProps] = useField<
-    Event[]
-  >('experiment.exposureEvents')
+  const [exposureEventsField, _exposureEventsFieldMetaProps, _exposureEventsFieldHelperProps] = useField<Event[]>(
+    'experiment.exposureEvents',
+  )
 
   return (
     <div className={classes.root}>
@@ -257,7 +259,7 @@ const Metrics = ({ indexedMetrics }: { indexedMetrics: Record<number, MetricBare
                       <TableRow>
                         <TableCell colSpan={5}>
                           <Typography variant='body1' align='center'>
-                            You don't have any metrics yet.
+                            You don&apos;t have any metrics yet.
                           </Typography>
                         </TableCell>
                       </TableRow>
@@ -304,7 +306,7 @@ const Metrics = ({ indexedMetrics }: { indexedMetrics: Record<number, MetricBare
           const onAddExposureEvent = () => {
             arrayHelpers.push({
               event: '',
-              props: {},
+              props: [],
             })
           }
           return (
@@ -316,7 +318,6 @@ const Metrics = ({ indexedMetrics }: { indexedMetrics: Record<number, MetricBare
                       const onRemoveExposureEvent = () => {
                         arrayHelpers.remove(index)
                       }
-                      const exposureEventPropEntries = exposureEvent.props && Object.entries(exposureEvent.props)
 
                       return (
                         <TableRow key={index}>
@@ -338,21 +339,95 @@ const Metrics = ({ indexedMetrics }: { indexedMetrics: Record<number, MetricBare
                                   shrink: true,
                                 }}
                               />
-                              <IconButton className={classes.exposureEventsEventRemoveButton} onClick={onRemoveExposureEvent} aria-label='Remove exposure event'>
+                              <IconButton
+                                className={classes.exposureEventsEventRemoveButton}
+                                onClick={onRemoveExposureEvent}
+                                aria-label='Remove exposure event'
+                              >
                                 <Clear />
                               </IconButton>
                             </div>
-                            <div>
-                              {exposureEventPropEntries && exposureEventPropEntries.length > 0 && (
-                                null
-                              )}
-                              <div className={classes.addMetric}>
-                                <Add className={classes.addMetricAddSymbol} />
-                                <Button variant='contained' disableElevation size='small' aria-label='Add Property'>
-                                  Add Property
-                                </Button>
-                              </div>
-                            </div>
+                            <FieldArray
+                              name={`experiment.exposureEvents[${index}].props`}
+                              render={(arrayHelpers) => {
+                                const onAddExposureEventProperty = () => {
+                                  arrayHelpers.push({
+                                    key: '',
+                                    value: '',
+                                  })
+                                }
+
+                                return (
+                                  <div>
+                                    <div>
+                                      {exposureEvent.props &&
+                                        (exposureEvent.props as unknown[]).map((_prop: unknown, propIndex: number) => {
+                                          const onRemoveExposureEventProperty = () => {
+                                            arrayHelpers.remove(propIndex)
+                                          }
+
+                                          return (
+                                            <div className={classes.exposureEventsEventPropertiesRow} key={propIndex}>
+                                              <Field
+                                                component={TextField}
+                                                className={classes.exposureEventsEventPropertiesKey}
+                                                name={`experiment.exposureEvents[${index}].props[${propIndex}].key`}
+                                                id={`experiment.exposureEvents[${index}].props[${propIndex}].key`}
+                                                type='text'
+                                                variant='outlined'
+                                                placeholder='key'
+                                                label='Key'
+                                                size='small'
+                                                inputProps={{
+                                                  'aria-label': 'Property Key',
+                                                }}
+                                                InputLabelProps={{
+                                                  shrink: true,
+                                                }}
+                                              />
+                                              <Field
+                                                component={TextField}
+                                                name={`experiment.exposureEvents[${index}].props[${propIndex}].value`}
+                                                id={`experiment.exposureEvents[${index}].props[${propIndex}].value`}
+                                                type='text'
+                                                variant='outlined'
+                                                placeholder='value'
+                                                label='Value'
+                                                size='small'
+                                                inputProps={{
+                                                  'aria-label': 'Property Value',
+                                                }}
+                                                InputLabelProps={{
+                                                  shrink: true,
+                                                }}
+                                              />
+                                              <IconButton
+                                                className={classes.exposureEventsEventRemoveButton}
+                                                onClick={onRemoveExposureEventProperty}
+                                                aria-label='Remove exposure event property'
+                                              >
+                                                <Clear />
+                                              </IconButton>
+                                            </div>
+                                          )
+                                        })}
+                                    </div>
+                                    <div className={classes.addMetric}>
+                                      <Add className={classes.addMetricAddSymbol} />
+                                      <Button
+                                        variant='contained'
+                                        onClick={onAddExposureEventProperty}
+                                        disableElevation
+                                        size='small'
+                                        aria-label='Add Property'
+                                      >
+                                        Add Property
+                                      </Button>
+                                    </div>
+                                  </div>
+                                )
+                              }}
+                            />
                           </TableCell>
                         </TableRow>
                       )
@@ -361,7 +436,7 @@ const Metrics = ({ indexedMetrics }: { indexedMetrics: Record<number, MetricBare
                       <TableRow>
                         <TableCell colSpan={1}>
                           <Typography variant='body1' align='center'>
-                            You don't have any exposure events.
+                            You don&apos;t have any exposure events.
                           </Typography>
                         </TableCell>
                       </TableRow>
@@ -371,7 +446,13 @@ const Metrics = ({ indexedMetrics }: { indexedMetrics: Record<number, MetricBare
               </TableContainer>
               <div className={classes.addMetric}>
                 <Add className={classes.addMetricAddSymbol} />
-                <Button variant='contained' disableElevation size='small' onClick={onAddExposureEvent} aria-label='Add exposure event'>
+                <Button
+                  variant='contained'
+                  disableElevation
+                  size='small'
+                  onClick={onAddExposureEvent}
+                  aria-label='Add exposure event'
+                >
                   Add Event
                 </Button>
               </div>

--- a/components/experiment-creation/Metrics.tsx
+++ b/components/experiment-creation/Metrics.tsx
@@ -23,7 +23,7 @@ import React, { useState } from 'react'
 
 import MoreMenu from '@/components/MoreMenu'
 import { AttributionWindowSecondsToHuman } from '@/lib/metric-assignments'
-import { Event, MetricAssignment, MetricBare, MetricParameterType } from '@/lib/schemas'
+import { EventNew, MetricAssignment, MetricBare, MetricParameterType } from '@/lib/schemas'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -120,7 +120,7 @@ const Metrics = ({ indexedMetrics }: { indexedMetrics: Record<number, MetricBare
   }
 
   // ### Exposure Events
-  const [exposureEventsField, _exposureEventsFieldMetaProps, _exposureEventsFieldHelperProps] = useField<Event[]>(
+  const [exposureEventsField, _exposureEventsFieldMetaProps, _exposureEventsFieldHelperProps] = useField<EventNew[]>(
     'experiment.exposureEvents',
   )
 
@@ -361,7 +361,7 @@ const Metrics = ({ indexedMetrics }: { indexedMetrics: Record<number, MetricBare
                                   <div>
                                     <div>
                                       {exposureEvent.props &&
-                                        (exposureEvent.props as unknown[]).map((_prop: unknown, propIndex: number) => {
+                                        exposureEvent.props.map((_prop: unknown, propIndex: number) => {
                                           const onRemoveExposureEventProperty = () => {
                                             arrayHelpers.remove(propIndex)
                                           }

--- a/components/experiment-creation/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/components/experiment-creation/__snapshots__/ExperimentForm.test.tsx.snap
@@ -393,10 +393,10 @@ exports[`renders as expected 1`] = `
 exports[`sections should be browsable by the section buttons 1`] = `
 <div>
   <div
-    class="makeStyles-root-66"
+    class="makeStyles-root-72"
   >
     <div
-      class="makeStyles-navigation-67"
+      class="makeStyles-navigation-73"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -683,17 +683,17 @@ exports[`sections should be browsable by the section buttons 1`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-68"
+        class="makeStyles-form-74"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-69"
+          class="makeStyles-formPart-75"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-71 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-77 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-74"
+              class="makeStyles-root-80"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -717,7 +717,7 @@ exports[`sections should be browsable by the section buttons 1`] = `
                 </strong>
               </p>
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-p2EntryField-75"
+                class="MuiFormControl-root MuiTextField-root makeStyles-p2EntryField-81"
               >
                 <label
                   class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
@@ -741,10 +741,10 @@ exports[`sections should be browsable by the section buttons 1`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-77 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-83 MuiOutlinedInput-notchedOutline"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legendLabelled-79 PrivateNotchedOutline-legendNotched-80"
+                      class="PrivateNotchedOutline-legendLabelled-85 PrivateNotchedOutline-legendNotched-86"
                     >
                       <span>
                         Your Post's URL
@@ -756,7 +756,7 @@ exports[`sections should be browsable by the section buttons 1`] = `
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-70"
+            class="makeStyles-formPartActions-76"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -783,10 +783,10 @@ exports[`sections should be browsable by the section buttons 1`] = `
 exports[`sections should be browsable by the section buttons 2`] = `
 <div>
   <div
-    class="makeStyles-root-66"
+    class="makeStyles-root-72"
   >
     <div
-      class="makeStyles-navigation-67"
+      class="makeStyles-navigation-73"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -1063,17 +1063,17 @@ exports[`sections should be browsable by the section buttons 2`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-68"
+        class="makeStyles-form-74"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-69"
+          class="makeStyles-formPart-75"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-71 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-77 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-81"
+              class="makeStyles-root-87"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1081,7 +1081,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
                 Basic Info
               </h4>
               <div
-                class="makeStyles-row-82"
+                class="makeStyles-row-88"
               >
                 <div
                   class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -1117,10 +1117,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-77 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-83 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-79 PrivateNotchedOutline-legendNotched-80"
+                        class="PrivateNotchedOutline-legendLabelled-85 PrivateNotchedOutline-legendNotched-86"
                       >
                         <span>
                           Experiment name
@@ -1138,7 +1138,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-row-82"
+                class="makeStyles-row-88"
               >
                 <div
                   class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -1173,10 +1173,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-77 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-83 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-79 PrivateNotchedOutline-legendNotched-80"
+                        class="PrivateNotchedOutline-legendLabelled-85 PrivateNotchedOutline-legendNotched-86"
                       >
                         <span>
                           Experiment description
@@ -1194,10 +1194,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-row-82"
+                class="makeStyles-row-88"
               >
                 <div
-                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-84"
+                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-90"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
@@ -1231,10 +1231,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-77 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-83 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-79 PrivateNotchedOutline-legendNotched-80"
+                        class="PrivateNotchedOutline-legendLabelled-85 PrivateNotchedOutline-legendNotched-86"
                       >
                         <span>
                           Start date
@@ -1251,12 +1251,12 @@ exports[`sections should be browsable by the section buttons 2`] = `
                   </p>
                 </div>
                 <span
-                  class="makeStyles-through-83"
+                  class="makeStyles-through-89"
                 >
                    through 
                 </span>
                 <div
-                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-84"
+                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-90"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
@@ -1288,10 +1288,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-77 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-83 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-79 PrivateNotchedOutline-legendNotched-80"
+                        class="PrivateNotchedOutline-legendLabelled-85 PrivateNotchedOutline-legendNotched-86"
                       >
                         <span>
                           End date
@@ -1309,7 +1309,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-row-82"
+                class="makeStyles-row-88"
               >
                 <div
                   class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -1354,10 +1354,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-77 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-83 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-79 PrivateNotchedOutline-legendNotched-80"
+                        class="PrivateNotchedOutline-legendLabelled-85 PrivateNotchedOutline-legendNotched-86"
                       >
                         <span>
                           Owner
@@ -1377,7 +1377,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-70"
+            class="makeStyles-formPartActions-76"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -1418,10 +1418,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
 exports[`sections should be browsable by the section buttons 3`] = `
 <div>
   <div
-    class="makeStyles-root-66"
+    class="makeStyles-root-72"
   >
     <div
-      class="makeStyles-navigation-67"
+      class="makeStyles-navigation-73"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -1668,14 +1668,14 @@ exports[`sections should be browsable by the section buttons 3`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-68"
+        class="makeStyles-form-74"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-69"
+          class="makeStyles-formPart-75"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-71 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-77 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <h4
               class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1710,7 +1710,7 @@ exports[`sections should be browsable by the section buttons 3`] = `
             </p>
           </div>
           <div
-            class="makeStyles-formPartActions-70"
+            class="makeStyles-formPartActions-76"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -1727,7 +1727,7 @@ exports[`sections should be browsable by the section buttons 3`] = `
               />
             </button>
             <div
-              class="makeStyles-submitContainer-72"
+              class="makeStyles-submitContainer-78"
             >
               <button
                 class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary Mui-disabled Mui-disabled"
@@ -1753,10 +1753,10 @@ exports[`sections should be browsable by the section buttons 3`] = `
 exports[`sections should be browsable by the section buttons 4`] = `
 <div>
   <div
-    class="makeStyles-root-66"
+    class="makeStyles-root-72"
   >
     <div
-      class="makeStyles-navigation-67"
+      class="makeStyles-navigation-73"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -2013,17 +2013,17 @@ exports[`sections should be browsable by the section buttons 4`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-68"
+        class="makeStyles-form-74"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-69"
+          class="makeStyles-formPart-75"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-71 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-77 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-85"
+              class="makeStyles-root-91"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -2093,11 +2093,11 @@ exports[`sections should be browsable by the section buttons 4`] = `
                 </table>
               </div>
               <div
-                class="makeStyles-addMetric-86"
+                class="makeStyles-addMetric-92"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-87"
+                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-93"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -2106,7 +2106,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
                   />
                 </svg>
                 <div
-                  class="MuiFormControl-root makeStyles-addMetricSelect-89"
+                  class="MuiFormControl-root makeStyles-addMetricSelect-95"
                 >
                   <div
                     class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -2120,7 +2120,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
                       tabindex="0"
                     >
                       <span
-                        class="makeStyles-addMetricPlaceholder-88"
+                        class="makeStyles-addMetricPlaceholder-94"
                       >
                         Select a Metric
                       </span>
@@ -2157,10 +2157,70 @@ exports[`sections should be browsable by the section buttons 4`] = `
                   />
                 </button>
               </div>
+              <h4
+                class="MuiTypography-root makeStyles-exposureEventsTitle-101 MuiTypography-h4 MuiTypography-gutterBottom"
+              >
+                Exposure Events (Optional)
+              </h4>
+              <div
+                class="MuiTableContainer-root"
+              >
+                <table
+                  class="MuiTable-root"
+                >
+                  <tbody
+                    class="MuiTableBody-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body"
+                        colspan="1"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter"
+                        >
+                          You don't have any exposure events.
+                        </p>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <div
+                class="makeStyles-addMetric-92"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-93"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                  />
+                </svg>
+                <button
+                  aria-label="Add exposure event"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label"
+                  >
+                    Add Event
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-70"
+            class="makeStyles-formPartActions-76"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -2201,10 +2261,10 @@ exports[`sections should be browsable by the section buttons 4`] = `
 exports[`skipping to submit should check all sections 1`] = `
 <div>
   <div
-    class="makeStyles-root-121"
+    class="makeStyles-root-133"
   >
     <div
-      class="makeStyles-navigation-122"
+      class="makeStyles-navigation-134"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -2451,14 +2511,14 @@ exports[`skipping to submit should check all sections 1`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-123"
+        class="makeStyles-form-135"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-124"
+          class="makeStyles-formPart-136"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-126 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-138 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <h4
               class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -2493,7 +2553,7 @@ exports[`skipping to submit should check all sections 1`] = `
             </p>
           </div>
           <div
-            class="makeStyles-formPartActions-125"
+            class="makeStyles-formPartActions-137"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -2510,7 +2570,7 @@ exports[`skipping to submit should check all sections 1`] = `
               />
             </button>
             <div
-              class="makeStyles-submitContainer-127"
+              class="makeStyles-submitContainer-139"
             >
               <button
                 class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary Mui-disabled Mui-disabled"

--- a/components/experiment-creation/__snapshots__/Metrics.test.tsx.snap
+++ b/components/experiment-creation/__snapshots__/Metrics.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`allows adding, editing and removing a Metric Assignment 1`] = `
 <div>
   <div
-    class="makeStyles-root-11"
+    class="makeStyles-root-17"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -73,11 +73,11 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-12"
+      class="makeStyles-addMetric-18"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-13"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-19"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -86,7 +86,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-15"
+        class="MuiFormControl-root makeStyles-addMetricSelect-21"
       >
         <div
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -100,7 +100,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
             tabindex="0"
           >
             <span
-              class="makeStyles-addMetricPlaceholder-14"
+              class="makeStyles-addMetricPlaceholder-20"
             >
               Select a Metric
             </span>
@@ -131,6 +131,66 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
           class="MuiButton-label"
         >
           Assign
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+    <h4
+      class="MuiTypography-root makeStyles-exposureEventsTitle-27 MuiTypography-h4 MuiTypography-gutterBottom"
+    >
+      Exposure Events (Optional)
+    </h4>
+    <div
+      class="MuiTableContainer-root"
+    >
+      <table
+        class="MuiTable-root"
+      >
+        <tbody
+          class="MuiTableBody-root"
+        >
+          <tr
+            class="MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body"
+              colspan="1"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter"
+              >
+                You don't have any exposure events.
+              </p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div
+      class="makeStyles-addMetric-18"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-19"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+        />
+      </svg>
+      <button
+        aria-label="Add exposure event"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-label"
+        >
+          Add Event
         </span>
         <span
           class="MuiTouchRipple-root"
@@ -144,7 +204,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
 exports[`allows adding, editing and removing a Metric Assignment 2`] = `
 <div>
   <div
-    class="makeStyles-root-11"
+    class="makeStyles-root-17"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -214,11 +274,11 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-12"
+      class="makeStyles-addMetric-18"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-13"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-19"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -227,7 +287,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-15"
+        class="MuiFormControl-root makeStyles-addMetricSelect-21"
       >
         <div
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -241,7 +301,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
             tabindex="0"
           >
             <span
-              class="makeStyles-addMetricPlaceholder-14"
+              class="makeStyles-addMetricPlaceholder-20"
             >
               Select a Metric
             </span>
@@ -278,6 +338,66 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
         />
       </button>
     </div>
+    <h4
+      class="MuiTypography-root makeStyles-exposureEventsTitle-27 MuiTypography-h4 MuiTypography-gutterBottom"
+    >
+      Exposure Events (Optional)
+    </h4>
+    <div
+      class="MuiTableContainer-root"
+    >
+      <table
+        class="MuiTable-root"
+      >
+        <tbody
+          class="MuiTableBody-root"
+        >
+          <tr
+            class="MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body"
+              colspan="1"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter"
+              >
+                You don't have any exposure events.
+              </p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div
+      class="makeStyles-addMetric-18"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-19"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+        />
+      </svg>
+      <button
+        aria-label="Add exposure event"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-label"
+        >
+          Add Event
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </div>
   </div>
 </div>
 `;
@@ -285,7 +405,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
 exports[`allows adding, editing and removing a Metric Assignment 3`] = `
 <div>
   <div
-    class="makeStyles-root-11"
+    class="makeStyles-root-17"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -344,14 +464,14 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                class="makeStyles-metricName-17"
+                class="makeStyles-metricName-23"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-primary-18"
+                class="makeStyles-primary-24"
               >
                 Primary
               </span>
@@ -360,7 +480,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-16"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-22"
               >
                 <div
                   aria-haspopup="listbox"
@@ -390,11 +510,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-21 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-33 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-22"
+                    class="PrivateNotchedOutline-legend-34"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -405,7 +525,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-20"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-26"
             >
               <span
                 class="MuiSwitch-root"
@@ -413,14 +533,14 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-25 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-37 MuiSwitch-switchBase MuiSwitch-colorSecondary"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-28 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-40 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -443,7 +563,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-19"
+                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-25"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
@@ -469,11 +589,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-21 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-33 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-22"
+                      class="PrivateNotchedOutline-legend-34"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -521,11 +641,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-12"
+      class="makeStyles-addMetric-18"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-13"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-19"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -534,7 +654,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-15"
+        class="MuiFormControl-root makeStyles-addMetricSelect-21"
       >
         <div
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -548,7 +668,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
             tabindex="0"
           >
             <span
-              class="makeStyles-addMetricPlaceholder-14"
+              class="makeStyles-addMetricPlaceholder-20"
             >
               Select a Metric
             </span>
@@ -579,6 +699,66 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
           class="MuiButton-label"
         >
           Assign
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+    <h4
+      class="MuiTypography-root makeStyles-exposureEventsTitle-27 MuiTypography-h4 MuiTypography-gutterBottom"
+    >
+      Exposure Events (Optional)
+    </h4>
+    <div
+      class="MuiTableContainer-root"
+    >
+      <table
+        class="MuiTable-root"
+      >
+        <tbody
+          class="MuiTableBody-root"
+        >
+          <tr
+            class="MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body"
+              colspan="1"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter"
+              >
+                You don't have any exposure events.
+              </p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div
+      class="makeStyles-addMetric-18"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-19"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+        />
+      </svg>
+      <button
+        aria-label="Add exposure event"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-label"
+        >
+          Add Event
         </span>
         <span
           class="MuiTouchRipple-root"
@@ -594,7 +774,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
   aria-hidden="true"
 >
   <div
-    class="makeStyles-root-11"
+    class="makeStyles-root-17"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -653,14 +833,14 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                class="makeStyles-metricName-17"
+                class="makeStyles-metricName-23"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-primary-18"
+                class="makeStyles-primary-24"
               >
                 Primary
               </span>
@@ -669,7 +849,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-16"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-22"
               >
                 <div
                   aria-haspopup="listbox"
@@ -699,11 +879,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-21 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-33 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-22"
+                    class="PrivateNotchedOutline-legend-34"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -714,7 +894,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-20"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-26"
             >
               <span
                 class="MuiSwitch-root"
@@ -722,14 +902,14 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-25 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-37 MuiSwitch-switchBase MuiSwitch-colorSecondary"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-28 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-40 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -752,7 +932,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-19"
+                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-25"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
@@ -778,11 +958,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-21 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-33 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-22"
+                      class="PrivateNotchedOutline-legend-34"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -830,11 +1010,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-12"
+      class="makeStyles-addMetric-18"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-13"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-19"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -843,7 +1023,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-15"
+        class="MuiFormControl-root makeStyles-addMetricSelect-21"
       >
         <div
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -857,7 +1037,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
             tabindex="0"
           >
             <span
-              class="makeStyles-addMetricPlaceholder-14"
+              class="makeStyles-addMetricPlaceholder-20"
             >
               Select a Metric
             </span>
@@ -888,6 +1068,66 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
           class="MuiButton-label"
         >
           Assign
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+    <h4
+      class="MuiTypography-root makeStyles-exposureEventsTitle-27 MuiTypography-h4 MuiTypography-gutterBottom"
+    >
+      Exposure Events (Optional)
+    </h4>
+    <div
+      class="MuiTableContainer-root"
+    >
+      <table
+        class="MuiTable-root"
+      >
+        <tbody
+          class="MuiTableBody-root"
+        >
+          <tr
+            class="MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body"
+              colspan="1"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter"
+              >
+                You don't have any exposure events.
+              </p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div
+      class="makeStyles-addMetric-18"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-19"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+        />
+      </svg>
+      <button
+        aria-label="Add exposure event"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-label"
+        >
+          Add Event
         </span>
         <span
           class="MuiTouchRipple-root"
@@ -901,7 +1141,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
 exports[`allows adding, editing and removing a Metric Assignment 5`] = `
 <div>
   <div
-    class="makeStyles-root-11"
+    class="makeStyles-root-17"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -960,14 +1200,14 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                class="makeStyles-metricName-17"
+                class="makeStyles-metricName-23"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-primary-18"
+                class="makeStyles-primary-24"
               >
                 Primary
               </span>
@@ -976,7 +1216,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-16"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-22"
               >
                 <div
                   aria-haspopup="listbox"
@@ -1006,11 +1246,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-21 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-33 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-22"
+                    class="PrivateNotchedOutline-legend-34"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -1021,7 +1261,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-20"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-26"
             >
               <span
                 class="MuiSwitch-root"
@@ -1029,14 +1269,14 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-25 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-37 MuiSwitch-switchBase MuiSwitch-colorSecondary"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-28 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-40 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -1059,7 +1299,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-19"
+                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-25"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
@@ -1085,11 +1325,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-21 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-33 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-22"
+                      class="PrivateNotchedOutline-legend-34"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -1137,11 +1377,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-12"
+      class="makeStyles-addMetric-18"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-13"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-19"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1150,7 +1390,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-15"
+        class="MuiFormControl-root makeStyles-addMetricSelect-21"
       >
         <div
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -1164,7 +1404,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
             tabindex="0"
           >
             <span
-              class="makeStyles-addMetricPlaceholder-14"
+              class="makeStyles-addMetricPlaceholder-20"
             >
               Select a Metric
             </span>
@@ -1201,6 +1441,66 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
         />
       </button>
     </div>
+    <h4
+      class="MuiTypography-root makeStyles-exposureEventsTitle-27 MuiTypography-h4 MuiTypography-gutterBottom"
+    >
+      Exposure Events (Optional)
+    </h4>
+    <div
+      class="MuiTableContainer-root"
+    >
+      <table
+        class="MuiTable-root"
+      >
+        <tbody
+          class="MuiTableBody-root"
+        >
+          <tr
+            class="MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body"
+              colspan="1"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter"
+              >
+                You don't have any exposure events.
+              </p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div
+      class="makeStyles-addMetric-18"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-19"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+        />
+      </svg>
+      <button
+        aria-label="Add exposure event"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-label"
+        >
+          Add Event
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </div>
   </div>
 </div>
 `;
@@ -1208,7 +1508,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
 exports[`allows adding, editing and removing a Metric Assignment 6`] = `
 <div>
   <div
-    class="makeStyles-root-11"
+    class="makeStyles-root-17"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1278,11 +1578,11 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-12"
+      class="makeStyles-addMetric-18"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-13"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-19"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1291,7 +1591,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-15"
+        class="MuiFormControl-root makeStyles-addMetricSelect-21"
       >
         <div
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -1305,7 +1605,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
             tabindex="0"
           >
             <span
-              class="makeStyles-addMetricPlaceholder-14"
+              class="makeStyles-addMetricPlaceholder-20"
             >
               Select a Metric
             </span>
@@ -1342,6 +1642,66 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
         />
       </button>
     </div>
+    <h4
+      class="MuiTypography-root makeStyles-exposureEventsTitle-27 MuiTypography-h4 MuiTypography-gutterBottom"
+    >
+      Exposure Events (Optional)
+    </h4>
+    <div
+      class="MuiTableContainer-root"
+    >
+      <table
+        class="MuiTable-root"
+      >
+        <tbody
+          class="MuiTableBody-root"
+        >
+          <tr
+            class="MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body"
+              colspan="1"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter"
+              >
+                You don't have any exposure events.
+              </p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div
+      class="makeStyles-addMetric-18"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-19"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+        />
+      </svg>
+      <button
+        aria-label="Add exposure event"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-label"
+        >
+          Add Event
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </div>
   </div>
 </div>
 `;
@@ -1349,7 +1709,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
 exports[`allows adding, editing and removing a Metric Assignment 7`] = `
 <div>
   <div
-    class="makeStyles-root-11"
+    class="makeStyles-root-17"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1408,14 +1768,14 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                class="makeStyles-metricName-17"
+                class="makeStyles-metricName-23"
                 title="string"
               >
                 registration_start
               </span>
               <br />
               <span
-                class="makeStyles-primary-18"
+                class="makeStyles-primary-24"
               >
                 Primary
               </span>
@@ -1424,7 +1784,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-16"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-22"
               >
                 <div
                   aria-haspopup="listbox"
@@ -1454,11 +1814,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-29 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-41 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-30"
+                    class="PrivateNotchedOutline-legend-42"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -1469,7 +1829,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-20"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-26"
             >
               <span
                 class="MuiSwitch-root"
@@ -1477,14 +1837,14 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-33 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-45 MuiSwitch-switchBase MuiSwitch-colorSecondary"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-36 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-48 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -1507,7 +1867,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-19"
+                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-25"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
@@ -1534,11 +1894,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                   </div>
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-29 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-41 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-30"
+                      class="PrivateNotchedOutline-legend-42"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -1586,11 +1946,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-12"
+      class="makeStyles-addMetric-18"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-13"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-19"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1599,7 +1959,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-15"
+        class="MuiFormControl-root makeStyles-addMetricSelect-21"
       >
         <div
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -1613,7 +1973,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
             tabindex="0"
           >
             <span
-              class="makeStyles-addMetricPlaceholder-14"
+              class="makeStyles-addMetricPlaceholder-20"
             >
               Select a Metric
             </span>
@@ -1644,6 +2004,66 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
           class="MuiButton-label"
         >
           Assign
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+    <h4
+      class="MuiTypography-root makeStyles-exposureEventsTitle-27 MuiTypography-h4 MuiTypography-gutterBottom"
+    >
+      Exposure Events (Optional)
+    </h4>
+    <div
+      class="MuiTableContainer-root"
+    >
+      <table
+        class="MuiTable-root"
+      >
+        <tbody
+          class="MuiTableBody-root"
+        >
+          <tr
+            class="MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body"
+              colspan="1"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter"
+              >
+                You don't have any exposure events.
+              </p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div
+      class="makeStyles-addMetric-18"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-19"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+        />
+      </svg>
+      <button
+        aria-label="Add exposure event"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-label"
+        >
+          Add Event
         </span>
         <span
           class="MuiTouchRipple-root"
@@ -1785,6 +2205,66 @@ exports[`renders as expected 1`] = `
           class="MuiButton-label"
         >
           Assign
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+    <h4
+      class="MuiTypography-root makeStyles-exposureEventsTitle-11 MuiTypography-h4 MuiTypography-gutterBottom"
+    >
+      Exposure Events (Optional)
+    </h4>
+    <div
+      class="MuiTableContainer-root"
+    >
+      <table
+        class="MuiTable-root"
+      >
+        <tbody
+          class="MuiTableBody-root"
+        >
+          <tr
+            class="MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body"
+              colspan="1"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter"
+              >
+                You don't have any exposure events.
+              </p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div
+      class="makeStyles-addMetric-2"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-3"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+        />
+      </svg>
+      <button
+        aria-label="Add exposure event"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-label"
+        >
+          Add Event
         </span>
         <span
           class="MuiTouchRipple-root"

--- a/e2e/navigation.test.tsx
+++ b/e2e/navigation.test.tsx
@@ -41,6 +41,17 @@ describe('Experiments', () => {
   })
 })
 
+describe('Experiment Creation', () => {
+  describe('from experiments creation', () => {
+    it('should render', async () => {
+      await page.goto('http://a8c-abacus-local:3001/experiments/new')
+      expect(page.url()).toMatch(/^http:\/\/a8c-abacus-local:3001\/experiments\/new/)
+      await page.waitForSelector('h4')
+      expect(/Design and Document Your Experiment/.exec(await page.content())).not.toBeNull()
+    })
+  })
+})
+
 describe('Metrics', () => {
   describe('from Metrics table', () => {
     it('should show metric details on row click', async () => {

--- a/lib/experiments.test.ts
+++ b/lib/experiments.test.ts
@@ -73,6 +73,7 @@ describe('lib/experiments.ts module', () => {
           "description": "",
           "endDatetime": "",
           "existingUsersAllowed": "true",
+          "exposureEvents": Array [],
           "metricAssignments": Array [],
           "name": "",
           "ownerLogin": "",

--- a/lib/experiments.ts
+++ b/lib/experiments.ts
@@ -64,6 +64,7 @@ export function createInitialExperiment() {
       { name: 'control', isDefault: true, allocatedPercentage: 50 },
       { name: 'treatment', isDefault: false, allocatedPercentage: 50 },
     ],
+    exposureEvents: [],
   }
 }
 

--- a/lib/schemas.test.ts
+++ b/lib/schemas.test.ts
@@ -1,0 +1,155 @@
+import * as Schemas from './schemas'
+
+describe('lib/schemas.ts module', () => {
+  describe('metricFullSchema params constraint', () => {
+    it('should require exactly one params property', async () => {
+      expect.assertions(4)
+
+      try {
+        await Schemas.metricFullSchema.validate(
+          {
+            eventParams: [],
+            revenueParams: {},
+          },
+          { abortEarly: false },
+        )
+      } catch (e) {
+        expect(e.errors).toMatchInlineSnapshot(`
+          Array [
+            "metricId must be defined",
+            "name must be defined",
+            "description must be defined",
+            "parameterType must be defined",
+            "higherIsBetter must be defined",
+            "revenueParams.refundDays must be defined",
+            "revenueParams.productSlugs must be defined",
+            "Exactly one of eventParams or revenueParams must be defined.",
+          ]
+        `)
+      }
+
+      try {
+        await Schemas.metricFullSchema.validate(
+          {
+            eventParams: null,
+            revenueParams: null,
+          },
+          { abortEarly: false },
+        )
+      } catch (e) {
+        expect(e.errors).toMatchInlineSnapshot(`
+          Array [
+            "metricId must be defined",
+            "name must be defined",
+            "description must be defined",
+            "parameterType must be defined",
+            "higherIsBetter must be defined",
+            "Exactly one of eventParams or revenueParams must be defined.",
+          ]
+        `)
+      }
+
+      try {
+        await Schemas.metricFullSchema.validate(
+          {
+            eventParams: [],
+            revenueParams: null,
+          },
+          { abortEarly: false },
+        )
+      } catch (e) {
+        expect(e.errors).toMatchInlineSnapshot(`
+          Array [
+            "metricId must be defined",
+            "name must be defined",
+            "description must be defined",
+            "parameterType must be defined",
+            "higherIsBetter must be defined",
+          ]
+        `)
+      }
+
+      try {
+        await Schemas.metricFullSchema.validate(
+          {
+            revenueParams: {},
+            eventParams: null,
+          },
+          { abortEarly: false },
+        )
+      } catch (e) {
+        expect(e.errors).toMatchInlineSnapshot(`
+          Array [
+            "metricId must be defined",
+            "name must be defined",
+            "description must be defined",
+            "parameterType must be defined",
+            "higherIsBetter must be defined",
+            "revenueParams.refundDays must be defined",
+            "revenueParams.productSlugs must be defined",
+          ]
+        `)
+      }
+    })
+  })
+
+  describe('experimentFullNewSchema endDatetime', () => {
+    it('throws validation error if endDate is before startDate', async () => {
+      expect.assertions(1)
+      try {
+        await Schemas.experimentFullNewSchema.validate(
+          {
+            startDatetime: '2020-08-02',
+            endDatetime: '2020-08-01',
+          },
+          { abortEarly: false },
+        )
+      } catch (e) {
+        expect(e.inner).toMatchInlineSnapshot(`
+          Array [
+            [ValidationError: name must be defined],
+            [ValidationError: Start date (UTC) must be in the future.],
+            [ValidationError: End date must be after start date.],
+            [ValidationError: platform must be defined],
+            [ValidationError: ownerLogin must be defined],
+            [ValidationError: description must be defined],
+            [ValidationError: existingUsersAllowed must be defined],
+            [ValidationError: p2Url must be defined],
+            [ValidationError: metricAssignments must be defined],
+            [ValidationError: segmentAssignments must be defined],
+            [ValidationError: variations must be defined],
+          ]
+        `)
+      }
+    })
+
+    it('throws validation error if endDate is not within defined period of startDate', async () => {
+      expect.assertions(1)
+      try {
+        await Schemas.experimentFullNewSchema.validate(
+          {
+            startDatetime: '2020-08-02',
+            endDatetime: '2021-08-03',
+          },
+          { abortEarly: false },
+        )
+      } catch (e) {
+        expect(e.inner).toMatchInlineSnapshot(`
+          Array [
+            [ValidationError: name must be defined],
+            [ValidationError: Start date (UTC) must be in the future.],
+            [ValidationError: End date must be within 12 months of start date.],
+            [ValidationError: platform must be defined],
+            [ValidationError: ownerLogin must be defined],
+            [ValidationError: description must be defined],
+            [ValidationError: existingUsersAllowed must be defined],
+            [ValidationError: p2Url must be defined],
+            [ValidationError: metricAssignments must be defined],
+            [ValidationError: segmentAssignments must be defined],
+            [ValidationError: variations must be defined],
+          ]
+        `)
+      }
+    })
+  })
+})

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -2,6 +2,7 @@
 // https://app.swaggerhub.com/apis/yanir/experiments/0.1.0
 
 import * as dateFns from 'date-fns'
+import _ from 'lodash'
 import * as yup from 'yup'
 
 const idSchema = yup.number().integer().positive()
@@ -283,7 +284,7 @@ export const experimentFullNewOutboundSchema = experimentFullNewSchema
       exposure_events: currentValue.exposure_events.map(
         (event: EventNew): Event => ({
           event: event.event,
-          props: event.props ? Object.fromEntries(event.props.map(({ key, value }) => [key, value])) : undefined,
+          props: event.props ? _.fromPairs(event.props.map(({ key, value }) => [key, value])) : undefined,
         }),
       ),
     }),

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -280,10 +280,12 @@ export const experimentFullNewOutboundSchema = experimentFullNewSchema
         .defined()
         .cast(currentValue.segment_assignments),
       // Converting EventNew to Event
-      exposure_events: currentValue.exposure_events.map((event: EventNew): Event => ({
-        event: event.event,
-        props: event.props ? Object.fromEntries(event.props.map(({ key, value }) => [key, value])) : undefined,
-      }))
+      exposure_events: currentValue.exposure_events.map(
+        (event: EventNew): Event => ({
+          event: event.event,
+          props: event.props ? Object.fromEntries(event.props.map(({ key, value }) => [key, value])) : undefined,
+        }),
+      ),
     }),
   )
 

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -19,6 +19,15 @@ export const eventSchema = yup
   .camelCase()
 export type Event = yup.InferType<typeof eventSchema>
 
+export const eventNewSchema = yup
+  .object({
+    event: yup.string().defined(),
+    props: yup.array(yup.object({ key: yup.string().defined(), value: yup.string().defined() }).defined()).defined(),
+  })
+  .defined()
+  .camelCase()
+export type EventNew = yup.InferType<typeof eventNewSchema>
+
 export enum TransactionTypes {
   NewPurchase = 'new purchase',
   Recurring = 'recurring',
@@ -242,6 +251,7 @@ export const experimentFullNewSchema = experimentFullSchema.shape({
             `End date must be within ${MAX_DISTANCE_BETWEEN_START_AND_END_DATE_IN_MONTHS} months of start date.`,
           ),
     ),
+  exposureEvents: yup.array(eventNewSchema).notRequired(),
   metricAssignments: yup.array(metricAssignmentNewSchema).defined().min(1),
   segmentAssignments: yup.array(segmentAssignmentNewSchema).defined(),
   variations: yup.array<VariationNew>(variationNewSchema).defined().min(2),
@@ -269,6 +279,11 @@ export const experimentFullNewOutboundSchema = experimentFullNewSchema
         .array(segmentAssignmentNewOutboundSchema)
         .defined()
         .cast(currentValue.segment_assignments),
+      // Converting EventNew to Event
+      exposure_events: currentValue.exposure_events.map((event: EventNew): Event => ({
+        event: event.event,
+        props: event.props ? Object.fromEntries(event.props.map(({ key, value }) => [key, value])) : undefined,
+      }))
     }),
   )
 

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -78,15 +78,10 @@ export const metricFullSchema = metricBareSchema
   })
   .defined()
   .camelCase()
-  .test(
-    'exactly-one-params',
-    'Exactly one of eventParams or revenueParams must be defined.',
-    /* istanbul ignore next; This is a test itself */
-    (metricFull) => {
-      // (Logical XOR)
-      return !!metricFull.eventParams !== !!metricFull.revenueParams
-    },
-  )
+  .test('exactly-one-params', 'Exactly one of eventParams or revenueParams must be defined.', (metricFull) => {
+    // (Logical XOR)
+    return !!metricFull.eventParams !== !!metricFull.revenueParams
+  })
 export type MetricFull = yup.InferType<typeof metricFullSchema>
 
 export enum AttributionWindowSeconds {
@@ -242,7 +237,6 @@ export const experimentFullNewSchema = experimentFullSchema.shape({
     .defined()
     .when(
       'startDatetime',
-      /* istanbul ignore next; should be e2e tested */
       (startDatetime: Date, schema: yup.DateSchema) =>
         startDatetime &&
         schema
@@ -268,7 +262,7 @@ export const experimentFullNewOutboundSchema = experimentFullNewSchema
   })
   .snakeCase()
   .transform(
-    // istanbul ignore next; This will be tested by e2e tests
+    // istanbul ignore next; Tested by integration
     (currentValue) => ({
       ...currentValue,
       // The P2 field gets incorrectly snake_cased so we fix it here

--- a/test-helpers/fixtures.ts
+++ b/test-helpers/fixtures.ts
@@ -330,9 +330,11 @@ function createExperimentFull(fieldOverrides: Partial<ExperimentFull> = {}): Exp
     'variations',
     'metricAssignments',
     'segmentAssignments',
+    'exposureEvents',
   ]
   const newExperimentFieldOverrides = {
     ..._.omit(fieldOverrides, fieldsOnlyForExistingExperiments),
+    exposureEvents: undefined,
     status: undefined,
   }
   const existingExperimentFieldOverrides = _.pick(fieldOverrides, fieldsOnlyForExistingExperiments)


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR adds Exposure Events to Experiment Creation:**

<img width="750" alt="Screen Shot 2020-08-26 at 2 08 47 pm" src="https://user-images.githubusercontent.com/971886/91267304-ac074880-e7a5-11ea-9aa4-5e6901d9fb9f.png">

- Video: https://d.pr/v/Wu8qsX
- Internally in the form I use an array of `{ key, value }` objects to represent the properties. It needs to be an array in form state to work with the `<FieldArray>`.
- Added extra integration testing: form state conversion to outbound.
- Added extra integration testing: using a real form state example to test `ExperimentsApi.create`

<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #262 

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
- Manual testing with mock data (locally)
- Additional manual testing instructions (please specify):
   - Create experiment using production data
   - Verify the fields are correct in the database