### PR TITLE
Add reload capabilities to useDataSource

### DIFF
--- a/utils/data-loading.ts
+++ b/utils/data-loading.ts
@@ -25,9 +25,6 @@ export function useDataSource<Data, Deps extends DependencyList | undefined, E e
     let isSubscribed = true
     // For isSubscribed to work with reloading we need to use reload as a Ref
     reloadRef.current = () => {
-      if (!isSubscribed) {
-        return
-      }
       setIsLoading(true)
       createDataPromise()
         .then((data) => isSubscribed && setData(data))

--- a/utils/data-loading.ts
+++ b/utils/data-loading.ts
@@ -24,7 +24,10 @@ export function useDataSource<Data, Deps extends DependencyList | undefined, E e
     let isSubscribed = true
     // For isSubscribed to work with reloading we need to use reload as a Ref
     reloadRef.current = () => {
-      isSubscribed && setIsLoading(true)
+      if (!isSubscribed) {
+        return
+      }
+      setIsLoading(true)
       createDataPromise()
         .then((data) => isSubscribed && setData(data))
         .catch((error) => isSubscribed && setError(error))

--- a/utils/data-loading.ts
+++ b/utils/data-loading.ts
@@ -19,7 +19,8 @@ export function useDataSource<Data, Deps extends DependencyList | undefined, E e
   const reloadRef = useRef<() => void>(noop)
 
   useEffect(() => {
-    // The isSubscribed logic is necessary to prevent setStates after unmounts or dependency changes
+    // The isSubscribed logic is necessary to prevent setStates after unmounts or dependency changes.
+    // For more information see: https://juliangaramendy.dev/use-promise-subscription/ 
     let isSubscribed = true
     // For isSubscribed to work with reloading we need to use reload as a Ref
     reloadRef.current = () => {

--- a/utils/data-loading.ts
+++ b/utils/data-loading.ts
@@ -8,6 +8,7 @@ import { DependencyList, useEffect, useRef, useState } from 'react'
  *
  * @param createDataPromise A function that returns a promise to the data
  * @param deps The hook dependencies for `createDataPromise`
+ *  * @returns { data, isLoading, error, reloadRef } Where data, isLoading and error are data states and reloadRef is a Ref to a function that reloads the data.
  */
 export function useDataSource<Data, Deps extends DependencyList | undefined, E extends Error>(
   createDataPromise: () => Promise<Data>,
@@ -20,7 +21,7 @@ export function useDataSource<Data, Deps extends DependencyList | undefined, E e
 
   useEffect(() => {
     // The isSubscribed logic is necessary to prevent setStates after unmounts or dependency changes.
-    // For more information see: https://juliangaramendy.dev/use-promise-subscription/ 
+    // For more information see: https://juliangaramendy.dev/use-promise-subscription/
     let isSubscribed = true
     // For isSubscribed to work with reloading we need to use reload as a Ref
     reloadRef.current = () => {

--- a/utils/data-loading.ts
+++ b/utils/data-loading.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import { noop } from 'lodash'
 import { useSnackbar } from 'notistack'
 import { DependencyList, useEffect, useRef, useState } from 'react'
 
@@ -16,8 +16,7 @@ export function useDataSource<Data, Deps extends DependencyList | undefined, E e
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [data, setData] = useState<Data | null>(null)
   const [error, setError] = useState<E | null>(null)
-  // eslint-disable-next-line @typescript-eslint/unbound-method
-  const reloadRef = useRef<() => void>(_.noop)
+  const reloadRef = useRef<() => void>(noop)
 
   useEffect(() => {
     // The isSubscribed logic is necessary to prevent setStates after unmounts or dependency changes
@@ -33,8 +32,7 @@ export function useDataSource<Data, Deps extends DependencyList | undefined, E e
     reloadRef.current()
     return () => {
       isSubscribed = false
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      reloadRef.current = _.noop
+      reloadRef.current = noop
     }
     // Dep checking here is not needed as we are using the additionalHooks option to check useDataSource
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR enables data from `useDataSource` to be reloaded**
- Uses `isSubscribed` to ensure subscription state as things can get messier now.
   See https://juliangaramendy.dev/use-promise-subscription/ for how it works.
- Extends the return object to include `reloadRef`. 
   I'd argue it is simpler to reason about and use (particularly in combination with the internal isSubscribed state - it just works) while not particularly changing the code that uses it - it is easy to see it is a ref and know that we need to call `reloadRef.current()` instead of the hypothetical alternative `reload()`.
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This change is necessary for all our update logic that will very soon need to reload data into the views.

Something to note is that the loading indicator can occur while we have old data present, we will be using this in our UIs - we should be both showing the old data and an indicator that the new data is loading.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
