### PR TITLE
Show conclusion panel based on status

### DIFF
--- a/components/ExperimentDetails.test.tsx
+++ b/components/ExperimentDetails.test.tsx
@@ -2,6 +2,7 @@ import MockDate from 'mockdate'
 import * as notistack from 'notistack'
 import React from 'react'
 
+import { Status } from '@/lib/schemas'
 import Fixtures from '@/test-helpers/fixtures'
 import { createMatchMedia, render } from '@/test-helpers/test-utils'
 
@@ -63,6 +64,7 @@ test('renders as expected with conclusion data', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 101, segmentId: 1 }),
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 102, segmentId: 2, isExcluded: true }),
     ],
+    status: Status.Disabled,
   })
   const { container } = render(<ExperimentDetails experiment={experiment} metrics={metrics} segments={segments} />)
 

--- a/components/ExperimentDetails.tsx
+++ b/components/ExperimentDetails.tsx
@@ -8,8 +8,7 @@ import AudiencePanel from '@/components/AudiencePanel'
 import ConclusionsPanel from '@/components/ConclusionsPanel'
 import GeneralPanel from '@/components/GeneralPanel'
 import MetricAssignmentsPanel from '@/components/MetricAssignmentsPanel'
-import * as Experiments from '@/lib/experiments'
-import { ExperimentFull, MetricBare, Segment } from '@/lib/schemas'
+import { ExperimentFull, MetricBare, Segment, Status } from '@/lib/schemas'
 
 const debug = debugFactory('abacus:components/ExperimentDetails.tsx')
 
@@ -44,7 +43,7 @@ function ExperimentDetails({
           <Grid item>
             <MetricAssignmentsPanel experiment={experiment} metrics={metrics} />
           </Grid>
-          {Experiments.hasConclusionData(experiment) && (
+          {(experiment.status === Status.Completed || experiment.status === Status.Disabled) && (
             <Grid item>
               <ConclusionsPanel experiment={experiment} />
             </Grid>

--- a/lib/experiments.test.ts
+++ b/lib/experiments.test.ts
@@ -37,24 +37,6 @@ describe('lib/experiments.ts module', () => {
     })
   })
 
-  describe('hasConclusionData', () => {
-    it('should return true if at least one piece of conclusion data is set', () => {
-      expect(
-        Experiments.hasConclusionData(
-          Fixtures.createExperimentFull({
-            conclusionUrl: 'https://betterexperiments.wordpress.com/experiment_1/conclusion',
-          }),
-        ),
-      ).toBe(true)
-      expect(Experiments.hasConclusionData(Fixtures.createExperimentFull({ deployedVariationId: 1 }))).toBe(true)
-      expect(Experiments.hasConclusionData(Fixtures.createExperimentFull({ endReason: 'Ran its course.' }))).toBe(true)
-    })
-
-    it('should return false if no conclusion data is set', () => {
-      expect(Experiments.hasConclusionData(Fixtures.createExperimentFull())).toBe(false)
-    })
-  })
-
   describe('getDefaultAnalysisSummary', () => {
     it('returns the correct strategy based on the exposureEvents', () => {
       expect(Experiments.getDefaultAnalysisStrategy(Fixtures.createExperimentFull({ exposureEvents: null }))).toBe(

--- a/lib/experiments.ts
+++ b/lib/experiments.ts
@@ -32,13 +32,6 @@ export function getPrimaryMetricAssignmentId(experiment: ExperimentFull): number
 }
 
 /**
- * Determines whether conclusion data has been entered for this experiment.
- */
-export function hasConclusionData(experiment: ExperimentFull): boolean {
-  return !!experiment.endReason || !!experiment.conclusionUrl || typeof experiment.deployedVariationId === 'number'
-}
-
-/**
  * Return this experiment's default analysis strategy, which depends on the existence of exposureEvents.
  */
 export function getDefaultAnalysisStrategy(experiment: ExperimentFull) {


### PR DESCRIPTION
As part of addressing #196, this PR changes the condition for showing the Conclusions panel on the experiment page to be based on the experiment's status rather than on whether it has conclusion fields. This will allow us to always edit the conclusions once #281 is in.

## How has this been tested?
- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
