### PR TITLE
GeneralPanel Edit Modal Validation

### DIFF
--- a/__tests__/api/ExperimentsApi.test.ts
+++ b/__tests__/api/ExperimentsApi.test.ts
@@ -1,13 +1,15 @@
 import { format } from 'date-fns'
+import MockDate from 'mockdate'
 
 import ExperimentsApi from '@/api/ExperimentsApi'
 import { ExperimentFullNew, experimentFullNewOutboundSchema } from '@/lib/schemas'
 import { validationErrorDisplayer } from '@/test-helpers/test-utils'
 
+MockDate.set('2020-08-13')
+
 describe('ExperimentsApi.ts module', () => {
   describe('create', () => {
     it('should transform a new experiment into a valid outbound form', () => {
-      // We need to make some dates relative to today since mocking the schema to work with MockDate is a pain!
       const now = new Date()
       now.setDate(now.getDate() + 1)
       const nextWeek = new Date()
@@ -112,7 +114,6 @@ describe('ExperimentsApi.ts module', () => {
     })
 
     it('should create a new experiment', async () => {
-      // We need to make some dates relative to today since mocking the schema to work with MockDate is a pain!
       const now = new Date()
       now.setDate(now.getDate() + 1)
       const nextWeek = new Date()

--- a/components/GeneralPanel.tsx
+++ b/components/GeneralPanel.tsx
@@ -17,10 +17,11 @@ import { TextField } from 'formik-material-ui'
 import _ from 'lodash'
 import { useSnackbar } from 'notistack'
 import React, { useState } from 'react'
+import * as yup from 'yup'
 
 import DatetimeText from '@/components/DatetimeText'
 import LabelValueTable from '@/components/LabelValueTable'
-import { ExperimentFull, Status } from '@/lib/schemas'
+import { ExperimentFull, Status, experimentFullNewSchema, experimentFullSchema, yupPick, MAX_DISTANCE_BETWEEN_START_AND_END_DATE_IN_MONTHS } from '@/lib/schemas'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -81,10 +82,18 @@ function GeneralPanel({ experiment }: { experiment: ExperimentFull }) {
   // Edit Modal
   const { enqueueSnackbar } = useSnackbar()
   const [isEditing, setIsEditing] = useState<boolean>(false)
+  const props = ['description', 'ownerLogin', 'endDatetime']
   const generalEditInitialExperiment = {
-    ..._.pick(experiment, ['description', 'p2Url', 'ownerLogin', 'endDatetime']),
+    ..._.pick(experiment, props),
     endDatetime: dateFns.format(experiment.endDatetime, 'yyyy-MM-dd'),
+    // Needed for endDatetime validation
+    startDatetime: experiment.startDatetime,
   }
+  const generalEditValidationSchema = yupPick(experimentFullSchema, props).shape({
+    // We need to ensure the end date is in the future
+    endDatetime: (yup.reach(experimentFullSchema, 'endDatetime') as unknown as yup.MixedSchema)
+      .test('future-date', 'End date must be in the future.', dateFns.isFuture)
+  })
   const onEdit = () => setIsEditing(true)
   const onCancelEdit = () => {
     setIsEditing(false)
@@ -111,7 +120,11 @@ function GeneralPanel({ experiment }: { experiment: ExperimentFull }) {
       <LabelValueTable data={data} />
       <Dialog open={isEditing} fullWidth aria-labelledby='edit-experiment-general-form-dialog-title'>
         <DialogTitle id='edit-experiment-general-form-dialog-title'>Edit Experiment: General</DialogTitle>
-        <Formik initialValues={{ experiment: generalEditInitialExperiment }} onSubmit={onSubmitEdit}>
+        <Formik
+          initialValues={{ experiment: generalEditInitialExperiment }}
+          validationSchema={yup.object({ experiment: generalEditValidationSchema })}
+          onSubmit={onSubmitEdit}
+        >
           {(formikProps) => (
             <form onSubmit={formikProps.handleSubmit}>
               <DialogContent>

--- a/components/GeneralPanel.tsx
+++ b/components/GeneralPanel.tsx
@@ -92,9 +92,10 @@ function GeneralPanel({ experiment }: { experiment: ExperimentFull }) {
   const generalEditValidationSchema = yupPick(experimentFullSchema, props).shape({
     // We need to ensure the end date is in the future
     endDatetime: ((yup.reach(experimentFullSchema, 'endDatetime') as unknown) as yup.MixedSchema).test(
-      'future-date',
-      'End date must be in the future.',
-      dateFns.isFuture,
+      'future-end-date',
+      'End date (UTC) must be in the future.',
+      // We need to refer to new Date() instead of using dateFns.isFuture so MockDate works with this in the tests.
+      (date) => dateFns.isBefore(new Date(), date),
     ),
   })
   const onEdit = () => setIsEditing(true)

--- a/components/GeneralPanel.tsx
+++ b/components/GeneralPanel.tsx
@@ -21,7 +21,7 @@ import * as yup from 'yup'
 
 import DatetimeText from '@/components/DatetimeText'
 import LabelValueTable from '@/components/LabelValueTable'
-import { ExperimentFull, Status, experimentFullNewSchema, experimentFullSchema, yupPick, MAX_DISTANCE_BETWEEN_START_AND_END_DATE_IN_MONTHS } from '@/lib/schemas'
+import { ExperimentFull, experimentFullSchema, Status, yupPick } from '@/lib/schemas'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -91,8 +91,11 @@ function GeneralPanel({ experiment }: { experiment: ExperimentFull }) {
   }
   const generalEditValidationSchema = yupPick(experimentFullSchema, props).shape({
     // We need to ensure the end date is in the future
-    endDatetime: (yup.reach(experimentFullSchema, 'endDatetime') as unknown as yup.MixedSchema)
-      .test('future-date', 'End date must be in the future.', dateFns.isFuture)
+    endDatetime: ((yup.reach(experimentFullSchema, 'endDatetime') as unknown) as yup.MixedSchema).test(
+      'future-date',
+      'End date must be in the future.',
+      dateFns.isFuture,
+    ),
   })
   const onEdit = () => setIsEditing(true)
   const onCancelEdit = () => {

--- a/components/experiment-creation/ExperimentForm.test.tsx
+++ b/components/experiment-creation/ExperimentForm.test.tsx
@@ -273,8 +273,7 @@ test('skipping to submit should check all sections', async () => {
 })
 
 test('form submits with valid fields', async () => {
-  // As I couldn't mock the date in the /lib/schemas...
-  MockDate.reset()
+  MockDate.set('2020-08-13')
 
   let submittedData: unknown = null
   const onSubmit = async (formData: unknown): Promise<undefined> => {

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -342,12 +342,12 @@ export type Analysis = yup.InferType<typeof analysisSchema>
 
 /**
  * The yup equivalant of _.pick, produces a subset of the original schema.
- * 
+ *
  * @param schema A yup object schema
  * @param props Properties to pick
  * @param value See yup.reach
  * @param context See yup.reach
  */
 export function yupPick(schema: yup.ObjectSchema, props: string[], value?: unknown, context?: unknown) {
-  return yup.object(_.fromPairs(props.map(prop => [prop, yup.reach(schema, prop, value, context)])))
+  return yup.object(_.fromPairs(props.map((prop) => [prop, yup.reach(schema, prop, value, context)])))
 }

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -240,10 +240,17 @@ export const experimentFullNewSchema = experimentFullSchema.shape({
   startDatetime: yup
     .date()
     .defined()
-    .min(now, 'Start date (UTC) must be in the future.')
-    .max(
-      dateFns.addMonths(now, MAX_DISTANCE_BETWEEN_NOW_AND_START_DATE_IN_MONTHS),
+    .test(
+      'future-start-date',
+      'Start date (UTC) must be in the future.',
+      // We need to refer to new Date() instead of using dateFns.isFuture so MockDate works with this in the tests.
+      (date) => dateFns.isBefore(new Date(), date),
+    )
+    .test(
+      'bounded-start-date',
       `Start date must be within ${MAX_DISTANCE_BETWEEN_NOW_AND_START_DATE_IN_MONTHS} months from now.`,
+      // We need to refer to new Date() instead of using dateFns.isFuture so MockDate works with this in the tests.
+      (date) => dateFns.isBefore(date, dateFns.addMonths(now, MAX_DISTANCE_BETWEEN_NOW_AND_START_DATE_IN_MONTHS)),
     ),
   exposureEvents: yup.array(eventNewSchema).notRequired(),
   metricAssignments: yup.array(metricAssignmentNewSchema).defined().min(1),


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR adds validation to the GeneralPanel edit modal:**
- Video: https://d.pr/v/jpDZgI
- Uses `yup.reach` and creates `yupPick` (the `_.pick` equivalent for yup) allowing picking subsets of a schema
- Fixes date testing in the schema by using `.test()` rather than `.min()` allowing mocking of `Date`
- Moves `endDatetime` tests from `experimentFullNewSchema` to `experimentBareSchema` so it will flow through to `experimentFullSchema` and allow use in editing (as well as better validating incoming data).
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
- More testing to come!
