### PR TITLE
Add edit button and dialog to Conclusions panel

### DIFF
--- a/components/ConclusionsPanel.test.tsx
+++ b/components/ConclusionsPanel.test.tsx
@@ -1,3 +1,4 @@
+import { fireEvent, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react'
 import * as notistack from 'notistack'
 import React from 'react'
 
@@ -235,4 +236,36 @@ test('renders as expected without deployed variation', () => {
       </div>
     </div>
   `)
+})
+
+const queryEditDialog = () => screen.queryByRole('heading', { name: /Edit Experiment: Conclusions/ })
+
+test('opens and saves edit dialog', async () => {
+  const experiment = Fixtures.createExperimentFull()
+  const { container: _container } = render(<ConclusionsPanel experiment={experiment} />)
+
+  const editButton = screen.getByRole('button', { name: /Edit/ })
+  fireEvent.click(editButton)
+
+  await waitFor(queryEditDialog)
+
+  const saveButton = screen.getByRole('button', { name: /Save/ })
+  fireEvent.click(saveButton)
+
+  await waitForElementToBeRemoved(queryEditDialog)
+})
+
+test('opens and cancels edit dialog', async () => {
+  const experiment = Fixtures.createExperimentFull()
+  const { container: _container } = render(<ConclusionsPanel experiment={experiment} />)
+
+  const editButton = screen.getByRole('button', { name: /Edit/ })
+  fireEvent.click(editButton)
+
+  await waitFor(queryEditDialog)
+
+  const cancelButton = screen.getByRole('button', { name: /Cancel/ })
+  fireEvent.click(cancelButton)
+
+  await waitForElementToBeRemoved(queryEditDialog)
 })

--- a/components/ConclusionsPanel.test.tsx
+++ b/components/ConclusionsPanel.test.tsx
@@ -1,9 +1,17 @@
+import * as notistack from 'notistack'
 import React from 'react'
 
 import Fixtures from '@/test-helpers/fixtures'
 import { render } from '@/test-helpers/test-utils'
 
 import ConclusionsPanel from './ConclusionsPanel'
+
+jest.mock('notistack')
+const mockedNotistack = notistack as jest.Mocked<typeof notistack>
+mockedNotistack.useSnackbar.mockImplementation(() => ({
+  enqueueSnackbar: jest.fn(),
+  closeSnackbar: jest.fn(),
+}))
 
 test('renders as expected with complete conclusion data', () => {
   const experiment = Fixtures.createExperimentFull({
@@ -18,11 +26,39 @@ test('renders as expected with complete conclusion data', () => {
       <div
         class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
       >
-        <h3
-          class="MuiTypography-root makeStyles-title-1 MuiTypography-h3 MuiTypography-colorTextPrimary"
+        <div
+          class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
         >
-          Conclusions
-        </h3>
+          <h3
+            class="MuiTypography-root makeStyles-title-1 MuiTypography-h3 MuiTypography-colorTextPrimary"
+          >
+            Conclusions
+          </h3>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.9959.9959 0 00-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                />
+              </svg>
+              Edit
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </div>
         <table
           class="MuiTable-root"
         >
@@ -103,11 +139,39 @@ test('renders as expected without deployed variation', () => {
       <div
         class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
       >
-        <h3
-          class="MuiTypography-root makeStyles-title-2 MuiTypography-h3 MuiTypography-colorTextPrimary"
+        <div
+          class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
         >
-          Conclusions
-        </h3>
+          <h3
+            class="MuiTypography-root makeStyles-title-3 MuiTypography-h3 MuiTypography-colorTextPrimary"
+          >
+            Conclusions
+          </h3>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.9959.9959 0 00-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                />
+              </svg>
+              Edit
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </div>
         <table
           class="MuiTable-root"
         >

--- a/components/ConclusionsPanel.tsx
+++ b/components/ConclusionsPanel.tsx
@@ -127,7 +127,6 @@ function ConclusionsPanel({ experiment }: { experiment: ExperimentFull }) {
                     label='Conclusion URL'
                     variant='outlined'
                     fullWidth
-                    required
                     InputLabelProps={{
                       shrink: true,
                     }}

--- a/components/ConclusionsPanel.tsx
+++ b/components/ConclusionsPanel.tsx
@@ -1,5 +1,25 @@
-import { createStyles, makeStyles, Paper, Theme, Typography } from '@material-ui/core'
-import React from 'react'
+import {
+  Button,
+  createStyles,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  makeStyles,
+  Paper,
+  Radio,
+  Theme,
+  Toolbar,
+  Typography,
+} from '@material-ui/core'
+import { Edit } from '@material-ui/icons'
+import { Field, Formik } from 'formik'
+import { RadioGroup as FormikMuiRadioGroup, TextField } from 'formik-material-ui'
+import { useSnackbar } from 'notistack'
+import React, { useState } from 'react'
 
 import LabelValueTable from '@/components/LabelValueTable'
 import * as Experiments from '@/lib/experiments'
@@ -8,9 +28,14 @@ import { ExperimentFull } from '@/lib/schemas'
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     title: {
-      padding: theme.spacing(1, 2),
-      [theme.breakpoints.down('xs')]: {
-        padding: theme.spacing(1),
+      flexGrow: 1,
+    },
+    row: {
+      margin: theme.spacing(5, 0),
+      display: 'flex',
+      alignItems: 'center',
+      '&:first-of-type': {
+        marginTop: theme.spacing(3),
       },
     },
   }),
@@ -38,12 +63,106 @@ function ConclusionsPanel({ experiment }: { experiment: ExperimentFull }) {
     { label: 'Deployed variation', value: deployedVariation?.name },
   ]
 
+  // Edit Modal
+  const { enqueueSnackbar } = useSnackbar()
+  const [isEditing, setIsEditing] = useState<boolean>(false)
+  const onEdit = () => setIsEditing(true)
+  const onCancelEdit = () => {
+    setIsEditing(false)
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/require-await
+  const onSubmitEdit = async (formData: unknown) => {
+    // TODO: Full submission
+    enqueueSnackbar('Experiment Updated!', { variant: 'success' })
+    setIsEditing(false)
+  }
+
   return (
     <Paper>
-      <Typography className={classes.title} color='textPrimary' variant='h3'>
-        Conclusions
-      </Typography>
+      <Toolbar>
+        <Typography className={classes.title} color='textPrimary' variant='h3'>
+          Conclusions
+        </Typography>
+        <Button onClick={onEdit} variant='outlined'>
+          <Edit />
+          Edit
+        </Button>
+      </Toolbar>
+
       <LabelValueTable data={data} />
+
+      <Dialog open={isEditing} fullWidth aria-labelledby='edit-experiment-conclusions-dialog-title'>
+        <DialogTitle id='edit-experiment-conclusions-dialog-title'>Edit Experiment: Conclusions</DialogTitle>
+        <Formik initialValues={{ experiment: experiment }} onSubmit={onSubmitEdit}>
+          {(formikProps) => (
+            <form onSubmit={formikProps.handleSubmit}>
+              <DialogContent>
+                <div className={classes.row}>
+                  <Field
+                    component={TextField}
+                    name='experiment.endReason'
+                    id='experiment.endReason'
+                    label='Reason the experiment ended'
+                    placeholder='Completed successfully'
+                    variant='outlined'
+                    fullWidth
+                    required
+                    multiline
+                    rows={2}
+                    InputLabelProps={{
+                      shrink: true,
+                    }}
+                  />
+                </div>
+
+                <div className={classes.row}>
+                  <Field
+                    component={TextField}
+                    id='experiment.conclusionUrl'
+                    name='experiment.conclusionUrl'
+                    placeholder='https://your-p2-post-here/#conclusion-comment'
+                    label='Conclusion URL'
+                    variant='outlined'
+                    fullWidth
+                    required
+                    InputLabelProps={{
+                      shrink: true,
+                    }}
+                  />
+                </div>
+
+                <div className={classes.row}>
+                  <FormControl component='fieldset'>
+                    <FormLabel component='legend'>Deployed variation</FormLabel>
+                    <Field
+                      component={FormikMuiRadioGroup}
+                      name='experiment.deployedVariationId'
+                      value={experiment.deployedVariationId}
+                    >
+                      {experiment.variations.map((variation) => (
+                        <FormControlLabel
+                          key={variation.variationId}
+                          value={variation.variationId}
+                          control={<Radio />}
+                          label={variation.name}
+                        />
+                      ))}
+                    </Field>
+                  </FormControl>
+                </div>
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={onCancelEdit} color='primary'>
+                  Cancel
+                </Button>
+                <Button color='primary' type='submit'>
+                  Save
+                </Button>
+              </DialogActions>
+            </form>
+          )}
+        </Formik>
+      </Dialog>
     </Paper>
   )
 }

--- a/components/ConclusionsPanel.tsx
+++ b/components/ConclusionsPanel.tsx
@@ -67,14 +67,12 @@ function ConclusionsPanel({ experiment }: { experiment: ExperimentFull }) {
   const { enqueueSnackbar } = useSnackbar()
   const [isEditing, setIsEditing] = useState<boolean>(false)
   const editInitialValues = {
-    endReason: experiment.endReason,
-    conclusionUrl: experiment.conclusionUrl,
-    deployedVariationId: String(experiment.deployedVariationId),
+    endReason: experiment.endReason ?? '',
+    conclusionUrl: experiment.conclusionUrl ?? '',
+    deployedVariationId: String(experiment.deployedVariationId ?? ''),
   }
   const onEdit = () => setIsEditing(true)
-  const onCancelEdit = () => {
-    setIsEditing(false)
-  }
+  const onCancelEdit = () => setIsEditing(false)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/require-await
   const onSubmitEdit = async (formData: unknown) => {
     // TODO: Full submission

--- a/components/ConclusionsPanel.tsx
+++ b/components/ConclusionsPanel.tsx
@@ -66,6 +66,11 @@ function ConclusionsPanel({ experiment }: { experiment: ExperimentFull }) {
   // Edit Modal
   const { enqueueSnackbar } = useSnackbar()
   const [isEditing, setIsEditing] = useState<boolean>(false)
+  const editInitialValues = {
+    endReason: experiment.endReason,
+    conclusionUrl: experiment.conclusionUrl,
+    deployedVariationId: String(experiment.deployedVariationId),
+  }
   const onEdit = () => setIsEditing(true)
   const onCancelEdit = () => {
     setIsEditing(false)
@@ -93,7 +98,7 @@ function ConclusionsPanel({ experiment }: { experiment: ExperimentFull }) {
 
       <Dialog open={isEditing} fullWidth aria-labelledby='edit-experiment-conclusions-dialog-title'>
         <DialogTitle id='edit-experiment-conclusions-dialog-title'>Edit Experiment: Conclusions</DialogTitle>
-        <Formik initialValues={{ experiment: experiment }} onSubmit={onSubmitEdit}>
+        <Formik initialValues={{ experiment: editInitialValues }} onSubmit={onSubmitEdit}>
           {(formikProps) => (
             <form onSubmit={formikProps.handleSubmit}>
               <DialogContent>
@@ -134,15 +139,11 @@ function ConclusionsPanel({ experiment }: { experiment: ExperimentFull }) {
                 <div className={classes.row}>
                   <FormControl component='fieldset'>
                     <FormLabel component='legend'>Deployed variation</FormLabel>
-                    <Field
-                      component={FormikMuiRadioGroup}
-                      name='experiment.deployedVariationId'
-                      value={experiment.deployedVariationId}
-                    >
+                    <Field component={FormikMuiRadioGroup} name='experiment.deployedVariationId'>
                       {experiment.variations.map((variation) => (
                         <FormControlLabel
                           key={variation.variationId}
-                          value={variation.variationId}
+                          value={String(variation.variationId)}
                           control={<Radio />}
                           label={variation.name}
                         />

--- a/components/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/components/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -1290,7 +1290,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-32 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-33 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Audience
               </h3>
@@ -1382,7 +1382,7 @@ exports[`renders as expected with conclusion data 1`] = `
                           >
                             control
                             <span
-                              class="makeStyles-default-33 makeStyles-root-30"
+                              class="makeStyles-default-34 makeStyles-root-30"
                             >
                               Default
                             </span>
@@ -1487,7 +1487,7 @@ exports[`renders as expected with conclusion data 1`] = `
                           >
                             segment_2
                             <span
-                              class="makeStyles-excluded-34 makeStyles-root-30"
+                              class="makeStyles-excluded-35 makeStyles-root-30"
                             >
                               Excluded
                             </span>
@@ -1701,11 +1701,39 @@ exports[`renders as expected with conclusion data 1`] = `
           <div
             class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
           >
-            <h3
-              class="MuiTypography-root makeStyles-title-31 MuiTypography-h3 MuiTypography-colorTextPrimary"
+            <div
+              class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
-              Conclusions
-            </h3>
+              <h3
+                class="MuiTypography-root makeStyles-title-31 MuiTypography-h3 MuiTypography-colorTextPrimary"
+              >
+                Conclusions
+              </h3>
+              <button
+                class="MuiButtonBase-root MuiButton-root MuiButton-outlined"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiButton-label"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.9959.9959 0 00-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                    />
+                  </svg>
+                  Edit
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
+            </div>
             <table
               class="MuiTable-root"
             >
@@ -1797,7 +1825,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-36 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-37 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 General
               </h3>
@@ -1884,18 +1912,18 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-39"
+                      class="makeStyles-root-40"
                       title="20/09/2020, 20:00:00"
                     >
                       2020-09-21
                     </span>
                     <span
-                      class="makeStyles-to-35"
+                      class="makeStyles-to-36"
                     >
                       to
                     </span>
                     <span
-                      class="makeStyles-root-39"
+                      class="makeStyles-root-40"
                       title="20/11/2020, 20:00:00"
                     >
                       2020-11-21
@@ -1932,7 +1960,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-43 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-44 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Audience
               </h3>
@@ -2024,7 +2052,7 @@ exports[`renders as expected without conclusion data 1`] = `
                           >
                             control
                             <span
-                              class="makeStyles-default-44 makeStyles-root-42"
+                              class="makeStyles-default-45 makeStyles-root-43"
                             >
                               Default
                             </span>
@@ -2129,7 +2157,7 @@ exports[`renders as expected without conclusion data 1`] = `
                           >
                             segment_2
                             <span
-                              class="makeStyles-excluded-45 makeStyles-root-42"
+                              class="makeStyles-excluded-46 makeStyles-root-43"
                             >
                               Excluded
                             </span>
@@ -2153,7 +2181,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-41 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-42 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Metrics
               </h3>
@@ -2232,7 +2260,7 @@ exports[`renders as expected without conclusion data 1`] = `
                   >
                     metric_1
                     <span
-                      class="makeStyles-primary-40 makeStyles-root-42"
+                      class="makeStyles-primary-41 makeStyles-root-43"
                     >
                       Primary
                     </span>


### PR DESCRIPTION
As part of addressing #196, this PR follows the same pattern as the editing modals so far, adding the conclusion edit dialog without the actual submission capabilities. 

![Peek 2020-08-27 17-54](https://user-images.githubusercontent.com/3952615/91413528-9c176380-e88e-11ea-9ba6-cbc068ae7767.gif)

## How has this been tested?

- Automated tests that cover added/changed functionality
- Manual testing with production data (see gif)
