### PR TITLE
Add exposure events and status

### DIFF
--- a/components/AudiencePanel.test.tsx
+++ b/components/AudiencePanel.test.tsx
@@ -64,3 +64,34 @@ test('throws an error when some segments not resolvable', () => {
     consoleErrorSpy.mockRestore()
   }
 })
+
+test('Shows exposure events', () => {
+  const experiment = Fixtures.createExperimentFull({
+    exposureEvents: [
+      {
+        event: 'test',
+        props: {
+          prop1: 'value1',
+        },
+      },
+    ],
+  })
+  const { container } = render(<AudiencePanel experiment={experiment} segments={[]} />)
+  expect(container).toMatchSnapshot()
+})
+
+test('Empty array shows no exposure events', () => {
+  const experiment = Fixtures.createExperimentFull({
+    exposureEvents: [],
+  })
+  const { container } = render(<AudiencePanel experiment={experiment} segments={[]} />)
+  expect(container).toMatchSnapshot()
+})
+
+test('null shows no exposure events', () => {
+  const experiment = Fixtures.createExperimentFull({
+    exposureEvents: null,
+  })
+  const { container } = render(<AudiencePanel experiment={experiment} segments={[]} />)
+  expect(container).toMatchSnapshot()
+})

--- a/components/AudiencePanel.tsx
+++ b/components/AudiencePanel.tsx
@@ -91,7 +91,7 @@ function ExposureEventsTable({ experiment }: { experiment: ExperimentFull }) {
           <span className={classes.eventName}>{ev.event}</span>
           {ev.props &&
             Object.entries(ev.props).map(([key, val]) => (
-              <span key={key + val} className={classes.entry}>
+              <span key={key} className={classes.entry}>
                 {key}: {val}
               </span>
             ))}

--- a/components/AudiencePanel.tsx
+++ b/components/AudiencePanel.tsx
@@ -52,6 +52,31 @@ const useStyles = makeStyles(() =>
   }),
 )
 
+function ExposureEventsTable({ experiment }: { experiment: ExperimentFull }) {
+  return (
+    <>
+      {experiment.exposureEvents?.map((ev) => {
+        return (
+          <LabelValueTable
+            key={ev.event}
+            data={[
+              {
+                label: ev.event,
+                value: Object.entries(ev.props ?? {}).map((entry) => (
+                  <LabelValueTable
+                    key={ev.event + entry[0] + entry[1]}
+                    data={[{ label: entry[0], value: <>{entry[1]}</> }]}
+                  />
+                )),
+              },
+            ]}
+          />
+        )
+      })}
+    </>
+  )
+}
+
 /**
  * Renders the audience information of an experiment in a panel component.
  *
@@ -90,6 +115,10 @@ function AudiencePanel({ experiment, segments }: { experiment: ExperimentFull; s
           />
         </>
       ),
+    },
+    {
+      label: 'Exposure Events',
+      value: <ExposureEventsTable experiment={experiment} />,
     },
   ]
   return (

--- a/components/AudiencePanel.tsx
+++ b/components/AudiencePanel.tsx
@@ -63,10 +63,6 @@ const eventStyles = makeStyles(() =>
     eventName: {
       fontFamily: theme.custom.fonts.monospace,
     },
-    propsList: {
-      margin: 0,
-      paddingInlineStart: 0,
-    },
     eventList: {
       '& p:not(:first-child)': {
         paddingTop: theme.spacing(2),
@@ -83,22 +79,22 @@ const eventStyles = makeStyles(() =>
 
 function ExposureEventsTable({ experiment }: { experiment: ExperimentFull }) {
   const classes = eventStyles()
+  const exposureEvents =
+    !Array.isArray(experiment.exposureEvents) || experiment.exposureEvents.length === 0
+      ? null
+      : experiment.exposureEvents
 
   return (
     <div className={classes.eventList}>
-      {experiment.exposureEvents?.map((ev) => (
+      {exposureEvents?.map((ev) => (
         <Typography key={ev.event}>
           <span className={classes.eventName}>{ev.event}</span>
-          {ev.props && (
-            <ul className={classes.propsList}>
-              {' '}
-              {Object.entries(ev.props).map(([key, val]) => (
-                <li key={key + val} className={classes.entry}>
-                  {key}: {val}
-                </li>
-              ))}
-            </ul>
-          )}
+          {ev.props &&
+            Object.entries(ev.props).map(([key, val]) => (
+              <span key={key + val} className={classes.entry}>
+                {key}: {val}
+              </span>
+            ))}
         </Typography>
       )) ?? <Typography>No exposure events defined</Typography>}
     </div>

--- a/components/AudiencePanel.tsx
+++ b/components/AudiencePanel.tsx
@@ -8,6 +8,7 @@ import SegmentsTable from '@/components/SegmentsTable'
 import VariationsTable from '@/components/VariationsTable'
 import { ExperimentFull, Segment, SegmentAssignment, SegmentType } from '@/lib/schemas'
 import * as Variations from '@/lib/variations'
+import theme from '@/styles/theme'
 
 /**
  * Resolves the segment ID of the segment assignment with the actual segment.
@@ -52,28 +53,55 @@ const useStyles = makeStyles(() =>
   }),
 )
 
+const eventStyles = makeStyles(() =>
+  createStyles({
+    entry: {
+      display: 'block',
+      fontFamily: theme.custom.fonts.monospace,
+      color: 'gray',
+    },
+    eventName: {
+      fontFamily: theme.custom.fonts.monospace,
+    },
+    propsList: {
+      margin: 0,
+      paddingInlineStart: 0,
+    },
+    eventList: {
+      '& p:not(:first-child)': {
+        paddingTop: theme.spacing(2),
+      },
+      '& p': {
+        paddingBottom: theme.spacing(2),
+      },
+      '& p:not(:last-child)': {
+        borderBottom: '1px solid rgb(224,224,224)',
+      },
+    },
+  }),
+)
+
 function ExposureEventsTable({ experiment }: { experiment: ExperimentFull }) {
+  const classes = eventStyles()
+
   return (
-    <>
-      {experiment.exposureEvents?.map((ev) => {
-        return (
-          <LabelValueTable
-            key={ev.event}
-            data={[
-              {
-                label: ev.event,
-                value: Object.entries(ev.props ?? {}).map((entry) => (
-                  <LabelValueTable
-                    key={ev.event + entry[0] + entry[1]}
-                    data={[{ label: entry[0], value: <>{entry[1]}</> }]}
-                  />
-                )),
-              },
-            ]}
-          />
-        )
-      })}
-    </>
+    <div className={classes.eventList}>
+      {experiment.exposureEvents?.map((ev) => (
+        <Typography key={ev.event}>
+          <span className={classes.eventName}>{ev.event}</span>
+          {ev.props && (
+            <ul className={classes.propsList}>
+              {' '}
+              {Object.entries(ev.props).map(([key, val]) => (
+                <li key={key + val} className={classes.entry}>
+                  {key}: {val}
+                </li>
+              ))}
+            </ul>
+          )}
+        </Typography>
+      )) ?? <Typography>No exposure events defined</Typography>}
+    </div>
   )
 }
 

--- a/components/AudiencePanel.tsx
+++ b/components/AudiencePanel.tsx
@@ -77,26 +77,26 @@ const eventStyles = makeStyles(() =>
   }),
 )
 
-function ExposureEventsTable({ experiment }: { experiment: ExperimentFull }) {
+function ExposureEventsTable({ experiment: { exposureEvents } }: { experiment: ExperimentFull }) {
   const classes = eventStyles()
-  const exposureEvents =
-    !Array.isArray(experiment.exposureEvents) || experiment.exposureEvents.length === 0
-      ? null
-      : experiment.exposureEvents
 
   return (
     <div className={classes.eventList}>
-      {exposureEvents?.map((ev) => (
-        <Typography key={ev.event}>
-          <span className={classes.eventName}>{ev.event}</span>
-          {ev.props &&
-            Object.entries(ev.props).map(([key, val]) => (
-              <span key={key} className={classes.entry}>
-                {key}: {val}
-              </span>
-            ))}
-        </Typography>
-      )) ?? <Typography>No exposure events defined</Typography>}
+      {exposureEvents && exposureEvents.length ? (
+        exposureEvents.map((ev) => (
+          <Typography key={ev.event}>
+            <span className={classes.eventName}>{ev.event}</span>
+            {ev.props &&
+              Object.entries(ev.props).map(([key, val]) => (
+                <span key={key} className={classes.entry}>
+                  {key}: {val}
+                </span>
+              ))}
+          </Typography>
+        ))
+      ) : (
+        <Typography>No exposure events defined</Typography>
+      )}
     </div>
   )
 }

--- a/components/GeneralPanel.test.tsx
+++ b/components/GeneralPanel.test.tsx
@@ -120,13 +120,37 @@ test('renders as expected', () => {
                 role="cell"
                 scope="row"
               >
-                Dates
+                Status
               </th>
               <td
                 class="MuiTableCell-root MuiTableCell-body"
               >
                 <span
                   class="makeStyles-root-5"
+                >
+                  <span
+                    class="makeStyles-statusDot-10 makeStyles-staging-8"
+                  />
+                   
+                  staging
+                </span>
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <th
+                class="MuiTableCell-root MuiTableCell-head"
+                role="cell"
+                scope="row"
+              >
+                Dates
+              </th>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <span
+                  class="makeStyles-root-11"
                   title="20/09/2020, 20:00:00"
                 >
                   2020-09-21
@@ -137,7 +161,7 @@ test('renders as expected', () => {
                   to
                 </span>
                 <span
-                  class="makeStyles-root-5"
+                  class="makeStyles-root-11"
                   title="20/11/2020, 20:00:00"
                 >
                   2020-11-21

--- a/components/GeneralPanel.tsx
+++ b/components/GeneralPanel.tsx
@@ -21,6 +21,7 @@ import * as yup from 'yup'
 
 import ExperimentsApi from '@/api/ExperimentsApi'
 import DatetimeText from '@/components/DatetimeText'
+import ExperimentStatus from '@/components/ExperimentStatus'
 import LabelValueTable from '@/components/LabelValueTable'
 import { ExperimentFull, experimentFullSchema, Status, yupPick } from '@/lib/schemas'
 
@@ -74,6 +75,10 @@ function GeneralPanel({
           {experiment.p2Url}
         </a>
       ),
+    },
+    {
+      label: 'Status',
+      value: <ExperimentStatus status={experiment.status} />,
     },
     {
       label: 'Dates',

--- a/components/__snapshots__/AudiencePanel.test.tsx.snap
+++ b/components/__snapshots__/AudiencePanel.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders as expected with all segments resolvable 1`] = `
+exports[`Empty array shows no exposure events 1`] = `
 <div>
   <div
     class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
@@ -9,7 +9,7 @@ exports[`renders as expected with all segments resolvable 1`] = `
       class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
     >
       <h3
-        class="MuiTypography-root makeStyles-title-17 MuiTypography-h3 MuiTypography-colorTextPrimary"
+        class="MuiTypography-root makeStyles-title-22 MuiTypography-h3 MuiTypography-colorTextPrimary"
       >
         Audience
       </h3>
@@ -101,276 +101,7 @@ exports[`renders as expected with all segments resolvable 1`] = `
                   >
                     control
                     <span
-                      class="makeStyles-default-18 makeStyles-root-19"
-                    >
-                      Default
-                    </span>
-                  </td>
-                  <td
-                    class="MuiTableCell-root MuiTableCell-body"
-                  >
-                    60
-                    %
-                  </td>
-                </tr>
-                <tr
-                  class="MuiTableRow-root"
-                >
-                  <td
-                    class="MuiTableCell-root MuiTableCell-body"
-                  >
-                    test
-                  </td>
-                  <td
-                    class="MuiTableCell-root MuiTableCell-body"
-                  >
-                    40
-                    %
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </td>
-        </tr>
-        <tr
-          class="MuiTableRow-root"
-        >
-          <th
-            class="MuiTableCell-root MuiTableCell-head"
-            role="cell"
-            scope="row"
-          >
-            Segments
-          </th>
-          <td
-            class="MuiTableCell-root MuiTableCell-body"
-          >
-            <table
-              class="MuiTable-root"
-            >
-              <thead
-                class="MuiTableHead-root"
-              >
-                <tr
-                  class="MuiTableRow-root MuiTableRow-head"
-                >
-                  <th
-                    class="MuiTableCell-root MuiTableCell-head"
-                    role="columnheader"
-                    scope="col"
-                  >
-                    Locales
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                class="MuiTableBody-root"
-              >
-                <tr
-                  class="MuiTableRow-root"
-                >
-                  <td
-                    class="MuiTableCell-root MuiTableCell-body"
-                  >
-                    segment_1
-                  </td>
-                </tr>
-                <tr
-                  class="MuiTableRow-root"
-                >
-                  <td
-                    class="MuiTableCell-root MuiTableCell-body"
-                  >
-                    segment_3
-                    <span
-                      class="makeStyles-excluded-20 makeStyles-root-19"
-                    >
-                      Excluded
-                    </span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <table
-              class="MuiTable-root"
-            >
-              <thead
-                class="MuiTableHead-root"
-              >
-                <tr
-                  class="MuiTableRow-root MuiTableRow-head"
-                >
-                  <th
-                    class="MuiTableCell-root MuiTableCell-head"
-                    role="columnheader"
-                    scope="col"
-                  >
-                    Countries
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                class="MuiTableBody-root"
-              >
-                <tr
-                  class="MuiTableRow-root"
-                >
-                  <td
-                    class="MuiTableCell-root MuiTableCell-body"
-                  >
-                    segment_2
-                    <span
-                      class="makeStyles-excluded-20 makeStyles-root-19"
-                    >
-                      Excluded
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  class="MuiTableRow-root"
-                >
-                  <td
-                    class="MuiTableCell-root MuiTableCell-body"
-                  >
-                    segment_4
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </td>
-        </tr>
-        <tr
-          class="MuiTableRow-root"
-        >
-          <th
-            class="MuiTableCell-root MuiTableCell-head"
-            role="cell"
-            scope="row"
-          >
-            Exposure Events
-          </th>
-          <td
-            class="MuiTableCell-root MuiTableCell-body"
-          >
-            <div
-              class="makeStyles-eventList-24"
-            >
-              <p
-                class="MuiTypography-root MuiTypography-body1"
-              >
-                No exposure events defined
-              </p>
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</div>
-`;
-
-exports[`renders as expected with existing users allowed 1`] = `
-<div>
-  <div
-    class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
-  >
-    <div
-      class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
-    >
-      <h3
-        class="MuiTypography-root makeStyles-title-9 MuiTypography-h3 MuiTypography-colorTextPrimary"
-      >
-        Audience
-      </h3>
-    </div>
-    <table
-      class="MuiTable-root"
-    >
-      <tbody
-        class="MuiTableBody-root"
-      >
-        <tr
-          class="MuiTableRow-root"
-        >
-          <th
-            class="MuiTableCell-root MuiTableCell-head"
-            role="cell"
-            scope="row"
-          >
-            Platform
-          </th>
-          <td
-            class="MuiTableCell-root MuiTableCell-body"
-          >
-            calypso
-          </td>
-        </tr>
-        <tr
-          class="MuiTableRow-root"
-        >
-          <th
-            class="MuiTableCell-root MuiTableCell-head"
-            role="cell"
-            scope="row"
-          >
-            User Type
-          </th>
-          <td
-            class="MuiTableCell-root MuiTableCell-body"
-          >
-            All users (new + existing)
-          </td>
-        </tr>
-        <tr
-          class="MuiTableRow-root"
-        >
-          <th
-            class="MuiTableCell-root MuiTableCell-head"
-            role="cell"
-            scope="row"
-          >
-            Variations
-          </th>
-          <td
-            class="MuiTableCell-root MuiTableCell-body"
-          >
-            <table
-              class="MuiTable-root"
-            >
-              <thead
-                class="MuiTableHead-root"
-              >
-                <tr
-                  class="MuiTableRow-root MuiTableRow-head"
-                >
-                  <th
-                    class="MuiTableCell-root MuiTableCell-head"
-                    role="columnheader"
-                    scope="col"
-                  >
-                    Name
-                  </th>
-                  <th
-                    class="MuiTableCell-root MuiTableCell-head"
-                    role="columnheader"
-                    scope="col"
-                  >
-                    Percent
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                class="MuiTableBody-root"
-              >
-                <tr
-                  class="MuiTableRow-root"
-                >
-                  <td
-                    class="MuiTableCell-root MuiTableCell-body"
-                  >
-                    control
-                    <span
-                      class="makeStyles-default-10 makeStyles-root-11"
+                      class="makeStyles-default-29 makeStyles-root-30"
                     >
                       Default
                     </span>
@@ -498,7 +229,1022 @@ exports[`renders as expected with existing users allowed 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <div
-              class="makeStyles-eventList-16"
+              class="makeStyles-eventList-34"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1"
+              >
+                No exposure events defined
+              </p>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Shows exposure events 1`] = `
+<div>
+  <div
+    class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
+  >
+    <div
+      class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
+    >
+      <h3
+        class="MuiTypography-root makeStyles-title-22 MuiTypography-h3 MuiTypography-colorTextPrimary"
+      >
+        Audience
+      </h3>
+    </div>
+    <table
+      class="MuiTable-root"
+    >
+      <tbody
+        class="MuiTableBody-root"
+      >
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Platform
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            calypso
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            User Type
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            New users only
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Variations
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <table
+              class="MuiTable-root"
+            >
+              <thead
+                class="MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Name
+                  </th>
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Percent
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root"
+              >
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    control
+                    <span
+                      class="makeStyles-default-23 makeStyles-root-24"
+                    >
+                      Default
+                    </span>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    60
+                    %
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    test
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    40
+                    %
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Segments
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <table
+              class="MuiTable-root"
+            >
+              <thead
+                class="MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Locales
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root"
+              >
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    All 
+                    locales
+                     included
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <table
+              class="MuiTable-root"
+            >
+              <thead
+                class="MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Countries
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root"
+              >
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    All 
+                    countries
+                     included
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Exposure Events
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <div
+              class="makeStyles-eventList-28"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1"
+              >
+                <span
+                  class="makeStyles-eventName-27"
+                >
+                  test
+                </span>
+                <span
+                  class="makeStyles-entry-26"
+                >
+                  prop1
+                  : 
+                  value1
+                </span>
+              </p>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`null shows no exposure events 1`] = `
+<div>
+  <div
+    class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
+  >
+    <div
+      class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
+    >
+      <h3
+        class="MuiTypography-root makeStyles-title-22 MuiTypography-h3 MuiTypography-colorTextPrimary"
+      >
+        Audience
+      </h3>
+    </div>
+    <table
+      class="MuiTable-root"
+    >
+      <tbody
+        class="MuiTableBody-root"
+      >
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Platform
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            calypso
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            User Type
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            New users only
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Variations
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <table
+              class="MuiTable-root"
+            >
+              <thead
+                class="MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Name
+                  </th>
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Percent
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root"
+              >
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    control
+                    <span
+                      class="makeStyles-default-35 makeStyles-root-36"
+                    >
+                      Default
+                    </span>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    60
+                    %
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    test
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    40
+                    %
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Segments
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <table
+              class="MuiTable-root"
+            >
+              <thead
+                class="MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Locales
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root"
+              >
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    All 
+                    locales
+                     included
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <table
+              class="MuiTable-root"
+            >
+              <thead
+                class="MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Countries
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root"
+              >
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    All 
+                    countries
+                     included
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Exposure Events
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <div
+              class="makeStyles-eventList-40"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1"
+              >
+                No exposure events defined
+              </p>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`renders as expected with all segments resolvable 1`] = `
+<div>
+  <div
+    class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
+  >
+    <div
+      class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
+    >
+      <h3
+        class="MuiTypography-root makeStyles-title-15 MuiTypography-h3 MuiTypography-colorTextPrimary"
+      >
+        Audience
+      </h3>
+    </div>
+    <table
+      class="MuiTable-root"
+    >
+      <tbody
+        class="MuiTableBody-root"
+      >
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Platform
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            calypso
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            User Type
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            New users only
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Variations
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <table
+              class="MuiTable-root"
+            >
+              <thead
+                class="MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Name
+                  </th>
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Percent
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root"
+              >
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    control
+                    <span
+                      class="makeStyles-default-16 makeStyles-root-17"
+                    >
+                      Default
+                    </span>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    60
+                    %
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    test
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    40
+                    %
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Segments
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <table
+              class="MuiTable-root"
+            >
+              <thead
+                class="MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Locales
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root"
+              >
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    segment_1
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    segment_3
+                    <span
+                      class="makeStyles-excluded-18 makeStyles-root-17"
+                    >
+                      Excluded
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <table
+              class="MuiTable-root"
+            >
+              <thead
+                class="MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Countries
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root"
+              >
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    segment_2
+                    <span
+                      class="makeStyles-excluded-18 makeStyles-root-17"
+                    >
+                      Excluded
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    segment_4
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Exposure Events
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <div
+              class="makeStyles-eventList-21"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1"
+              >
+                No exposure events defined
+              </p>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`renders as expected with existing users allowed 1`] = `
+<div>
+  <div
+    class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
+  >
+    <div
+      class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
+    >
+      <h3
+        class="MuiTypography-root makeStyles-title-8 MuiTypography-h3 MuiTypography-colorTextPrimary"
+      >
+        Audience
+      </h3>
+    </div>
+    <table
+      class="MuiTable-root"
+    >
+      <tbody
+        class="MuiTableBody-root"
+      >
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Platform
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            calypso
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            User Type
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            All users (new + existing)
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Variations
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <table
+              class="MuiTable-root"
+            >
+              <thead
+                class="MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Name
+                  </th>
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Percent
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root"
+              >
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    control
+                    <span
+                      class="makeStyles-default-9 makeStyles-root-10"
+                    >
+                      Default
+                    </span>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    60
+                    %
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    test
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    40
+                    %
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Segments
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <table
+              class="MuiTable-root"
+            >
+              <thead
+                class="MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Locales
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root"
+              >
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    All 
+                    locales
+                     included
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <table
+              class="MuiTable-root"
+            >
+              <thead
+                class="MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Countries
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root"
+              >
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    All 
+                    countries
+                     included
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Exposure Events
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <div
+              class="makeStyles-eventList-14"
             >
               <p
                 class="MuiTypography-root MuiTypography-body1"
@@ -743,7 +1489,7 @@ exports[`renders as expected with no segment assignments 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <div
-              class="makeStyles-eventList-8"
+              class="makeStyles-eventList-7"
             >
               <p
                 class="MuiTypography-root MuiTypography-body1"

--- a/components/__snapshots__/AudiencePanel.test.tsx.snap
+++ b/components/__snapshots__/AudiencePanel.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`renders as expected with all segments resolvable 1`] = `
       class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
     >
       <h3
-        class="MuiTypography-root makeStyles-title-9 MuiTypography-h3 MuiTypography-colorTextPrimary"
+        class="MuiTypography-root makeStyles-title-17 MuiTypography-h3 MuiTypography-colorTextPrimary"
       >
         Audience
       </h3>
@@ -101,7 +101,7 @@ exports[`renders as expected with all segments resolvable 1`] = `
                   >
                     control
                     <span
-                      class="makeStyles-default-10 makeStyles-root-11"
+                      class="makeStyles-default-18 makeStyles-root-19"
                     >
                       Default
                     </span>
@@ -183,7 +183,7 @@ exports[`renders as expected with all segments resolvable 1`] = `
                   >
                     segment_3
                     <span
-                      class="makeStyles-excluded-12 makeStyles-root-11"
+                      class="makeStyles-excluded-20 makeStyles-root-19"
                     >
                       Excluded
                     </span>
@@ -220,7 +220,7 @@ exports[`renders as expected with all segments resolvable 1`] = `
                   >
                     segment_2
                     <span
-                      class="makeStyles-excluded-12 makeStyles-root-11"
+                      class="makeStyles-excluded-20 makeStyles-root-19"
                     >
                       Excluded
                     </span>
@@ -251,7 +251,17 @@ exports[`renders as expected with all segments resolvable 1`] = `
           </th>
           <td
             class="MuiTableCell-root MuiTableCell-body"
-          />
+          >
+            <div
+              class="makeStyles-eventList-24"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1"
+              >
+                No exposure events defined
+              </p>
+            </div>
+          </td>
         </tr>
       </tbody>
     </table>
@@ -268,7 +278,7 @@ exports[`renders as expected with existing users allowed 1`] = `
       class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
     >
       <h3
-        class="MuiTypography-root makeStyles-title-5 MuiTypography-h3 MuiTypography-colorTextPrimary"
+        class="MuiTypography-root makeStyles-title-9 MuiTypography-h3 MuiTypography-colorTextPrimary"
       >
         Audience
       </h3>
@@ -360,7 +370,7 @@ exports[`renders as expected with existing users allowed 1`] = `
                   >
                     control
                     <span
-                      class="makeStyles-default-6 makeStyles-root-7"
+                      class="makeStyles-default-10 makeStyles-root-11"
                     >
                       Default
                     </span>
@@ -486,7 +496,17 @@ exports[`renders as expected with existing users allowed 1`] = `
           </th>
           <td
             class="MuiTableCell-root MuiTableCell-body"
-          />
+          >
+            <div
+              class="makeStyles-eventList-16"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1"
+              >
+                No exposure events defined
+              </p>
+            </div>
+          </td>
         </tr>
       </tbody>
     </table>
@@ -721,7 +741,17 @@ exports[`renders as expected with no segment assignments 1`] = `
           </th>
           <td
             class="MuiTableCell-root MuiTableCell-body"
-          />
+          >
+            <div
+              class="makeStyles-eventList-8"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1"
+              >
+                No exposure events defined
+              </p>
+            </div>
+          </td>
         </tr>
       </tbody>
     </table>

--- a/components/__snapshots__/AudiencePanel.test.tsx.snap
+++ b/components/__snapshots__/AudiencePanel.test.tsx.snap
@@ -239,6 +239,20 @@ exports[`renders as expected with all segments resolvable 1`] = `
             </table>
           </td>
         </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Exposure Events
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          />
+        </tr>
       </tbody>
     </table>
   </div>
@@ -460,6 +474,20 @@ exports[`renders as expected with existing users allowed 1`] = `
             </table>
           </td>
         </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Exposure Events
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          />
+        </tr>
       </tbody>
     </table>
   </div>
@@ -680,6 +708,20 @@ exports[`renders as expected with no segment assignments 1`] = `
               </tbody>
             </table>
           </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Exposure Events
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          />
         </tr>
       </tbody>
     </table>

--- a/components/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/components/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -597,7 +597,7 @@ exports[`renders as expected at large width 1`] = `
                 class="MuiTableCell-root MuiTableCell-body"
               >
                 <div
-                  class="makeStyles-eventList-21"
+                  class="makeStyles-eventList-20"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -636,7 +636,7 @@ exports[`renders as expected at small width 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-23 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-22 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 General
               </h3>
@@ -723,10 +723,10 @@ exports[`renders as expected at small width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-26"
+                      class="makeStyles-root-25"
                     >
                       <span
-                        class="makeStyles-statusDot-31 makeStyles-staging-29"
+                        class="makeStyles-statusDot-30 makeStyles-staging-28"
                       />
                        
                       staging
@@ -747,18 +747,18 @@ exports[`renders as expected at small width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-32"
+                      class="makeStyles-root-31"
                       title="20/09/2020, 20:00:00"
                     >
                       2020-09-21
                     </span>
                     <span
-                      class="makeStyles-to-22"
+                      class="makeStyles-to-21"
                     >
                       to
                     </span>
                     <span
-                      class="makeStyles-root-32"
+                      class="makeStyles-root-31"
                       title="20/11/2020, 20:00:00"
                     >
                       2020-11-21
@@ -795,7 +795,7 @@ exports[`renders as expected at small width 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-36 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-35 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Audience
               </h3>
@@ -887,7 +887,7 @@ exports[`renders as expected at small width 1`] = `
                           >
                             control
                             <span
-                              class="makeStyles-default-37 makeStyles-root-35"
+                              class="makeStyles-default-36 makeStyles-root-34"
                             >
                               Default
                             </span>
@@ -992,7 +992,7 @@ exports[`renders as expected at small width 1`] = `
                           >
                             segment_2
                             <span
-                              class="makeStyles-excluded-38 makeStyles-root-35"
+                              class="makeStyles-excluded-37 makeStyles-root-34"
                             >
                               Excluded
                             </span>
@@ -1016,7 +1016,7 @@ exports[`renders as expected at small width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <div
-                      class="makeStyles-eventList-42"
+                      class="makeStyles-eventList-40"
                     >
                       <p
                         class="MuiTypography-root MuiTypography-body1"
@@ -1040,7 +1040,7 @@ exports[`renders as expected at small width 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-34 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-33 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Metrics
               </h3>
@@ -1119,7 +1119,7 @@ exports[`renders as expected at small width 1`] = `
                   >
                     metric_1
                     <span
-                      class="makeStyles-primary-33 makeStyles-root-35"
+                      class="makeStyles-primary-32 makeStyles-root-34"
                     >
                       Primary
                     </span>
@@ -1251,7 +1251,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-44 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-42 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 General
               </h3>
@@ -1338,10 +1338,10 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-47"
+                      class="makeStyles-root-45"
                     >
                       <span
-                        class="makeStyles-statusDot-52 makeStyles-disabled-51"
+                        class="makeStyles-statusDot-50 makeStyles-disabled-49"
                       />
                        
                       disabled
@@ -1362,18 +1362,18 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-53"
+                      class="makeStyles-root-51"
                       title="20/09/2020, 20:00:00"
                     >
                       2020-09-21
                     </span>
                     <span
-                      class="makeStyles-to-43"
+                      class="makeStyles-to-41"
                     >
                       to
                     </span>
                     <span
-                      class="makeStyles-root-53"
+                      class="makeStyles-root-51"
                       title="20/11/2020, 20:00:00"
                     >
                       2020-11-21
@@ -1410,7 +1410,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-59 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-57 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Audience
               </h3>
@@ -1502,7 +1502,7 @@ exports[`renders as expected with conclusion data 1`] = `
                           >
                             control
                             <span
-                              class="makeStyles-default-60 makeStyles-root-56"
+                              class="makeStyles-default-58 makeStyles-root-54"
                             >
                               Default
                             </span>
@@ -1607,7 +1607,7 @@ exports[`renders as expected with conclusion data 1`] = `
                           >
                             segment_2
                             <span
-                              class="makeStyles-excluded-61 makeStyles-root-56"
+                              class="makeStyles-excluded-59 makeStyles-root-54"
                             >
                               Excluded
                             </span>
@@ -1631,7 +1631,7 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <div
-                      class="makeStyles-eventList-65"
+                      class="makeStyles-eventList-62"
                     >
                       <p
                         class="MuiTypography-root MuiTypography-body1"
@@ -1655,7 +1655,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-55 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-53 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Metrics
               </h3>
@@ -1734,7 +1734,7 @@ exports[`renders as expected with conclusion data 1`] = `
                   >
                     metric_1
                     <span
-                      class="makeStyles-primary-54 makeStyles-root-56"
+                      class="makeStyles-primary-52 makeStyles-root-54"
                     >
                       Primary
                     </span>
@@ -1849,7 +1849,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-57 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-55 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Conclusions
               </h3>
@@ -1969,7 +1969,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-67 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-64 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 General
               </h3>
@@ -2056,10 +2056,10 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-70"
+                      class="makeStyles-root-67"
                     >
                       <span
-                        class="makeStyles-statusDot-75 makeStyles-staging-73"
+                        class="makeStyles-statusDot-72 makeStyles-staging-70"
                       />
                        
                       staging
@@ -2080,18 +2080,18 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-76"
+                      class="makeStyles-root-73"
                       title="20/09/2020, 20:00:00"
                     >
                       2020-09-21
                     </span>
                     <span
-                      class="makeStyles-to-66"
+                      class="makeStyles-to-63"
                     >
                       to
                     </span>
                     <span
-                      class="makeStyles-root-76"
+                      class="makeStyles-root-73"
                       title="20/11/2020, 20:00:00"
                     >
                       2020-11-21
@@ -2128,7 +2128,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-80 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-77 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Audience
               </h3>
@@ -2220,7 +2220,7 @@ exports[`renders as expected without conclusion data 1`] = `
                           >
                             control
                             <span
-                              class="makeStyles-default-81 makeStyles-root-79"
+                              class="makeStyles-default-78 makeStyles-root-76"
                             >
                               Default
                             </span>
@@ -2325,7 +2325,7 @@ exports[`renders as expected without conclusion data 1`] = `
                           >
                             segment_2
                             <span
-                              class="makeStyles-excluded-82 makeStyles-root-79"
+                              class="makeStyles-excluded-79 makeStyles-root-76"
                             >
                               Excluded
                             </span>
@@ -2349,7 +2349,7 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <div
-                      class="makeStyles-eventList-86"
+                      class="makeStyles-eventList-82"
                     >
                       <p
                         class="MuiTypography-root MuiTypography-body1"
@@ -2373,7 +2373,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-78 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-75 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Metrics
               </h3>
@@ -2452,7 +2452,7 @@ exports[`renders as expected without conclusion data 1`] = `
                   >
                     metric_1
                     <span
-                      class="makeStyles-primary-77 makeStyles-root-79"
+                      class="makeStyles-primary-74 makeStyles-root-76"
                     >
                       Primary
                     </span>

--- a/components/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/components/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -102,13 +102,37 @@ exports[`renders as expected at large width 1`] = `
                     role="cell"
                     scope="row"
                   >
-                    Dates
+                    Status
                   </th>
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
                       class="makeStyles-root-5"
+                    >
+                      <span
+                        class="makeStyles-statusDot-10 makeStyles-staging-8"
+                      />
+                       
+                      staging
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="cell"
+                    scope="row"
+                  >
+                    Dates
+                  </th>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    <span
+                      class="makeStyles-root-11"
                       title="20/09/2020, 20:00:00"
                     >
                       2020-09-21
@@ -119,7 +143,7 @@ exports[`renders as expected at large width 1`] = `
                       to
                     </span>
                     <span
-                      class="makeStyles-root-5"
+                      class="makeStyles-root-11"
                       title="20/11/2020, 20:00:00"
                     >
                       2020-11-21
@@ -156,7 +180,7 @@ exports[`renders as expected at large width 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-7 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-13 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Metrics
               </h3>
@@ -235,7 +259,7 @@ exports[`renders as expected at large width 1`] = `
                   >
                     metric_1
                     <span
-                      class="makeStyles-primary-6 makeStyles-root-8"
+                      class="makeStyles-primary-12 makeStyles-root-14"
                     >
                       Primary
                     </span>
@@ -352,7 +376,7 @@ exports[`renders as expected at large width 1`] = `
           class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
         >
           <h3
-            class="MuiTypography-root makeStyles-title-9 MuiTypography-h3 MuiTypography-colorTextPrimary"
+            class="MuiTypography-root makeStyles-title-15 MuiTypography-h3 MuiTypography-colorTextPrimary"
           >
             Audience
           </h3>
@@ -444,7 +468,7 @@ exports[`renders as expected at large width 1`] = `
                       >
                         control
                         <span
-                          class="makeStyles-default-10 makeStyles-root-8"
+                          class="makeStyles-default-16 makeStyles-root-14"
                         >
                           Default
                         </span>
@@ -549,7 +573,7 @@ exports[`renders as expected at large width 1`] = `
                       >
                         segment_2
                         <span
-                          class="makeStyles-excluded-11 makeStyles-root-8"
+                          class="makeStyles-excluded-17 makeStyles-root-14"
                         >
                           Excluded
                         </span>
@@ -558,6 +582,20 @@ exports[`renders as expected at large width 1`] = `
                   </tbody>
                 </table>
               </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <th
+                class="MuiTableCell-root MuiTableCell-head"
+                role="cell"
+                scope="row"
+              >
+                Exposure Events
+              </th>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              />
             </tr>
           </tbody>
         </table>
@@ -588,7 +626,7 @@ exports[`renders as expected at small width 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-13 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-19 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 General
               </h3>
@@ -669,24 +707,48 @@ exports[`renders as expected at small width 1`] = `
                     role="cell"
                     scope="row"
                   >
+                    Status
+                  </th>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    <span
+                      class="makeStyles-root-22"
+                    >
+                      <span
+                        class="makeStyles-statusDot-27 makeStyles-staging-25"
+                      />
+                       
+                      staging
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="cell"
+                    scope="row"
+                  >
                     Dates
                   </th>
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-16"
+                      class="makeStyles-root-28"
                       title="20/09/2020, 20:00:00"
                     >
                       2020-09-21
                     </span>
                     <span
-                      class="makeStyles-to-12"
+                      class="makeStyles-to-18"
                     >
                       to
                     </span>
                     <span
-                      class="makeStyles-root-16"
+                      class="makeStyles-root-28"
                       title="20/11/2020, 20:00:00"
                     >
                       2020-11-21
@@ -723,7 +785,7 @@ exports[`renders as expected at small width 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-20 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-32 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Audience
               </h3>
@@ -815,7 +877,7 @@ exports[`renders as expected at small width 1`] = `
                           >
                             control
                             <span
-                              class="makeStyles-default-21 makeStyles-root-19"
+                              class="makeStyles-default-33 makeStyles-root-31"
                             >
                               Default
                             </span>
@@ -920,7 +982,7 @@ exports[`renders as expected at small width 1`] = `
                           >
                             segment_2
                             <span
-                              class="makeStyles-excluded-22 makeStyles-root-19"
+                              class="makeStyles-excluded-34 makeStyles-root-31"
                             >
                               Excluded
                             </span>
@@ -929,6 +991,20 @@ exports[`renders as expected at small width 1`] = `
                       </tbody>
                     </table>
                   </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="cell"
+                    scope="row"
+                  >
+                    Exposure Events
+                  </th>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  />
                 </tr>
               </tbody>
             </table>
@@ -944,7 +1020,7 @@ exports[`renders as expected at small width 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-18 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-30 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Metrics
               </h3>
@@ -1023,7 +1099,7 @@ exports[`renders as expected at small width 1`] = `
                   >
                     metric_1
                     <span
-                      class="makeStyles-primary-17 makeStyles-root-19"
+                      class="makeStyles-primary-29 makeStyles-root-31"
                     >
                       Primary
                     </span>
@@ -1155,7 +1231,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-24 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-36 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 General
               </h3>
@@ -1236,24 +1312,48 @@ exports[`renders as expected with conclusion data 1`] = `
                     role="cell"
                     scope="row"
                   >
+                    Status
+                  </th>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    <span
+                      class="makeStyles-root-39"
+                    >
+                      <span
+                        class="makeStyles-statusDot-44 makeStyles-disabled-43"
+                      />
+                       
+                      disabled
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="cell"
+                    scope="row"
+                  >
                     Dates
                   </th>
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-27"
+                      class="makeStyles-root-45"
                       title="20/09/2020, 20:00:00"
                     >
                       2020-09-21
                     </span>
                     <span
-                      class="makeStyles-to-23"
+                      class="makeStyles-to-35"
                     >
                       to
                     </span>
                     <span
-                      class="makeStyles-root-27"
+                      class="makeStyles-root-45"
                       title="20/11/2020, 20:00:00"
                     >
                       2020-11-21
@@ -1290,7 +1390,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-33 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-51 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Audience
               </h3>
@@ -1382,7 +1482,7 @@ exports[`renders as expected with conclusion data 1`] = `
                           >
                             control
                             <span
-                              class="makeStyles-default-34 makeStyles-root-30"
+                              class="makeStyles-default-52 makeStyles-root-48"
                             >
                               Default
                             </span>
@@ -1487,7 +1587,7 @@ exports[`renders as expected with conclusion data 1`] = `
                           >
                             segment_2
                             <span
-                              class="makeStyles-excluded-35 makeStyles-root-30"
+                              class="makeStyles-excluded-53 makeStyles-root-48"
                             >
                               Excluded
                             </span>
@@ -1496,6 +1596,20 @@ exports[`renders as expected with conclusion data 1`] = `
                       </tbody>
                     </table>
                   </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="cell"
+                    scope="row"
+                  >
+                    Exposure Events
+                  </th>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  />
                 </tr>
               </tbody>
             </table>
@@ -1511,7 +1625,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-29 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-47 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Metrics
               </h3>
@@ -1590,7 +1704,7 @@ exports[`renders as expected with conclusion data 1`] = `
                   >
                     metric_1
                     <span
-                      class="makeStyles-primary-28 makeStyles-root-30"
+                      class="makeStyles-primary-46 makeStyles-root-48"
                     >
                       Primary
                     </span>
@@ -1705,7 +1819,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-31 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-49 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Conclusions
               </h3>
@@ -1825,7 +1939,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-37 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-55 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 General
               </h3>
@@ -1906,24 +2020,48 @@ exports[`renders as expected without conclusion data 1`] = `
                     role="cell"
                     scope="row"
                   >
+                    Status
+                  </th>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    <span
+                      class="makeStyles-root-58"
+                    >
+                      <span
+                        class="makeStyles-statusDot-63 makeStyles-staging-61"
+                      />
+                       
+                      staging
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="cell"
+                    scope="row"
+                  >
                     Dates
                   </th>
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-40"
+                      class="makeStyles-root-64"
                       title="20/09/2020, 20:00:00"
                     >
                       2020-09-21
                     </span>
                     <span
-                      class="makeStyles-to-36"
+                      class="makeStyles-to-54"
                     >
                       to
                     </span>
                     <span
-                      class="makeStyles-root-40"
+                      class="makeStyles-root-64"
                       title="20/11/2020, 20:00:00"
                     >
                       2020-11-21
@@ -1960,7 +2098,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-44 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-68 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Audience
               </h3>
@@ -2052,7 +2190,7 @@ exports[`renders as expected without conclusion data 1`] = `
                           >
                             control
                             <span
-                              class="makeStyles-default-45 makeStyles-root-43"
+                              class="makeStyles-default-69 makeStyles-root-67"
                             >
                               Default
                             </span>
@@ -2157,7 +2295,7 @@ exports[`renders as expected without conclusion data 1`] = `
                           >
                             segment_2
                             <span
-                              class="makeStyles-excluded-46 makeStyles-root-43"
+                              class="makeStyles-excluded-70 makeStyles-root-67"
                             >
                               Excluded
                             </span>
@@ -2166,6 +2304,20 @@ exports[`renders as expected without conclusion data 1`] = `
                       </tbody>
                     </table>
                   </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="cell"
+                    scope="row"
+                  >
+                    Exposure Events
+                  </th>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  />
                 </tr>
               </tbody>
             </table>
@@ -2181,7 +2333,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-42 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-66 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Metrics
               </h3>
@@ -2260,7 +2412,7 @@ exports[`renders as expected without conclusion data 1`] = `
                   >
                     metric_1
                     <span
-                      class="makeStyles-primary-41 makeStyles-root-43"
+                      class="makeStyles-primary-65 makeStyles-root-67"
                     >
                       Primary
                     </span>

--- a/components/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/components/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -595,7 +595,17 @@ exports[`renders as expected at large width 1`] = `
               </th>
               <td
                 class="MuiTableCell-root MuiTableCell-body"
-              />
+              >
+                <div
+                  class="makeStyles-eventList-21"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1"
+                  >
+                    No exposure events defined
+                  </p>
+                </div>
+              </td>
             </tr>
           </tbody>
         </table>
@@ -626,7 +636,7 @@ exports[`renders as expected at small width 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-19 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-23 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 General
               </h3>
@@ -713,10 +723,10 @@ exports[`renders as expected at small width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-22"
+                      class="makeStyles-root-26"
                     >
                       <span
-                        class="makeStyles-statusDot-27 makeStyles-staging-25"
+                        class="makeStyles-statusDot-31 makeStyles-staging-29"
                       />
                        
                       staging
@@ -737,18 +747,18 @@ exports[`renders as expected at small width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-28"
+                      class="makeStyles-root-32"
                       title="20/09/2020, 20:00:00"
                     >
                       2020-09-21
                     </span>
                     <span
-                      class="makeStyles-to-18"
+                      class="makeStyles-to-22"
                     >
                       to
                     </span>
                     <span
-                      class="makeStyles-root-28"
+                      class="makeStyles-root-32"
                       title="20/11/2020, 20:00:00"
                     >
                       2020-11-21
@@ -785,7 +795,7 @@ exports[`renders as expected at small width 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-32 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-36 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Audience
               </h3>
@@ -877,7 +887,7 @@ exports[`renders as expected at small width 1`] = `
                           >
                             control
                             <span
-                              class="makeStyles-default-33 makeStyles-root-31"
+                              class="makeStyles-default-37 makeStyles-root-35"
                             >
                               Default
                             </span>
@@ -982,7 +992,7 @@ exports[`renders as expected at small width 1`] = `
                           >
                             segment_2
                             <span
-                              class="makeStyles-excluded-34 makeStyles-root-31"
+                              class="makeStyles-excluded-38 makeStyles-root-35"
                             >
                               Excluded
                             </span>
@@ -1004,7 +1014,17 @@ exports[`renders as expected at small width 1`] = `
                   </th>
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
-                  />
+                  >
+                    <div
+                      class="makeStyles-eventList-42"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1"
+                      >
+                        No exposure events defined
+                      </p>
+                    </div>
+                  </td>
                 </tr>
               </tbody>
             </table>
@@ -1020,7 +1040,7 @@ exports[`renders as expected at small width 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-30 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-34 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Metrics
               </h3>
@@ -1099,7 +1119,7 @@ exports[`renders as expected at small width 1`] = `
                   >
                     metric_1
                     <span
-                      class="makeStyles-primary-29 makeStyles-root-31"
+                      class="makeStyles-primary-33 makeStyles-root-35"
                     >
                       Primary
                     </span>
@@ -1231,7 +1251,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-36 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-44 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 General
               </h3>
@@ -1318,10 +1338,10 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-39"
+                      class="makeStyles-root-47"
                     >
                       <span
-                        class="makeStyles-statusDot-44 makeStyles-disabled-43"
+                        class="makeStyles-statusDot-52 makeStyles-disabled-51"
                       />
                        
                       disabled
@@ -1342,18 +1362,18 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-45"
+                      class="makeStyles-root-53"
                       title="20/09/2020, 20:00:00"
                     >
                       2020-09-21
                     </span>
                     <span
-                      class="makeStyles-to-35"
+                      class="makeStyles-to-43"
                     >
                       to
                     </span>
                     <span
-                      class="makeStyles-root-45"
+                      class="makeStyles-root-53"
                       title="20/11/2020, 20:00:00"
                     >
                       2020-11-21
@@ -1390,7 +1410,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-51 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-59 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Audience
               </h3>
@@ -1482,7 +1502,7 @@ exports[`renders as expected with conclusion data 1`] = `
                           >
                             control
                             <span
-                              class="makeStyles-default-52 makeStyles-root-48"
+                              class="makeStyles-default-60 makeStyles-root-56"
                             >
                               Default
                             </span>
@@ -1587,7 +1607,7 @@ exports[`renders as expected with conclusion data 1`] = `
                           >
                             segment_2
                             <span
-                              class="makeStyles-excluded-53 makeStyles-root-48"
+                              class="makeStyles-excluded-61 makeStyles-root-56"
                             >
                               Excluded
                             </span>
@@ -1609,7 +1629,17 @@ exports[`renders as expected with conclusion data 1`] = `
                   </th>
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
-                  />
+                  >
+                    <div
+                      class="makeStyles-eventList-65"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1"
+                      >
+                        No exposure events defined
+                      </p>
+                    </div>
+                  </td>
                 </tr>
               </tbody>
             </table>
@@ -1625,7 +1655,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-47 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-55 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Metrics
               </h3>
@@ -1704,7 +1734,7 @@ exports[`renders as expected with conclusion data 1`] = `
                   >
                     metric_1
                     <span
-                      class="makeStyles-primary-46 makeStyles-root-48"
+                      class="makeStyles-primary-54 makeStyles-root-56"
                     >
                       Primary
                     </span>
@@ -1819,7 +1849,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-49 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-57 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Conclusions
               </h3>
@@ -1939,7 +1969,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-55 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-67 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 General
               </h3>
@@ -2026,10 +2056,10 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-58"
+                      class="makeStyles-root-70"
                     >
                       <span
-                        class="makeStyles-statusDot-63 makeStyles-staging-61"
+                        class="makeStyles-statusDot-75 makeStyles-staging-73"
                       />
                        
                       staging
@@ -2050,18 +2080,18 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-64"
+                      class="makeStyles-root-76"
                       title="20/09/2020, 20:00:00"
                     >
                       2020-09-21
                     </span>
                     <span
-                      class="makeStyles-to-54"
+                      class="makeStyles-to-66"
                     >
                       to
                     </span>
                     <span
-                      class="makeStyles-root-64"
+                      class="makeStyles-root-76"
                       title="20/11/2020, 20:00:00"
                     >
                       2020-11-21
@@ -2098,7 +2128,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-68 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-80 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Audience
               </h3>
@@ -2190,7 +2220,7 @@ exports[`renders as expected without conclusion data 1`] = `
                           >
                             control
                             <span
-                              class="makeStyles-default-69 makeStyles-root-67"
+                              class="makeStyles-default-81 makeStyles-root-79"
                             >
                               Default
                             </span>
@@ -2295,7 +2325,7 @@ exports[`renders as expected without conclusion data 1`] = `
                           >
                             segment_2
                             <span
-                              class="makeStyles-excluded-70 makeStyles-root-67"
+                              class="makeStyles-excluded-82 makeStyles-root-79"
                             >
                               Excluded
                             </span>
@@ -2317,7 +2347,17 @@ exports[`renders as expected without conclusion data 1`] = `
                   </th>
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
-                  />
+                  >
+                    <div
+                      class="makeStyles-eventList-86"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1"
+                      >
+                        No exposure events defined
+                      </p>
+                    </div>
+                  </td>
                 </tr>
               </tbody>
             </table>
@@ -2333,7 +2373,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-66 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-78 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Metrics
               </h3>
@@ -2412,7 +2452,7 @@ exports[`renders as expected without conclusion data 1`] = `
                   >
                     metric_1
                     <span
-                      class="makeStyles-primary-65 makeStyles-root-67"
+                      class="makeStyles-primary-77 makeStyles-root-79"
                     >
                       Primary
                     </span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10508,7 +10508,10 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "icu4c-data": "^0.64.2"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -11285,6 +11288,12 @@
       "requires": {
         "postcss": "^7.0.14"
       }
+    },
+    "icu4c-data": {
+      "version": "0.64.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
+      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ==",
+      "dev": true
     },
     "ieee754": {
       "version": "1.1.13",


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
resolves #217 

This adds exposure events and the status to the experiment details pane. I chose to use several layers of `LabelValueTable` because this sort-of provides a "tree-like" structure which is the best way to visualize the data IMHO. I'm happy to use a different component and/or a different approach. I also chose to keep the `ExposureEventsTable` as a non-reusable component because 1) it can be easily refactored into one if we chose to and 2) it's incredibly simple such that I'm not sure we need to make it it's own file yet. 3) I'm not sure what the conventions are around here yet :)

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
- Manual testing with mock data (locally or on Vercel)
- Additional manual testing instructions (please specify):
