### PR TITLE
Add fields to add Metric Assignment Modal

### DIFF
--- a/components/MetricAssignmentsPanel.test.tsx
+++ b/components/MetricAssignmentsPanel.test.tsx
@@ -107,7 +107,7 @@ test('renders as expected with all metrics resolvable', () => {
               >
                 metric_1
                 <span
-                  class="makeStyles-primary-1 makeStyles-root-3"
+                  class="makeStyles-primary-1 makeStyles-root-6"
                 >
                   Primary
                 </span>

--- a/components/MetricAssignmentsPanel.test.tsx
+++ b/components/MetricAssignmentsPanel.test.tsx
@@ -1,9 +1,10 @@
-import { fireEvent, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react'
+/* eslint-disable @typescript-eslint/require-await */
+import { act, fireEvent, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react'
 import * as notistack from 'notistack'
 import React from 'react'
 
 import Fixtures from '@/test-helpers/fixtures'
-import { render } from '@/test-helpers/test-utils'
+import { changeFieldByRole, render } from '@/test-helpers/test-utils'
 
 import MetricAssignmentsPanel from './MetricAssignmentsPanel'
 
@@ -242,6 +243,32 @@ test('opens, submits and cancels assign metric dialog', async () => {
   fireEvent.click(startAssignButton)
 
   await waitFor(() => screen.getByRole('button', { name: 'Assign' }))
+
+  const metricSearchField = screen.getByRole('button', { name: /Select a Metric/ })
+  await act(async () => {
+    fireEvent.focus(metricSearchField)
+  })
+  await act(async () => {
+    fireEvent.keyDown(metricSearchField, { key: 'Enter' })
+  })
+  const metricOption = await screen.findByRole('option', { name: /metric_3/ })
+  await act(async () => {
+    fireEvent.click(metricOption)
+  })
+
+  const attributionWindowField = await screen.findByLabelText(/Attribution Window/)
+  await act(async () => {
+    fireEvent.focus(attributionWindowField)
+  })
+  await act(async () => {
+    fireEvent.keyDown(attributionWindowField, { key: 'Enter' })
+  })
+  const attributionWindowFieldOption = await screen.findByRole('option', { name: /24 hours/ })
+  await act(async () => {
+    fireEvent.click(attributionWindowFieldOption)
+  })
+
+  await changeFieldByRole('spinbutton', /Minimum Difference/, '0.01')
 
   const assignButton = screen.getByRole('button', { name: 'Assign' })
   fireEvent.click(assignButton)

--- a/components/MetricAssignmentsPanel.tsx
+++ b/components/MetricAssignmentsPanel.tsx
@@ -1,4 +1,16 @@
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Toolbar, FormControl, MenuItem, FormLabel, InputAdornment, Tooltip } from '@material-ui/core'
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormLabel,
+  InputAdornment,
+  MenuItem,
+  Toolbar,
+  Tooltip,
+} from '@material-ui/core'
 import Paper from '@material-ui/core/Paper'
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import Table from '@material-ui/core/Table'
@@ -8,17 +20,17 @@ import TableHead from '@material-ui/core/TableHead'
 import TableRow from '@material-ui/core/TableRow'
 import Typography from '@material-ui/core/Typography'
 import { Add } from '@material-ui/icons'
-import { Formik, Field } from 'formik'
+import { Field, Formik } from 'formik'
+import { Select, Switch, TextField } from 'formik-material-ui'
 import { useSnackbar } from 'notistack'
 import React, { useMemo, useState } from 'react'
 
 import Label from '@/components/Label'
 import { AttributionWindowSecondsToHuman } from '@/lib/metric-assignments'
 import * as MetricAssignments from '@/lib/metric-assignments'
+import { indexMetrics } from '@/lib/normalizers'
 import { ExperimentFull, MetricAssignment, MetricBare, MetricParameterType } from '@/lib/schemas'
 import { formatBoolean, formatUsCurrencyDollar } from '@/utils/formatters'
-import { Select, Switch, TextField } from 'formik-material-ui'
-import { indexMetrics } from '@/lib/normalizers'
 
 /**
  * Resolves the metric ID of the metric assignment with the actual metric. If the
@@ -168,7 +180,9 @@ function MetricAssignmentsPanel({ experiment, metrics }: { experiment: Experimen
               <DialogContent>
                 <div className={classes.row}>
                   <FormControl component='fieldset' fullWidth>
-                    <FormLabel required className={classes.label}>Metric</FormLabel>
+                    <FormLabel required className={classes.label}>
+                      Metric
+                    </FormLabel>
                     <Field
                       component={Select}
                       name={`metricAssignment.metricId`}
@@ -190,7 +204,9 @@ function MetricAssignmentsPanel({ experiment, metrics }: { experiment: Experimen
                 </div>
                 <div className={classes.row}>
                   <FormControl component='fieldset' fullWidth>
-                    <FormLabel required className={classes.label}>Attribution Window</FormLabel>
+                    <FormLabel required className={classes.label}>
+                      Attribution Window
+                    </FormLabel>
                     <Field
                       component={Select}
                       name={`metricAssignment.attributionWindowSeconds`}
@@ -211,10 +227,12 @@ function MetricAssignmentsPanel({ experiment, metrics }: { experiment: Experimen
                 </div>
                 <div className={classes.row}>
                   <FormControl component='fieldset' fullWidth>
-                    <FormLabel required className={classes.label}>Change Expected</FormLabel>
+                    <FormLabel required className={classes.label}>
+                      Change Expected
+                    </FormLabel>
                     <Field
                       component={Switch}
-                      label="Change Expected"
+                      label='Change Expected'
                       name={`metricAssignment.changeExpected`}
                       id={`metricAssignment.changeExpected`}
                       variant='outlined'
@@ -224,7 +242,9 @@ function MetricAssignmentsPanel({ experiment, metrics }: { experiment: Experimen
                 </div>
                 <div className={classes.row}>
                   <FormControl component='fieldset' fullWidth>
-                    <FormLabel required className={classes.label}>Minimum Difference</FormLabel>
+                    <FormLabel required className={classes.label}>
+                      Minimum Difference
+                    </FormLabel>
                     <Field
                       component={TextField}
                       name={`metricAssignment.minDifference`}
@@ -234,22 +254,22 @@ function MetricAssignmentsPanel({ experiment, metrics }: { experiment: Experimen
                       placeholder='-'
                       InputProps={
                         formikProps.values.metricAssignment.metricId &&
-                          indexedMetrics[formikProps.values.metricAssignment.metricId as unknown as number].parameterType ===
-                          MetricParameterType.Conversion
+                        indexedMetrics[(formikProps.values.metricAssignment.metricId as unknown) as number]
+                          .parameterType === MetricParameterType.Conversion
                           ? {
-                            endAdornment: (
-                              <InputAdornment position='end'>
-                                <Tooltip title='Percentage Points'>
-                                  <Typography variant='body1' color='textSecondary'>
-                                    pp
-                                            </Typography>
-                                </Tooltip>
-                              </InputAdornment>
-                            ),
-                          }
+                              endAdornment: (
+                                <InputAdornment position='end'>
+                                  <Tooltip title='Percentage Points'>
+                                    <Typography variant='body1' color='textSecondary'>
+                                      pp
+                                    </Typography>
+                                  </Tooltip>
+                                </InputAdornment>
+                              ),
+                            }
                           : {
-                            startAdornment: <InputAdornment position='start'>$</InputAdornment>,
-                          }
+                              startAdornment: <InputAdornment position='start'>$</InputAdornment>,
+                            }
                       }
                     />
                   </FormControl>
@@ -259,7 +279,7 @@ function MetricAssignmentsPanel({ experiment, metrics }: { experiment: Experimen
                     <FormLabel className={classes.label}>Make Primary</FormLabel>
                     <Field
                       component={Switch}
-                      label="Make Primary"
+                      label='Make Primary'
                       name={`metricAssignment.isPrimary`}
                       id={`metricAssignment.isPrimary`}
                       variant='outlined'

--- a/components/MetricAssignmentsPanel.tsx
+++ b/components/MetricAssignmentsPanel.tsx
@@ -173,7 +173,7 @@ function MetricAssignmentsPanel({ experiment, metrics }: { experiment: Experimen
         </TableBody>
       </Table>
       <Dialog open={isAssigningMetric} aria-labelledby='assign-metric-form-dialog-title'>
-        <DialogTitle id='assign-metric-form-dialog-title'>Add Metric</DialogTitle>
+        <DialogTitle id='assign-metric-form-dialog-title'>Assign Metric</DialogTitle>
         <Formik initialValues={{ metricAssignment: assignMetricInitialAssignMetric }} onSubmit={onSubmitAssignMetric}>
           {(formikProps) => (
             <form onSubmit={formikProps.handleSubmit}>
@@ -204,12 +204,17 @@ function MetricAssignmentsPanel({ experiment, metrics }: { experiment: Experimen
                 </div>
                 <div className={classes.row}>
                   <FormControl component='fieldset' fullWidth>
-                    <FormLabel required className={classes.label}>
+                    <FormLabel
+                      required
+                      className={classes.label}
+                      id={`metricAssignment.attributionWindowSeconds-label`}
+                    >
                       Attribution Window
                     </FormLabel>
                     <Field
                       component={Select}
                       name={`metricAssignment.attributionWindowSeconds`}
+                      labelId={`metricAssignment.attributionWindowSeconds-label`}
                       id={`metricAssignment.attributionWindowSeconds`}
                       variant='outlined'
                       displayEmpty
@@ -235,6 +240,9 @@ function MetricAssignmentsPanel({ experiment, metrics }: { experiment: Experimen
                       label='Change Expected'
                       name={`metricAssignment.changeExpected`}
                       id={`metricAssignment.changeExpected`}
+                      inputProps={{
+                        'aria-label': 'Change Expected',
+                      }}
                       variant='outlined'
                       type='checkbox'
                     />
@@ -242,7 +250,7 @@ function MetricAssignmentsPanel({ experiment, metrics }: { experiment: Experimen
                 </div>
                 <div className={classes.row}>
                   <FormControl component='fieldset' fullWidth>
-                    <FormLabel required className={classes.label}>
+                    <FormLabel required className={classes.label} id={`metricAssignment.minDifference-label`}>
                       Minimum Difference
                     </FormLabel>
                     <Field
@@ -252,6 +260,9 @@ function MetricAssignmentsPanel({ experiment, metrics }: { experiment: Experimen
                       type='number'
                       variant='outlined'
                       placeholder='-'
+                      inputProps={{
+                        'aria-label': 'Minimum Difference',
+                      }}
                       InputProps={
                         formikProps.values.metricAssignment.metricId &&
                         indexedMetrics[(formikProps.values.metricAssignment.metricId as unknown) as number]
@@ -271,19 +282,6 @@ function MetricAssignmentsPanel({ experiment, metrics }: { experiment: Experimen
                               startAdornment: <InputAdornment position='start'>$</InputAdornment>,
                             }
                       }
-                    />
-                  </FormControl>
-                </div>
-                <div className={classes.row}>
-                  <FormControl component='fieldset' fullWidth>
-                    <FormLabel className={classes.label}>Make Primary</FormLabel>
-                    <Field
-                      component={Switch}
-                      label='Make Primary'
-                      name={`metricAssignment.isPrimary`}
-                      id={`metricAssignment.isPrimary`}
-                      variant='outlined'
-                      type='checkbox'
                     />
                   </FormControl>
                 </div>

--- a/components/MetricAssignmentsPanel.tsx
+++ b/components/MetricAssignmentsPanel.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Toolbar } from '@material-ui/core'
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Toolbar, FormControl, MenuItem, FormLabel, InputAdornment, Tooltip } from '@material-ui/core'
 import Paper from '@material-ui/core/Paper'
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import Table from '@material-ui/core/Table'
@@ -8,7 +8,7 @@ import TableHead from '@material-ui/core/TableHead'
 import TableRow from '@material-ui/core/TableRow'
 import Typography from '@material-ui/core/Typography'
 import { Add } from '@material-ui/icons'
-import { Formik } from 'formik'
+import { Formik, Field } from 'formik'
 import { useSnackbar } from 'notistack'
 import React, { useMemo, useState } from 'react'
 
@@ -17,6 +17,8 @@ import { AttributionWindowSecondsToHuman } from '@/lib/metric-assignments'
 import * as MetricAssignments from '@/lib/metric-assignments'
 import { ExperimentFull, MetricAssignment, MetricBare, MetricParameterType } from '@/lib/schemas'
 import { formatBoolean, formatUsCurrencyDollar } from '@/utils/formatters'
+import { Select, Switch, TextField } from 'formik-material-ui'
+import { indexMetrics } from '@/lib/normalizers'
 
 /**
  * Resolves the metric ID of the metric assignment with the actual metric. If the
@@ -52,6 +54,21 @@ const useStyles = makeStyles((theme: Theme) =>
     title: {
       flexGrow: 1,
     },
+    addMetricPlaceholder: {
+      fontFamily: theme.typography.fontFamily,
+    },
+    row: {
+      minWidth: 400,
+      marginTop: theme.spacing(3),
+      display: 'flex',
+      alignItems: 'center',
+      '&:first-of-type': {
+        marginTop: theme.spacing(0),
+      },
+    },
+    label: {
+      marginBottom: theme.spacing(1),
+    },
   }),
 )
 
@@ -69,14 +86,17 @@ function MetricAssignmentsPanel({ experiment, metrics }: { experiment: Experimen
     [experiment, metrics],
   )
 
+  // TODO: Normalize this higher up
+  const indexedMetrics = indexMetrics(metrics)
+
   // Assign Metric Modal
   const { enqueueSnackbar } = useSnackbar()
   const [isAssigningMetric, setIsAssigningMetric] = useState<boolean>(false)
   const assignMetricInitialAssignMetric = {
     metricId: '',
     attributionWindowSeconds: '',
-    changeExpected: 'false',
-    isPrimary: 'false',
+    changeExpected: false,
+    isPrimary: false,
     minDifference: '',
   }
   const onAssignMetric = () => setIsAssigningMetric(true)
@@ -145,7 +165,109 @@ function MetricAssignmentsPanel({ experiment, metrics }: { experiment: Experimen
         <Formik initialValues={{ metricAssignment: assignMetricInitialAssignMetric }} onSubmit={onSubmitAssignMetric}>
           {(formikProps) => (
             <form onSubmit={formikProps.handleSubmit}>
-              <DialogContent></DialogContent>
+              <DialogContent>
+                <div className={classes.row}>
+                  <FormControl component='fieldset' fullWidth>
+                    <FormLabel required className={classes.label}>Metric</FormLabel>
+                    <Field
+                      component={Select}
+                      name={`metricAssignment.metricId`}
+                      id={`metricAssignment.metricId`}
+                      variant='outlined'
+                      fullWidth
+                      displayEmpty
+                    >
+                      <MenuItem value=''>
+                        <span className={classes.addMetricPlaceholder}>Select a Metric</span>
+                      </MenuItem>
+                      {Object.values(indexedMetrics).map((metric) => (
+                        <MenuItem value={metric.metricId} key={metric.metricId}>
+                          {metric.name}
+                        </MenuItem>
+                      ))}
+                    </Field>
+                  </FormControl>
+                </div>
+                <div className={classes.row}>
+                  <FormControl component='fieldset' fullWidth>
+                    <FormLabel required className={classes.label}>Attribution Window</FormLabel>
+                    <Field
+                      component={Select}
+                      name={`metricAssignment.attributionWindowSeconds`}
+                      id={`metricAssignment.attributionWindowSeconds`}
+                      variant='outlined'
+                      displayEmpty
+                    >
+                      <MenuItem value=''>-</MenuItem>
+                      {Object.entries(AttributionWindowSecondsToHuman).map(
+                        ([attributionWindowSeconds, attributionWindowSecondsHuman]) => (
+                          <MenuItem value={attributionWindowSeconds} key={attributionWindowSeconds}>
+                            {attributionWindowSecondsHuman}
+                          </MenuItem>
+                        ),
+                      )}
+                    </Field>
+                  </FormControl>
+                </div>
+                <div className={classes.row}>
+                  <FormControl component='fieldset' fullWidth>
+                    <FormLabel required className={classes.label}>Change Expected</FormLabel>
+                    <Field
+                      component={Switch}
+                      label="Change Expected"
+                      name={`metricAssignment.changeExpected`}
+                      id={`metricAssignment.changeExpected`}
+                      variant='outlined'
+                      type='checkbox'
+                    />
+                  </FormControl>
+                </div>
+                <div className={classes.row}>
+                  <FormControl component='fieldset' fullWidth>
+                    <FormLabel required className={classes.label}>Minimum Difference</FormLabel>
+                    <Field
+                      component={TextField}
+                      name={`metricAssignment.minDifference`}
+                      id={`metricAssignment.minDifference`}
+                      type='number'
+                      variant='outlined'
+                      placeholder='-'
+                      InputProps={
+                        formikProps.values.metricAssignment.metricId &&
+                          indexedMetrics[formikProps.values.metricAssignment.metricId as unknown as number].parameterType ===
+                          MetricParameterType.Conversion
+                          ? {
+                            endAdornment: (
+                              <InputAdornment position='end'>
+                                <Tooltip title='Percentage Points'>
+                                  <Typography variant='body1' color='textSecondary'>
+                                    pp
+                                            </Typography>
+                                </Tooltip>
+                              </InputAdornment>
+                            ),
+                          }
+                          : {
+                            startAdornment: <InputAdornment position='start'>$</InputAdornment>,
+                          }
+                      }
+                    />
+                  </FormControl>
+                </div>
+                <div className={classes.row}>
+                  <FormControl component='fieldset' fullWidth>
+                    <FormLabel className={classes.label}>Make Primary</FormLabel>
+                    <Field
+                      component={Switch}
+                      label="Make Primary"
+                      name={`metricAssignment.isPrimary`}
+                      id={`metricAssignment.isPrimary`}
+                      variant='outlined'
+                      type='checkbox'
+                    />
+                  </FormControl>
+                </div>
+              </DialogContent>
               <DialogActions>
                 <Button onClick={onCancelAssignMetric} color='primary'>
                   Cancel

--- a/components/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/components/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -235,7 +235,7 @@ exports[`renders as expected at large width 1`] = `
                   >
                     metric_1
                     <span
-                      class="makeStyles-primary-6 makeStyles-root-8"
+                      class="makeStyles-primary-6 makeStyles-root-11"
                     >
                       Primary
                     </span>
@@ -352,7 +352,7 @@ exports[`renders as expected at large width 1`] = `
           class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
         >
           <h3
-            class="MuiTypography-root makeStyles-title-9 MuiTypography-h3 MuiTypography-colorTextPrimary"
+            class="MuiTypography-root makeStyles-title-12 MuiTypography-h3 MuiTypography-colorTextPrimary"
           >
             Audience
           </h3>
@@ -444,7 +444,7 @@ exports[`renders as expected at large width 1`] = `
                       >
                         control
                         <span
-                          class="makeStyles-default-10 makeStyles-root-8"
+                          class="makeStyles-default-13 makeStyles-root-11"
                         >
                           Default
                         </span>
@@ -549,7 +549,7 @@ exports[`renders as expected at large width 1`] = `
                       >
                         segment_2
                         <span
-                          class="makeStyles-excluded-11 makeStyles-root-8"
+                          class="makeStyles-excluded-14 makeStyles-root-11"
                         >
                           Excluded
                         </span>
@@ -588,7 +588,7 @@ exports[`renders as expected at small width 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-13 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-16 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 General
               </h3>
@@ -675,18 +675,18 @@ exports[`renders as expected at small width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-16"
+                      class="makeStyles-root-19"
                       title="20/09/2020, 20:00:00"
                     >
                       2020-09-21
                     </span>
                     <span
-                      class="makeStyles-to-12"
+                      class="makeStyles-to-15"
                     >
                       to
                     </span>
                     <span
-                      class="makeStyles-root-16"
+                      class="makeStyles-root-19"
                       title="20/11/2020, 20:00:00"
                     >
                       2020-11-21
@@ -723,7 +723,7 @@ exports[`renders as expected at small width 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-20 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-26 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Audience
               </h3>
@@ -815,7 +815,7 @@ exports[`renders as expected at small width 1`] = `
                           >
                             control
                             <span
-                              class="makeStyles-default-21 makeStyles-root-19"
+                              class="makeStyles-default-27 makeStyles-root-25"
                             >
                               Default
                             </span>
@@ -920,7 +920,7 @@ exports[`renders as expected at small width 1`] = `
                           >
                             segment_2
                             <span
-                              class="makeStyles-excluded-22 makeStyles-root-19"
+                              class="makeStyles-excluded-28 makeStyles-root-25"
                             >
                               Excluded
                             </span>
@@ -944,7 +944,7 @@ exports[`renders as expected at small width 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-18 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-21 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Metrics
               </h3>
@@ -1023,7 +1023,7 @@ exports[`renders as expected at small width 1`] = `
                   >
                     metric_1
                     <span
-                      class="makeStyles-primary-17 makeStyles-root-19"
+                      class="makeStyles-primary-20 makeStyles-root-25"
                     >
                       Primary
                     </span>
@@ -1155,7 +1155,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-24 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-30 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 General
               </h3>
@@ -1242,18 +1242,18 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-27"
+                      class="makeStyles-root-33"
                       title="20/09/2020, 20:00:00"
                     >
                       2020-09-21
                     </span>
                     <span
-                      class="makeStyles-to-23"
+                      class="makeStyles-to-29"
                     >
                       to
                     </span>
                     <span
-                      class="makeStyles-root-27"
+                      class="makeStyles-root-33"
                       title="20/11/2020, 20:00:00"
                     >
                       2020-11-21
@@ -1290,7 +1290,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-33 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-42 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Audience
               </h3>
@@ -1382,7 +1382,7 @@ exports[`renders as expected with conclusion data 1`] = `
                           >
                             control
                             <span
-                              class="makeStyles-default-34 makeStyles-root-30"
+                              class="makeStyles-default-43 makeStyles-root-39"
                             >
                               Default
                             </span>
@@ -1487,7 +1487,7 @@ exports[`renders as expected with conclusion data 1`] = `
                           >
                             segment_2
                             <span
-                              class="makeStyles-excluded-35 makeStyles-root-30"
+                              class="makeStyles-excluded-44 makeStyles-root-39"
                             >
                               Excluded
                             </span>
@@ -1511,7 +1511,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-29 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-35 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Metrics
               </h3>
@@ -1590,7 +1590,7 @@ exports[`renders as expected with conclusion data 1`] = `
                   >
                     metric_1
                     <span
-                      class="makeStyles-primary-28 makeStyles-root-30"
+                      class="makeStyles-primary-34 makeStyles-root-39"
                     >
                       Primary
                     </span>
@@ -1705,7 +1705,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-31 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-40 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Conclusions
               </h3>
@@ -1825,7 +1825,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-37 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-46 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 General
               </h3>
@@ -1912,18 +1912,18 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-40"
+                      class="makeStyles-root-49"
                       title="20/09/2020, 20:00:00"
                     >
                       2020-09-21
                     </span>
                     <span
-                      class="makeStyles-to-36"
+                      class="makeStyles-to-45"
                     >
                       to
                     </span>
                     <span
-                      class="makeStyles-root-40"
+                      class="makeStyles-root-49"
                       title="20/11/2020, 20:00:00"
                     >
                       2020-11-21
@@ -1960,7 +1960,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-44 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-56 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Audience
               </h3>
@@ -2052,7 +2052,7 @@ exports[`renders as expected without conclusion data 1`] = `
                           >
                             control
                             <span
-                              class="makeStyles-default-45 makeStyles-root-43"
+                              class="makeStyles-default-57 makeStyles-root-55"
                             >
                               Default
                             </span>
@@ -2157,7 +2157,7 @@ exports[`renders as expected without conclusion data 1`] = `
                           >
                             segment_2
                             <span
-                              class="makeStyles-excluded-46 makeStyles-root-43"
+                              class="makeStyles-excluded-58 makeStyles-root-55"
                             >
                               Excluded
                             </span>
@@ -2181,7 +2181,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-42 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-51 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Metrics
               </h3>
@@ -2260,7 +2260,7 @@ exports[`renders as expected without conclusion data 1`] = `
                   >
                     metric_1
                     <span
-                      class="makeStyles-primary-41 makeStyles-root-43"
+                      class="makeStyles-primary-50 makeStyles-root-55"
                     >
                       Primary
                     </span>

--- a/components/experiment-creation/ExperimentForm.test.tsx
+++ b/components/experiment-creation/ExperimentForm.test.tsx
@@ -10,7 +10,7 @@ import React from 'react'
 import { createInitialExperiment } from '@/lib/experiments'
 import * as Normalizers from '@/lib/normalizers'
 import Fixtures from '@/test-helpers/fixtures'
-import { render } from '@/test-helpers/test-utils'
+import { changeFieldByRole, render } from '@/test-helpers/test-utils'
 
 import ExperimentForm from './ExperimentForm'
 
@@ -45,13 +45,6 @@ function isSectionError(sectionButton: HTMLElement) {
 
 function isSectionComplete(sectionButton: HTMLElement) {
   return !!sectionButton.querySelector('.MuiStepIcon-completed')
-}
-
-async function changeFieldByRole(role: string, name: RegExp, value: string) {
-  const field = screen.getByRole(role, { name: name })
-  await act(async () => {
-    fireEvent.change(field, { target: { value: value } })
-  })
 }
 
 test('renders as expected', () => {

--- a/test-helpers/test-utils.tsx
+++ b/test-helpers/test-utils.tsx
@@ -1,4 +1,4 @@
-import { Queries, render as actualRender, RenderOptions } from '@testing-library/react'
+import { act, fireEvent, Queries, render as actualRender, RenderOptions, screen } from '@testing-library/react'
 import mediaQuery from 'css-mediaquery'
 import { Formik } from 'formik'
 import React from 'react'
@@ -66,4 +66,12 @@ export async function validationErrorDisplayer<T>(promise: Promise<T>): Promise<
     }
     throw err
   }
+}
+
+export async function changeFieldByRole(role: string, name: RegExp, value: string) {
+  const field = screen.getByRole(role, { name: name })
+  // eslint-disable-next-line @typescript-eslint/require-await
+  await act(async () => {
+    fireEvent.change(field, { target: { value: value } })
+  })
 }


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
This PR adds fields to the Add MetricAssignment Modal:

<img width="515" alt="Screen Shot 2020-09-02 at 2 29 07 am" src="https://user-images.githubusercontent.com/971886/91891727-1a776980-ecc4-11ea-94ba-d2c927615fc0.png">

- Allows you to add a new metric assignment and have it set to primary, no way to change primary otherwise, this should be good enough for now.
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
- More testing to come later