### PR TITLE
Fix console warnings in panel edit tests

### DIFF
--- a/components/GeneralPanel.test.tsx
+++ b/components/GeneralPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react'
 import MockDate from 'mockdate'
 import * as notistack from 'notistack'
 import React from 'react'
@@ -159,50 +159,36 @@ test('renders as expected', () => {
   `)
 })
 
-test('opens, submits and cancels edit dialog with running experiment', () => {
+test('opens, submits and cancels edit dialog with running experiment', async () => {
   const experiment = Fixtures.createExperimentFull({ status: Status.Running })
   const { container: _container } = render(<GeneralPanel experiment={experiment} />)
 
   const editButton = screen.getByRole('button', { name: /Edit/ })
   fireEvent.click(editButton)
 
-  waitFor(() => {
-    screen.getByRole('button', { name: /Save/ })
-  })
+  await waitFor(() => screen.getByRole('button', { name: /Save/ }))
 
   const saveButton = screen.getByRole('button', { name: /Save/ })
   fireEvent.click(saveButton)
+  await waitForElementToBeRemoved(saveButton)
 
   fireEvent.click(editButton)
 
-  waitFor(() => {
-    screen.getByRole('button', { name: /Cancel/ })
-  })
+  await waitFor(() => screen.getByRole('button', { name: /Cancel/ }))
 
   const cancelButton = screen.getByRole('button', { name: /Cancel/ })
   fireEvent.click(cancelButton)
+  await waitForElementToBeRemoved(cancelButton)
 })
 
-test('opens, submits and cancels edit dialog with disabled experiment', () => {
+test('checks edit dialog does not allow end datetime changes with disabled experiment', async () => {
   const experiment = Fixtures.createExperimentFull({ status: Status.Disabled })
   const { container: _container } = render(<GeneralPanel experiment={experiment} />)
 
   const editButton = screen.getByRole('button', { name: /Edit/ })
   fireEvent.click(editButton)
 
-  waitFor(() => {
-    screen.getByRole('button', { name: /Save/ })
-  })
+  await waitFor(() => screen.getByRole('button', { name: /Save/ }))
 
-  const saveButton = screen.getByRole('button', { name: /Save/ })
-  fireEvent.click(saveButton)
-
-  fireEvent.click(editButton)
-
-  waitFor(() => {
-    screen.getByRole('button', { name: /Cancel/ })
-  })
-
-  const cancelButton = screen.getByRole('button', { name: /Cancel/ })
-  fireEvent.click(cancelButton)
+  expect(screen.getByLabelText(/End date/)).toBeDisabled()
 })

--- a/components/MetricAssignmentsPanel.test.tsx
+++ b/components/MetricAssignmentsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react'
 import * as notistack from 'notistack'
 import React from 'react'
 
@@ -233,7 +233,7 @@ test('throws an error when some metrics not resolvable', () => {
   }
 })
 
-test('opens, submits and cancels assign metric dialog', () => {
+test('opens, submits and cancels assign metric dialog', async () => {
   const metrics = Fixtures.createMetricBares(5)
   const experiment = Fixtures.createExperimentFull()
   const { container: _container } = render(<MetricAssignmentsPanel experiment={experiment} metrics={metrics} />)
@@ -241,19 +241,17 @@ test('opens, submits and cancels assign metric dialog', () => {
   const startAssignButton = screen.getByRole('button', { name: /Assign Metric/ })
   fireEvent.click(startAssignButton)
 
-  waitFor(() => {
-    screen.getByRole('button', { name: 'Assign' })
-  })
+  await waitFor(() => screen.getByRole('button', { name: 'Assign' }))
 
   const assignButton = screen.getByRole('button', { name: 'Assign' })
   fireEvent.click(assignButton)
+  await waitForElementToBeRemoved(assignButton)
 
   fireEvent.click(startAssignButton)
 
-  waitFor(() => {
-    screen.getByRole('button', { name: /Cancel/ })
-  })
+  await waitFor(() => screen.getByRole('button', { name: /Cancel/ }))
 
   const cancelButton = screen.getByRole('button', { name: /Cancel/ })
   fireEvent.click(cancelButton)
+  await waitForElementToBeRemoved(cancelButton)
 })


### PR DESCRIPTION
Apply a similar fix to that discussed in https://github.com/Automattic/abacus/pull/281#discussion_r478225310 to eliminate some testing console warnings.

## How has this been tested?

- Automated tests that cover added/changed functionality (ran in the console and verified that the warnings went away)