### PR TITLE
Add GeneralPanel Edit Modal data reload

### DIFF
--- a/components/ExperimentDetails.test.tsx
+++ b/components/ExperimentDetails.test.tsx
@@ -1,3 +1,4 @@
+import { noop } from 'lodash'
 import MockDate from 'mockdate'
 import * as notistack from 'notistack'
 import React from 'react'
@@ -22,6 +23,8 @@ afterEach(() => {
   window.matchMedia = createMatchMedia(initialJsDomWindowInnerWidth)
 })
 
+const experimentReloadRef: React.MutableRefObject<() => void> = { current: noop }
+
 test('renders as expected at large width', () => {
   window.matchMedia = createMatchMedia(1600)
 
@@ -33,7 +36,14 @@ test('renders as expected at large width', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 102, segmentId: 2, isExcluded: true }),
     ],
   })
-  const { container } = render(<ExperimentDetails experiment={experiment} metrics={metrics} segments={segments} />)
+  const { container } = render(
+    <ExperimentDetails
+      experiment={experiment}
+      metrics={metrics}
+      segments={segments}
+      experimentReloadRef={experimentReloadRef}
+    />,
+  )
 
   expect(container).toMatchSnapshot()
 })
@@ -48,7 +58,14 @@ test('renders as expected at small width', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 102, segmentId: 2, isExcluded: true }),
     ],
   })
-  const { container } = render(<ExperimentDetails experiment={experiment} metrics={metrics} segments={segments} />)
+  const { container } = render(
+    <ExperimentDetails
+      experiment={experiment}
+      metrics={metrics}
+      segments={segments}
+      experimentReloadRef={experimentReloadRef}
+    />,
+  )
 
   expect(container).toMatchSnapshot()
 })
@@ -66,7 +83,14 @@ test('renders as expected with conclusion data', () => {
     ],
     status: Status.Disabled,
   })
-  const { container } = render(<ExperimentDetails experiment={experiment} metrics={metrics} segments={segments} />)
+  const { container } = render(
+    <ExperimentDetails
+      experiment={experiment}
+      metrics={metrics}
+      segments={segments}
+      experimentReloadRef={experimentReloadRef}
+    />,
+  )
 
   expect(container).toMatchSnapshot()
 })
@@ -80,7 +104,14 @@ test('renders as expected without conclusion data', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 102, segmentId: 2, isExcluded: true }),
     ],
   })
-  const { container } = render(<ExperimentDetails experiment={experiment} metrics={metrics} segments={segments} />)
+  const { container } = render(
+    <ExperimentDetails
+      experiment={experiment}
+      metrics={metrics}
+      segments={segments}
+      experimentReloadRef={experimentReloadRef}
+    />,
+  )
 
   expect(container).toMatchSnapshot()
 })

--- a/components/ExperimentDetails.tsx
+++ b/components/ExperimentDetails.tsx
@@ -19,10 +19,12 @@ function ExperimentDetails({
   experiment,
   metrics,
   segments,
+  experimentReloadRef,
 }: {
   experiment: ExperimentFull
   metrics: MetricBare[]
   segments: Segment[]
+  experimentReloadRef: React.MutableRefObject<() => void>,
 }) {
   debug('ExperimentDetails#render')
   const theme = useTheme()
@@ -33,7 +35,7 @@ function ExperimentDetails({
       <Grid item xs={12} lg={7}>
         <Grid container direction='column' spacing={2}>
           <Grid item>
-            <GeneralPanel experiment={experiment} />
+            <GeneralPanel {...{ experiment, experimentReloadRef }} />
           </Grid>
           {isMdDown && (
             <Grid item>

--- a/components/ExperimentDetails.tsx
+++ b/components/ExperimentDetails.tsx
@@ -24,7 +24,7 @@ function ExperimentDetails({
   experiment: ExperimentFull
   metrics: MetricBare[]
   segments: Segment[]
-  experimentReloadRef: React.MutableRefObject<() => void>,
+  experimentReloadRef: React.MutableRefObject<() => void>
 }) {
   debug('ExperimentDetails#render')
   const theme = useTheme()

--- a/components/ExperimentPageView.tsx
+++ b/components/ExperimentPageView.tsx
@@ -41,7 +41,12 @@ export default function ExperimentPageView({
 }) {
   const classes = useStyles()
 
-  const { isLoading: experimentIsLoading, data: experiment, error: experimentError, reloadRef: experimentReloadRef } = useDataSource(
+  const {
+    isLoading: experimentIsLoading,
+    data: experiment,
+    error: experimentError,
+    reloadRef: experimentReloadRef,
+  } = useDataSource(
     () => (experimentId ? ExperimentsApi.findById(experimentId) : createUnresolvingPromise<ExperimentFull>()),
     [experimentId],
   )
@@ -72,22 +77,16 @@ export default function ExperimentPageView({
       <>
         {/* TODO: Inline this. */}
         <ExperimentTabs experimentId={experimentId} tab={view} className={classes.viewTabs} />
-        {isLoading ? (
-          <LinearProgress />
-        ) : (
-            experiment &&
-            metrics &&
-            segments &&
-            analyses && (
-              <>
-                {view === ExperimentView.Overview && <ExperimentDetails {...{ experiment, metrics, segments, experimentReloadRef }} />}
-                {view === ExperimentView.Results && (
-                  <ExperimentResults {...{ experiment, metrics, analyses, debugMode }} />
-                )}
-                {view === ExperimentView.CodeSetup && <ExperimentCodeSetup />}
-              </>
-            )
-          )}
+        {isLoading && <LinearProgress />}
+        {experiment && metrics && segments && analyses && (
+          <>
+            {view === ExperimentView.Overview && (
+              <ExperimentDetails {...{ experiment, metrics, segments, experimentReloadRef }} />
+            )}
+            {view === ExperimentView.Results && <ExperimentResults {...{ experiment, metrics, analyses, debugMode }} />}
+            {view === ExperimentView.CodeSetup && <ExperimentCodeSetup />}
+          </>
+        )}
       </>
     </Layout>
   )

--- a/components/ExperimentPageView.tsx
+++ b/components/ExperimentPageView.tsx
@@ -41,7 +41,7 @@ export default function ExperimentPageView({
 }) {
   const classes = useStyles()
 
-  const { isLoading: experimentIsLoading, data: experiment, error: experimentError } = useDataSource(
+  const { isLoading: experimentIsLoading, data: experiment, error: experimentError, reloadRef: experimentReloadRef } = useDataSource(
     () => (experimentId ? ExperimentsApi.findById(experimentId) : createUnresolvingPromise<ExperimentFull>()),
     [experimentId],
   )
@@ -75,19 +75,19 @@ export default function ExperimentPageView({
         {isLoading ? (
           <LinearProgress />
         ) : (
-          experiment &&
-          metrics &&
-          segments &&
-          analyses && (
-            <>
-              {view === ExperimentView.Overview && <ExperimentDetails {...{ experiment, metrics, segments }} />}
-              {view === ExperimentView.Results && (
-                <ExperimentResults {...{ experiment, metrics, analyses, debugMode }} />
-              )}
-              {view === ExperimentView.CodeSetup && <ExperimentCodeSetup />}
-            </>
-          )
-        )}
+            experiment &&
+            metrics &&
+            segments &&
+            analyses && (
+              <>
+                {view === ExperimentView.Overview && <ExperimentDetails {...{ experiment, metrics, segments, experimentReloadRef }} />}
+                {view === ExperimentView.Results && (
+                  <ExperimentResults {...{ experiment, metrics, analyses, debugMode }} />
+                )}
+                {view === ExperimentView.CodeSetup && <ExperimentCodeSetup />}
+              </>
+            )
+          )}
       </>
     </Layout>
   )

--- a/components/GeneralPanel.test.tsx
+++ b/components/GeneralPanel.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/require-await */
 import { fireEvent, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react'
+import { noop } from 'lodash'
 import MockDate from 'mockdate'
 import * as notistack from 'notistack'
 import React from 'react'
@@ -19,9 +20,11 @@ mockedNotistack.useSnackbar.mockImplementation(() => ({
   closeSnackbar: jest.fn(),
 }))
 
+const experimentReloadRef: React.MutableRefObject<() => void> = { current: noop }
+
 test('renders as expected', () => {
   const experiment = Fixtures.createExperimentFull()
-  const { container } = render(<GeneralPanel experiment={experiment} />)
+  const { container } = render(<GeneralPanel experiment={experiment} experimentReloadRef={experimentReloadRef} />)
 
   expect(container).toMatchInlineSnapshot(`
     <div>
@@ -162,7 +165,7 @@ test('renders as expected', () => {
 
 test('opens, submits and cancels edit dialog with running experiment', async () => {
   const experiment = Fixtures.createExperimentFull({ status: Status.Running })
-  const { container: _container } = render(<GeneralPanel experiment={experiment} />)
+  render(<GeneralPanel experiment={experiment} experimentReloadRef={experimentReloadRef} />)
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
   // @ts-ignore
@@ -190,7 +193,7 @@ test('opens, submits and cancels edit dialog with running experiment', async () 
 
 test('checks edit dialog does not allow end datetime changes with disabled experiment', async () => {
   const experiment = Fixtures.createExperimentFull({ status: Status.Disabled })
-  const { container: _container } = render(<GeneralPanel experiment={experiment} />)
+  render(<GeneralPanel experiment={experiment} experimentReloadRef={experimentReloadRef} />)
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
   // @ts-ignore

--- a/components/GeneralPanel.tsx
+++ b/components/GeneralPanel.tsx
@@ -71,7 +71,13 @@ const useStyles = makeStyles((theme: Theme) =>
  *
  * @param props.experiment - The experiment with the general information.
  */
-function GeneralPanel({ experiment, experimentReloadRef }: { experiment: ExperimentFull, experimentReloadRef: React.MutableRefObject<() => void> }) {
+function GeneralPanel({
+  experiment,
+  experimentReloadRef,
+}: {
+  experiment: ExperimentFull
+  experimentReloadRef: React.MutableRefObject<() => void>
+}) {
   const classes = useStyles()
   const data = [
     { label: 'Description', value: experiment.description },

--- a/components/GeneralPanel.tsx
+++ b/components/GeneralPanel.tsx
@@ -71,7 +71,7 @@ const useStyles = makeStyles((theme: Theme) =>
  *
  * @param props.experiment - The experiment with the general information.
  */
-function GeneralPanel({ experiment }: { experiment: ExperimentFull }) {
+function GeneralPanel({ experiment, experimentReloadRef }: { experiment: ExperimentFull, experimentReloadRef: React.MutableRefObject<() => void> }) {
   const classes = useStyles()
   const data = [
     { label: 'Description', value: experiment.description },
@@ -124,6 +124,7 @@ function GeneralPanel({ experiment }: { experiment: ExperimentFull }) {
       const experimentPatch = _.pick(formData.experiment, props)
       await ExperimentsApi.patch(experiment.experimentId, experimentPatch)
       enqueueSnackbar('Experiment Updated!', { variant: 'success' })
+      experimentReloadRef.current()
       setIsEditing(false)
     } catch (e) {
       enqueueSnackbar('Oops! Something went wrong while trying to update your experiment.', { variant: 'error' })


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
This PR adds reloading after submit:
- Passes down the reload function to the modal.
- Shows the linear loader independently to the data state.
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)