### PR TITLE
Add assignment bookmarklet

### DIFF
--- a/components/AudiencePanel.tsx
+++ b/components/AudiencePanel.tsx
@@ -7,7 +7,6 @@ import LabelValueTable from '@/components/LabelValueTable'
 import SegmentsTable from '@/components/SegmentsTable'
 import VariationsTable from '@/components/VariationsTable'
 import { ExperimentFull, Segment, SegmentAssignment, SegmentType } from '@/lib/schemas'
-import * as Variations from '@/lib/variations'
 import theme from '@/styles/theme'
 
 /**
@@ -122,13 +121,7 @@ function AudiencePanel({ experiment, segments }: { experiment: ExperimentFull; s
     {
       label: 'Variations',
       padding: 'none' as TableCellProps['padding'],
-      value: (
-        <VariationsTable
-          variations={Variations.sort(experiment.variations)}
-          experimentName={experiment.name}
-          experimentPlatform={experiment.platform}
-        />
-      ),
+      value: <VariationsTable experiment={experiment} />,
     },
     {
       label: 'Segments',

--- a/components/AudiencePanel.tsx
+++ b/components/AudiencePanel.tsx
@@ -122,7 +122,13 @@ function AudiencePanel({ experiment, segments }: { experiment: ExperimentFull; s
     {
       label: 'Variations',
       padding: 'none' as TableCellProps['padding'],
-      value: <VariationsTable variations={Variations.sort(experiment.variations)} />,
+      value: (
+        <VariationsTable
+          variations={Variations.sort(experiment.variations)}
+          experimentName={experiment.name}
+          experimentPlatform={experiment.platform}
+        />
+      ),
     },
     {
       label: 'Segments',

--- a/components/VariationsTable.tsx
+++ b/components/VariationsTable.tsx
@@ -5,7 +5,6 @@ import TableBody from '@material-ui/core/TableBody'
 import TableCell from '@material-ui/core/TableCell'
 import TableHead from '@material-ui/core/TableHead'
 import TableRow from '@material-ui/core/TableRow'
-import { withStyles } from '@material-ui/styles'
 import React from 'react'
 
 import Label from '@/components/Label'
@@ -19,6 +18,13 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     variation: {
       borderBottom: '1px dashed #a3a3a3',
+    },
+    tooltip: {
+      maxWidth: '500px',
+      padding: theme.spacing(2),
+      '& a:link': {
+        color: '#cee6f8',
+      },
     },
   }),
 )
@@ -49,17 +55,6 @@ function dangerousAssignmentLink(variationName: string, experimentName: string, 
   }
 }
 
-const HtmlTooltip = withStyles((theme) => ({
-  tooltip: {
-    maxWidth: '500px',
-    border: '1px solid #dadde9',
-    padding: theme.spacing(2),
-    '& a:link': {
-      color: '#cee6f8',
-    },
-  },
-}))(Tooltip)
-
 /**
  * Renders the variations in tabular formation, in the order that they're given.
  *
@@ -88,10 +83,13 @@ function VariationsTable({
           return (
             <TableRow key={variation.variationId}>
               <TableCell>
-                <HtmlTooltip
+                <Tooltip
                   interactive
                   arrow
                   placement={'left'}
+                  classes={{
+                    popper: classes.tooltip,
+                  }}
                   title={
                     <>
                       <Typography color='inherit' variant='body1' gutterBottom>
@@ -110,7 +108,7 @@ function VariationsTable({
                   }
                 >
                   <span className={classes.variation}>{variation.name}</span>
-                </HtmlTooltip>
+                </Tooltip>
                 {variation.isDefault && <Label className={classes.default} text='Default' />}
               </TableCell>
               <TableCell>{variation.allocatedPercentage}%</TableCell>

--- a/components/VariationsTable.tsx
+++ b/components/VariationsTable.tsx
@@ -7,7 +7,8 @@ import TableRow from '@material-ui/core/TableRow'
 import React from 'react'
 
 import Label from '@/components/Label'
-import { Variation } from '@/lib/schemas'
+import { ExperimentFull } from '@/lib/schemas'
+import * as Variations from '@/lib/variations'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -31,13 +32,9 @@ function assignmentHref(variationName: string, experimentName: string, experimen
  * @param props.variations - The variations to render.
  */
 function VariationsTable({
-  variations,
-  experimentName,
-  experimentPlatform,
+  experiment: { variations, name: experimentName, platform: experimentPlatform },
 }: {
-  variations: Variation[]
-  experimentName: string
-  experimentPlatform: string
+  experiment: ExperimentFull
 }) {
   const classes = useStyles()
   return (
@@ -53,7 +50,7 @@ function VariationsTable({
         </TableRow>
       </TableHead>
       <TableBody>
-        {variations.map((variation) => {
+        {Variations.sort(variations).map((variation) => {
           return (
             <TableRow key={variation.variationId}>
               <TableCell>

--- a/components/VariationsTable.tsx
+++ b/components/VariationsTable.tsx
@@ -1,9 +1,11 @@
+import { Tooltip, Typography } from '@material-ui/core'
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import Table from '@material-ui/core/Table'
 import TableBody from '@material-ui/core/TableBody'
 import TableCell from '@material-ui/core/TableCell'
 import TableHead from '@material-ui/core/TableHead'
 import TableRow from '@material-ui/core/TableRow'
+import { withStyles } from '@material-ui/styles'
 import React from 'react'
 
 import Label from '@/components/Label'
@@ -15,6 +17,9 @@ const useStyles = makeStyles((theme: Theme) =>
     default: {
       marginLeft: theme.spacing(1),
     },
+    variation: {
+      borderBottom: '1px dashed #a3a3a3',
+    },
   }),
 )
 
@@ -25,6 +30,27 @@ function assignmentHref(variationName: string, experimentName: string, experimen
         .catch((er) => alert('Unable to set variation: ' + er))
     )()`
 }
+
+function dangerousAssignmentLink(variationName: string, experimentName: string, experimentPlatform: string) {
+  return {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __html: `<a href="${assignmentHref(
+      variationName,
+      experimentName,
+      experimentPlatform,
+    )}">${variationName} - ${experimentName}</a>`,
+  }
+}
+
+const HtmlTooltip = withStyles((theme) => ({
+  tooltip: {
+    backgroundColor: '#f5f5f9',
+    color: 'rgba(0, 0, 0, 0.87)',
+    maxWidth: '10dw',
+    fontSize: theme.typography.pxToRem(12),
+    border: '1px solid #dadde9',
+  },
+}))(Tooltip)
 
 /**
  * Renders the variations in tabular formation, in the order that they're given.
@@ -54,12 +80,28 @@ function VariationsTable({
           return (
             <TableRow key={variation.variationId}>
               <TableCell>
-                <a
-                  title='Drag this to your bookmarks to make it easier to switch between active variations'
-                  href={assignmentHref(variation.name, experimentName, experimentPlatform)}
+                <HtmlTooltip
+                  interactive
+                  arrow
+                  placement={'left'}
+                  title={
+                    <>
+                      <Typography color='inherit'>
+                        Drag this link to your bookmarks to make it easier to switch between active variations:
+                      </Typography>
+                      <Typography
+                        color='inherit'
+                        dangerouslySetInnerHTML={dangerousAssignmentLink(
+                          variation.name,
+                          experimentName,
+                          experimentPlatform,
+                        )}
+                      />
+                    </>
+                  }
                 >
-                  {variation.name}
-                </a>
+                  <span className={classes.variation}>{variation.name}</span>
+                </HtmlTooltip>
                 {variation.isDefault && <Label className={classes.default} text='Default' />}
               </TableCell>
               <TableCell>{variation.allocatedPercentage}%</TableCell>

--- a/components/VariationsTable.tsx
+++ b/components/VariationsTable.tsx
@@ -44,11 +44,12 @@ function dangerousAssignmentLink(variationName: string, experimentName: string, 
 
 const HtmlTooltip = withStyles((theme) => ({
   tooltip: {
-    backgroundColor: '#f5f5f9',
-    color: 'rgba(0, 0, 0, 0.87)',
-    maxWidth: '10dw',
-    fontSize: theme.typography.pxToRem(12),
+    maxWidth: '500px',
     border: '1px solid #dadde9',
+    padding: theme.spacing(2),
+    '& a:link': {
+      color: '#cee6f8',
+    },
   },
 }))(Tooltip)
 
@@ -86,11 +87,12 @@ function VariationsTable({
                   placement={'left'}
                   title={
                     <>
-                      <Typography color='inherit'>
+                      <Typography color='inherit' variant='body1' gutterBottom>
                         Drag this link to your bookmarks to make it easier to switch between active variations:
                       </Typography>
                       <Typography
                         color='inherit'
+                        variant='body1'
                         dangerouslySetInnerHTML={dangerousAssignmentLink(
                           variation.name,
                           experimentName,

--- a/components/VariationsTable.tsx
+++ b/components/VariationsTable.tsx
@@ -57,7 +57,12 @@ function VariationsTable({
           return (
             <TableRow key={variation.variationId}>
               <TableCell>
-                <a href={assignmentHref(variation.name, experimentName, experimentPlatform)}>{variation.name}</a>
+                <a
+                  title='Drag this to your bookmarks to make it easier to switch between active variations'
+                  href={assignmentHref(variation.name, experimentName, experimentPlatform)}
+                >
+                  {variation.name}
+                </a>
                 {variation.isDefault && <Label className={classes.default} text='Default' />}
               </TableCell>
               <TableCell>{variation.allocatedPercentage}%</TableCell>

--- a/components/VariationsTable.tsx
+++ b/components/VariationsTable.tsx
@@ -17,12 +17,28 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 )
 
+function assignmentHref(variationName: string, experimentName: string, experimentPlatform: string) {
+  return `javascript:(() => 
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/${experimentPlatform}?${experimentName}=${variationName}', {credentials: 'include'})
+        .then(() => alert('Successfully set ${experimentName} to variation ${variationName}'))
+        .catch((er) => alert('Unable to set variation: ' + er))
+    )()`
+}
+
 /**
  * Renders the variations in tabular formation, in the order that they're given.
  *
  * @param props.variations - The variations to render.
  */
-function VariationsTable({ variations }: { variations: Variation[] }) {
+function VariationsTable({
+  variations,
+  experimentName,
+  experimentPlatform,
+}: {
+  variations: Variation[]
+  experimentName: string
+  experimentPlatform: string
+}) {
   const classes = useStyles()
   return (
     <Table>
@@ -41,7 +57,7 @@ function VariationsTable({ variations }: { variations: Variation[] }) {
           return (
             <TableRow key={variation.variationId}>
               <TableCell>
-                {variation.name}
+                <a href={assignmentHref(variation.name, experimentName, experimentPlatform)}>{variation.name}</a>
                 {variation.isDefault && <Label className={classes.default} text='Default' />}
               </TableCell>
               <TableCell>{variation.allocatedPercentage}%</TableCell>

--- a/components/VariationsTable.tsx
+++ b/components/VariationsTable.tsx
@@ -9,7 +9,7 @@ import { withStyles } from '@material-ui/styles'
 import React from 'react'
 
 import Label from '@/components/Label'
-import { ExperimentFull } from '@/lib/schemas'
+import { ExperimentFull, nameSchema } from '@/lib/schemas'
 import * as Variations from '@/lib/variations'
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -24,9 +24,16 @@ const useStyles = makeStyles((theme: Theme) =>
 )
 
 function assignmentHref(variationName: string, experimentName: string, experimentPlatform: string) {
+  nameSchema.validateSync(variationName)
+  nameSchema.validateSync(experimentName)
+  nameSchema.validateSync(experimentPlatform)
   return `javascript:(() => 
-        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/${experimentPlatform}?${experimentName}=${variationName}', {credentials: 'include'})
-        .then(() => alert('Successfully set ${experimentName} to variation ${variationName}'))
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/${encodeURIComponent(
+          experimentPlatform,
+        )}?${encodeURIComponent(experimentName)}=${encodeURIComponent(variationName)}', {credentials: 'include'})
+        .then(() => alert('Successfully set ' + decodeURIComponent('${encodeURIComponent(
+          experimentName,
+        )}') + ' to variation ' + decodeURIComponent('${encodeURIComponent(variationName)}')))
         .catch((er) => alert('Unable to set variation: ' + er))
     )()`
 }

--- a/components/__snapshots__/AudiencePanel.test.tsx.snap
+++ b/components/__snapshots__/AudiencePanel.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Empty array shows no exposure events 1`] = `
       class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
     >
       <h3
-        class="MuiTypography-root makeStyles-title-22 MuiTypography-h3 MuiTypography-colorTextPrimary"
+        class="MuiTypography-root makeStyles-title-28 MuiTypography-h3 MuiTypography-colorTextPrimary"
       >
         Audience
       </h3>
@@ -99,18 +99,13 @@ exports[`Empty array shows no exposure events 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    <a
-                      href="javascript:(() => 
-        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=control', {credentials: 'include'})
-        .then(() => alert('Successfully set experiment_1 to variation control'))
-        .catch((er) => alert('Unable to set variation: ' + er))
-    )()"
-                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    <span
+                      class="makeStyles-variation-38"
                     >
                       control
-                    </a>
+                    </span>
                     <span
-                      class="makeStyles-default-29 makeStyles-root-30"
+                      class="makeStyles-default-37 makeStyles-root-40"
                     >
                       Default
                     </span>
@@ -128,16 +123,11 @@ exports[`Empty array shows no exposure events 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    <a
-                      href="javascript:(() => 
-        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=test', {credentials: 'include'})
-        .then(() => alert('Successfully set experiment_1 to variation test'))
-        .catch((er) => alert('Unable to set variation: ' + er))
-    )()"
-                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    <span
+                      class="makeStyles-variation-38"
                     >
                       test
-                    </a>
+                    </span>
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
@@ -247,7 +237,7 @@ exports[`Empty array shows no exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <div
-              class="makeStyles-eventList-34"
+              class="makeStyles-eventList-44"
             >
               <p
                 class="MuiTypography-root MuiTypography-body1"
@@ -272,7 +262,7 @@ exports[`Shows exposure events 1`] = `
       class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
     >
       <h3
-        class="MuiTypography-root makeStyles-title-22 MuiTypography-h3 MuiTypography-colorTextPrimary"
+        class="MuiTypography-root makeStyles-title-28 MuiTypography-h3 MuiTypography-colorTextPrimary"
       >
         Audience
       </h3>
@@ -362,18 +352,13 @@ exports[`Shows exposure events 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    <a
-                      href="javascript:(() => 
-        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=control', {credentials: 'include'})
-        .then(() => alert('Successfully set experiment_1 to variation control'))
-        .catch((er) => alert('Unable to set variation: ' + er))
-    )()"
-                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    <span
+                      class="makeStyles-variation-30"
                     >
                       control
-                    </a>
+                    </span>
                     <span
-                      class="makeStyles-default-23 makeStyles-root-24"
+                      class="makeStyles-default-29 makeStyles-root-32"
                     >
                       Default
                     </span>
@@ -391,16 +376,11 @@ exports[`Shows exposure events 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    <a
-                      href="javascript:(() => 
-        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=test', {credentials: 'include'})
-        .then(() => alert('Successfully set experiment_1 to variation test'))
-        .catch((er) => alert('Unable to set variation: ' + er))
-    )()"
-                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    <span
+                      class="makeStyles-variation-30"
                     >
                       test
-                    </a>
+                    </span>
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
@@ -510,18 +490,18 @@ exports[`Shows exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <div
-              class="makeStyles-eventList-28"
+              class="makeStyles-eventList-36"
             >
               <p
                 class="MuiTypography-root MuiTypography-body1"
               >
                 <span
-                  class="makeStyles-eventName-27"
+                  class="makeStyles-eventName-35"
                 >
                   test
                 </span>
                 <span
-                  class="makeStyles-entry-26"
+                  class="makeStyles-entry-34"
                 >
                   prop1
                   : 
@@ -546,7 +526,7 @@ exports[`null shows no exposure events 1`] = `
       class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
     >
       <h3
-        class="MuiTypography-root makeStyles-title-22 MuiTypography-h3 MuiTypography-colorTextPrimary"
+        class="MuiTypography-root makeStyles-title-28 MuiTypography-h3 MuiTypography-colorTextPrimary"
       >
         Audience
       </h3>
@@ -636,18 +616,13 @@ exports[`null shows no exposure events 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    <a
-                      href="javascript:(() => 
-        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=control', {credentials: 'include'})
-        .then(() => alert('Successfully set experiment_1 to variation control'))
-        .catch((er) => alert('Unable to set variation: ' + er))
-    )()"
-                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    <span
+                      class="makeStyles-variation-46"
                     >
                       control
-                    </a>
+                    </span>
                     <span
-                      class="makeStyles-default-35 makeStyles-root-36"
+                      class="makeStyles-default-45 makeStyles-root-48"
                     >
                       Default
                     </span>
@@ -665,16 +640,11 @@ exports[`null shows no exposure events 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    <a
-                      href="javascript:(() => 
-        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=test', {credentials: 'include'})
-        .then(() => alert('Successfully set experiment_1 to variation test'))
-        .catch((er) => alert('Unable to set variation: ' + er))
-    )()"
-                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    <span
+                      class="makeStyles-variation-46"
                     >
                       test
-                    </a>
+                    </span>
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
@@ -784,7 +754,7 @@ exports[`null shows no exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <div
-              class="makeStyles-eventList-40"
+              class="makeStyles-eventList-52"
             >
               <p
                 class="MuiTypography-root MuiTypography-body1"
@@ -809,7 +779,7 @@ exports[`renders as expected with all segments resolvable 1`] = `
       class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
     >
       <h3
-        class="MuiTypography-root makeStyles-title-15 MuiTypography-h3 MuiTypography-colorTextPrimary"
+        class="MuiTypography-root makeStyles-title-19 MuiTypography-h3 MuiTypography-colorTextPrimary"
       >
         Audience
       </h3>
@@ -899,18 +869,13 @@ exports[`renders as expected with all segments resolvable 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    <a
-                      href="javascript:(() => 
-        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=control', {credentials: 'include'})
-        .then(() => alert('Successfully set experiment_1 to variation control'))
-        .catch((er) => alert('Unable to set variation: ' + er))
-    )()"
-                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    <span
+                      class="makeStyles-variation-21"
                     >
                       control
-                    </a>
+                    </span>
                     <span
-                      class="makeStyles-default-16 makeStyles-root-17"
+                      class="makeStyles-default-20 makeStyles-root-23"
                     >
                       Default
                     </span>
@@ -928,16 +893,11 @@ exports[`renders as expected with all segments resolvable 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    <a
-                      href="javascript:(() => 
-        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=test', {credentials: 'include'})
-        .then(() => alert('Successfully set experiment_1 to variation test'))
-        .catch((er) => alert('Unable to set variation: ' + er))
-    )()"
-                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    <span
+                      class="makeStyles-variation-21"
                     >
                       test
-                    </a>
+                    </span>
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
@@ -1001,7 +961,7 @@ exports[`renders as expected with all segments resolvable 1`] = `
                   >
                     segment_3
                     <span
-                      class="makeStyles-excluded-18 makeStyles-root-17"
+                      class="makeStyles-excluded-24 makeStyles-root-23"
                     >
                       Excluded
                     </span>
@@ -1038,7 +998,7 @@ exports[`renders as expected with all segments resolvable 1`] = `
                   >
                     segment_2
                     <span
-                      class="makeStyles-excluded-18 makeStyles-root-17"
+                      class="makeStyles-excluded-24 makeStyles-root-23"
                     >
                       Excluded
                     </span>
@@ -1071,7 +1031,7 @@ exports[`renders as expected with all segments resolvable 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <div
-              class="makeStyles-eventList-21"
+              class="makeStyles-eventList-27"
             >
               <p
                 class="MuiTypography-root MuiTypography-body1"
@@ -1096,7 +1056,7 @@ exports[`renders as expected with existing users allowed 1`] = `
       class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
     >
       <h3
-        class="MuiTypography-root makeStyles-title-8 MuiTypography-h3 MuiTypography-colorTextPrimary"
+        class="MuiTypography-root makeStyles-title-10 MuiTypography-h3 MuiTypography-colorTextPrimary"
       >
         Audience
       </h3>
@@ -1186,18 +1146,13 @@ exports[`renders as expected with existing users allowed 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    <a
-                      href="javascript:(() => 
-        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=control', {credentials: 'include'})
-        .then(() => alert('Successfully set experiment_1 to variation control'))
-        .catch((er) => alert('Unable to set variation: ' + er))
-    )()"
-                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    <span
+                      class="makeStyles-variation-12"
                     >
                       control
-                    </a>
+                    </span>
                     <span
-                      class="makeStyles-default-9 makeStyles-root-10"
+                      class="makeStyles-default-11 makeStyles-root-14"
                     >
                       Default
                     </span>
@@ -1215,16 +1170,11 @@ exports[`renders as expected with existing users allowed 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    <a
-                      href="javascript:(() => 
-        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=test', {credentials: 'include'})
-        .then(() => alert('Successfully set experiment_1 to variation test'))
-        .catch((er) => alert('Unable to set variation: ' + er))
-    )()"
-                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    <span
+                      class="makeStyles-variation-12"
                     >
                       test
-                    </a>
+                    </span>
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
@@ -1334,7 +1284,7 @@ exports[`renders as expected with existing users allowed 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <div
-              class="makeStyles-eventList-14"
+              class="makeStyles-eventList-18"
             >
               <p
                 class="MuiTypography-root MuiTypography-body1"
@@ -1449,18 +1399,13 @@ exports[`renders as expected with no segment assignments 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    <a
-                      href="javascript:(() => 
-        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=control', {credentials: 'include'})
-        .then(() => alert('Successfully set experiment_1 to variation control'))
-        .catch((er) => alert('Unable to set variation: ' + er))
-    )()"
-                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    <span
+                      class="makeStyles-variation-3"
                     >
                       control
-                    </a>
+                    </span>
                     <span
-                      class="makeStyles-default-2 makeStyles-root-3"
+                      class="makeStyles-default-2 makeStyles-root-5"
                     >
                       Default
                     </span>
@@ -1478,16 +1423,11 @@ exports[`renders as expected with no segment assignments 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    <a
-                      href="javascript:(() => 
-        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=test', {credentials: 'include'})
-        .then(() => alert('Successfully set experiment_1 to variation test'))
-        .catch((er) => alert('Unable to set variation: ' + er))
-    )()"
-                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    <span
+                      class="makeStyles-variation-3"
                     >
                       test
-                    </a>
+                    </span>
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
@@ -1597,7 +1537,7 @@ exports[`renders as expected with no segment assignments 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <div
-              class="makeStyles-eventList-7"
+              class="makeStyles-eventList-9"
             >
               <p
                 class="MuiTypography-root MuiTypography-body1"

--- a/components/__snapshots__/AudiencePanel.test.tsx.snap
+++ b/components/__snapshots__/AudiencePanel.test.tsx.snap
@@ -99,7 +99,16 @@ exports[`Empty array shows no exposure events 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    control
+                    <a
+                      href="javascript:(() => 
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=control', {credentials: 'include'})
+        .then(() => alert('Successfully set experiment_1 to variation control'))
+        .catch((er) => alert('Unable to set variation: ' + er))
+    )()"
+                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    >
+                      control
+                    </a>
                     <span
                       class="makeStyles-default-29 makeStyles-root-30"
                     >
@@ -119,7 +128,16 @@ exports[`Empty array shows no exposure events 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    test
+                    <a
+                      href="javascript:(() => 
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=test', {credentials: 'include'})
+        .then(() => alert('Successfully set experiment_1 to variation test'))
+        .catch((er) => alert('Unable to set variation: ' + er))
+    )()"
+                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    >
+                      test
+                    </a>
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
@@ -344,7 +362,16 @@ exports[`Shows exposure events 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    control
+                    <a
+                      href="javascript:(() => 
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=control', {credentials: 'include'})
+        .then(() => alert('Successfully set experiment_1 to variation control'))
+        .catch((er) => alert('Unable to set variation: ' + er))
+    )()"
+                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    >
+                      control
+                    </a>
                     <span
                       class="makeStyles-default-23 makeStyles-root-24"
                     >
@@ -364,7 +391,16 @@ exports[`Shows exposure events 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    test
+                    <a
+                      href="javascript:(() => 
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=test', {credentials: 'include'})
+        .then(() => alert('Successfully set experiment_1 to variation test'))
+        .catch((er) => alert('Unable to set variation: ' + er))
+    )()"
+                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    >
+                      test
+                    </a>
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
@@ -600,7 +636,16 @@ exports[`null shows no exposure events 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    control
+                    <a
+                      href="javascript:(() => 
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=control', {credentials: 'include'})
+        .then(() => alert('Successfully set experiment_1 to variation control'))
+        .catch((er) => alert('Unable to set variation: ' + er))
+    )()"
+                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    >
+                      control
+                    </a>
                     <span
                       class="makeStyles-default-35 makeStyles-root-36"
                     >
@@ -620,7 +665,16 @@ exports[`null shows no exposure events 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    test
+                    <a
+                      href="javascript:(() => 
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=test', {credentials: 'include'})
+        .then(() => alert('Successfully set experiment_1 to variation test'))
+        .catch((er) => alert('Unable to set variation: ' + er))
+    )()"
+                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    >
+                      test
+                    </a>
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
@@ -845,7 +899,16 @@ exports[`renders as expected with all segments resolvable 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    control
+                    <a
+                      href="javascript:(() => 
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=control', {credentials: 'include'})
+        .then(() => alert('Successfully set experiment_1 to variation control'))
+        .catch((er) => alert('Unable to set variation: ' + er))
+    )()"
+                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    >
+                      control
+                    </a>
                     <span
                       class="makeStyles-default-16 makeStyles-root-17"
                     >
@@ -865,7 +928,16 @@ exports[`renders as expected with all segments resolvable 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    test
+                    <a
+                      href="javascript:(() => 
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=test', {credentials: 'include'})
+        .then(() => alert('Successfully set experiment_1 to variation test'))
+        .catch((er) => alert('Unable to set variation: ' + er))
+    )()"
+                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    >
+                      test
+                    </a>
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
@@ -1114,7 +1186,16 @@ exports[`renders as expected with existing users allowed 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    control
+                    <a
+                      href="javascript:(() => 
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=control', {credentials: 'include'})
+        .then(() => alert('Successfully set experiment_1 to variation control'))
+        .catch((er) => alert('Unable to set variation: ' + er))
+    )()"
+                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    >
+                      control
+                    </a>
                     <span
                       class="makeStyles-default-9 makeStyles-root-10"
                     >
@@ -1134,7 +1215,16 @@ exports[`renders as expected with existing users allowed 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    test
+                    <a
+                      href="javascript:(() => 
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=test', {credentials: 'include'})
+        .then(() => alert('Successfully set experiment_1 to variation test'))
+        .catch((er) => alert('Unable to set variation: ' + er))
+    )()"
+                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    >
+                      test
+                    </a>
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
@@ -1359,7 +1449,16 @@ exports[`renders as expected with no segment assignments 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    control
+                    <a
+                      href="javascript:(() => 
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=control', {credentials: 'include'})
+        .then(() => alert('Successfully set experiment_1 to variation control'))
+        .catch((er) => alert('Unable to set variation: ' + er))
+    )()"
+                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    >
+                      control
+                    </a>
                     <span
                       class="makeStyles-default-2 makeStyles-root-3"
                     >
@@ -1379,7 +1478,16 @@ exports[`renders as expected with no segment assignments 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body"
                   >
-                    test
+                    <a
+                      href="javascript:(() => 
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=test', {credentials: 'include'})
+        .then(() => alert('Successfully set experiment_1 to variation test'))
+        .catch((er) => alert('Unable to set variation: ' + er))
+    )()"
+                      title="Drag this to your bookmarks to make it easier to switch between active variations"
+                    >
+                      test
+                    </a>
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body"

--- a/components/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/components/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -466,16 +466,11 @@ exports[`renders as expected at large width 1`] = `
                       <td
                         class="MuiTableCell-root MuiTableCell-body"
                       >
-                        <a
-                          href="javascript:(() => 
-        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=control', {credentials: 'include'})
-        .then(() => alert('Successfully set experiment_1 to variation control'))
-        .catch((er) => alert('Unable to set variation: ' + er))
-    )()"
-                          title="Drag this to your bookmarks to make it easier to switch between active variations"
+                        <span
+                          class="makeStyles-variation-20"
                         >
                           control
-                        </a>
+                        </span>
                         <span
                           class="makeStyles-default-19 makeStyles-root-17"
                         >
@@ -495,16 +490,11 @@ exports[`renders as expected at large width 1`] = `
                       <td
                         class="MuiTableCell-root MuiTableCell-body"
                       >
-                        <a
-                          href="javascript:(() => 
-        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=test', {credentials: 'include'})
-        .then(() => alert('Successfully set experiment_1 to variation test'))
-        .catch((er) => alert('Unable to set variation: ' + er))
-    )()"
-                          title="Drag this to your bookmarks to make it easier to switch between active variations"
+                        <span
+                          class="makeStyles-variation-20"
                         >
                           test
-                        </a>
+                        </span>
                       </td>
                       <td
                         class="MuiTableCell-root MuiTableCell-body"
@@ -591,7 +581,7 @@ exports[`renders as expected at large width 1`] = `
                       >
                         segment_2
                         <span
-                          class="makeStyles-excluded-20 makeStyles-root-17"
+                          class="makeStyles-excluded-22 makeStyles-root-17"
                         >
                           Excluded
                         </span>
@@ -615,7 +605,7 @@ exports[`renders as expected at large width 1`] = `
                 class="MuiTableCell-root MuiTableCell-body"
               >
                 <div
-                  class="makeStyles-eventList-23"
+                  class="makeStyles-eventList-25"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -654,7 +644,7 @@ exports[`renders as expected at small width 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-25 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-27 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 General
               </h3>
@@ -741,10 +731,10 @@ exports[`renders as expected at small width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-28"
+                      class="makeStyles-root-30"
                     >
                       <span
-                        class="makeStyles-statusDot-33 makeStyles-staging-31"
+                        class="makeStyles-statusDot-35 makeStyles-staging-33"
                       />
                        
                       staging
@@ -765,18 +755,18 @@ exports[`renders as expected at small width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-34"
+                      class="makeStyles-root-36"
                       title="20/09/2020, 20:00:00"
                     >
                       2020-09-21
                     </span>
                     <span
-                      class="makeStyles-to-24"
+                      class="makeStyles-to-26"
                     >
                       to
                     </span>
                     <span
-                      class="makeStyles-root-34"
+                      class="makeStyles-root-36"
                       title="20/11/2020, 20:00:00"
                     >
                       2020-11-21
@@ -813,7 +803,7 @@ exports[`renders as expected at small width 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-41 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-43 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Audience
               </h3>
@@ -903,18 +893,13 @@ exports[`renders as expected at small width 1`] = `
                           <td
                             class="MuiTableCell-root MuiTableCell-body"
                           >
-                            <a
-                              href="javascript:(() => 
-        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=control', {credentials: 'include'})
-        .then(() => alert('Successfully set experiment_1 to variation control'))
-        .catch((er) => alert('Unable to set variation: ' + er))
-    )()"
-                              title="Drag this to your bookmarks to make it easier to switch between active variations"
+                            <span
+                              class="makeStyles-variation-45"
                             >
                               control
-                            </a>
+                            </span>
                             <span
-                              class="makeStyles-default-42 makeStyles-root-40"
+                              class="makeStyles-default-44 makeStyles-root-42"
                             >
                               Default
                             </span>
@@ -932,16 +917,11 @@ exports[`renders as expected at small width 1`] = `
                           <td
                             class="MuiTableCell-root MuiTableCell-body"
                           >
-                            <a
-                              href="javascript:(() => 
-        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=test', {credentials: 'include'})
-        .then(() => alert('Successfully set experiment_1 to variation test'))
-        .catch((er) => alert('Unable to set variation: ' + er))
-    )()"
-                              title="Drag this to your bookmarks to make it easier to switch between active variations"
+                            <span
+                              class="makeStyles-variation-45"
                             >
                               test
-                            </a>
+                            </span>
                           </td>
                           <td
                             class="MuiTableCell-root MuiTableCell-body"
@@ -1028,7 +1008,7 @@ exports[`renders as expected at small width 1`] = `
                           >
                             segment_2
                             <span
-                              class="makeStyles-excluded-43 makeStyles-root-40"
+                              class="makeStyles-excluded-47 makeStyles-root-42"
                             >
                               Excluded
                             </span>
@@ -1052,7 +1032,7 @@ exports[`renders as expected at small width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <div
-                      class="makeStyles-eventList-46"
+                      class="makeStyles-eventList-50"
                     >
                       <p
                         class="MuiTypography-root MuiTypography-body1"
@@ -1076,7 +1056,7 @@ exports[`renders as expected at small width 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-36 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-38 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Metrics
               </h3>
@@ -1155,7 +1135,7 @@ exports[`renders as expected at small width 1`] = `
                   >
                     metric_1
                     <span
-                      class="makeStyles-primary-35 makeStyles-root-40"
+                      class="makeStyles-primary-37 makeStyles-root-42"
                     >
                       Primary
                     </span>
@@ -1287,7 +1267,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-48 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-52 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 General
               </h3>
@@ -1374,10 +1354,10 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-51"
+                      class="makeStyles-root-55"
                     >
                       <span
-                        class="makeStyles-statusDot-56 makeStyles-disabled-55"
+                        class="makeStyles-statusDot-60 makeStyles-disabled-59"
                       />
                        
                       disabled
@@ -1398,18 +1378,18 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-57"
+                      class="makeStyles-root-61"
                       title="20/09/2020, 20:00:00"
                     >
                       2020-09-21
                     </span>
                     <span
-                      class="makeStyles-to-47"
+                      class="makeStyles-to-51"
                     >
                       to
                     </span>
                     <span
-                      class="makeStyles-root-57"
+                      class="makeStyles-root-61"
                       title="20/11/2020, 20:00:00"
                     >
                       2020-11-21
@@ -1446,7 +1426,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-66 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-70 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Audience
               </h3>
@@ -1536,18 +1516,13 @@ exports[`renders as expected with conclusion data 1`] = `
                           <td
                             class="MuiTableCell-root MuiTableCell-body"
                           >
-                            <a
-                              href="javascript:(() => 
-        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=control', {credentials: 'include'})
-        .then(() => alert('Successfully set experiment_1 to variation control'))
-        .catch((er) => alert('Unable to set variation: ' + er))
-    )()"
-                              title="Drag this to your bookmarks to make it easier to switch between active variations"
+                            <span
+                              class="makeStyles-variation-72"
                             >
                               control
-                            </a>
+                            </span>
                             <span
-                              class="makeStyles-default-67 makeStyles-root-63"
+                              class="makeStyles-default-71 makeStyles-root-67"
                             >
                               Default
                             </span>
@@ -1565,16 +1540,11 @@ exports[`renders as expected with conclusion data 1`] = `
                           <td
                             class="MuiTableCell-root MuiTableCell-body"
                           >
-                            <a
-                              href="javascript:(() => 
-        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=test', {credentials: 'include'})
-        .then(() => alert('Successfully set experiment_1 to variation test'))
-        .catch((er) => alert('Unable to set variation: ' + er))
-    )()"
-                              title="Drag this to your bookmarks to make it easier to switch between active variations"
+                            <span
+                              class="makeStyles-variation-72"
                             >
                               test
-                            </a>
+                            </span>
                           </td>
                           <td
                             class="MuiTableCell-root MuiTableCell-body"
@@ -1661,7 +1631,7 @@ exports[`renders as expected with conclusion data 1`] = `
                           >
                             segment_2
                             <span
-                              class="makeStyles-excluded-68 makeStyles-root-63"
+                              class="makeStyles-excluded-74 makeStyles-root-67"
                             >
                               Excluded
                             </span>
@@ -1685,7 +1655,7 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <div
-                      class="makeStyles-eventList-71"
+                      class="makeStyles-eventList-77"
                     >
                       <p
                         class="MuiTypography-root MuiTypography-body1"
@@ -1709,7 +1679,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-59 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-63 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Metrics
               </h3>
@@ -1788,7 +1758,7 @@ exports[`renders as expected with conclusion data 1`] = `
                   >
                     metric_1
                     <span
-                      class="makeStyles-primary-58 makeStyles-root-63"
+                      class="makeStyles-primary-62 makeStyles-root-67"
                     >
                       Primary
                     </span>
@@ -1903,7 +1873,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-64 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-68 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Conclusions
               </h3>
@@ -2023,7 +1993,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-73 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-79 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 General
               </h3>
@@ -2110,10 +2080,10 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-76"
+                      class="makeStyles-root-82"
                     >
                       <span
-                        class="makeStyles-statusDot-81 makeStyles-staging-79"
+                        class="makeStyles-statusDot-87 makeStyles-staging-85"
                       />
                        
                       staging
@@ -2134,18 +2104,18 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-82"
+                      class="makeStyles-root-88"
                       title="20/09/2020, 20:00:00"
                     >
                       2020-09-21
                     </span>
                     <span
-                      class="makeStyles-to-72"
+                      class="makeStyles-to-78"
                     >
                       to
                     </span>
                     <span
-                      class="makeStyles-root-82"
+                      class="makeStyles-root-88"
                       title="20/11/2020, 20:00:00"
                     >
                       2020-11-21
@@ -2182,7 +2152,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-89 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-95 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Audience
               </h3>
@@ -2272,18 +2242,13 @@ exports[`renders as expected without conclusion data 1`] = `
                           <td
                             class="MuiTableCell-root MuiTableCell-body"
                           >
-                            <a
-                              href="javascript:(() => 
-        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=control', {credentials: 'include'})
-        .then(() => alert('Successfully set experiment_1 to variation control'))
-        .catch((er) => alert('Unable to set variation: ' + er))
-    )()"
-                              title="Drag this to your bookmarks to make it easier to switch between active variations"
+                            <span
+                              class="makeStyles-variation-97"
                             >
                               control
-                            </a>
+                            </span>
                             <span
-                              class="makeStyles-default-90 makeStyles-root-88"
+                              class="makeStyles-default-96 makeStyles-root-94"
                             >
                               Default
                             </span>
@@ -2301,16 +2266,11 @@ exports[`renders as expected without conclusion data 1`] = `
                           <td
                             class="MuiTableCell-root MuiTableCell-body"
                           >
-                            <a
-                              href="javascript:(() => 
-        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=test', {credentials: 'include'})
-        .then(() => alert('Successfully set experiment_1 to variation test'))
-        .catch((er) => alert('Unable to set variation: ' + er))
-    )()"
-                              title="Drag this to your bookmarks to make it easier to switch between active variations"
+                            <span
+                              class="makeStyles-variation-97"
                             >
                               test
-                            </a>
+                            </span>
                           </td>
                           <td
                             class="MuiTableCell-root MuiTableCell-body"
@@ -2397,7 +2357,7 @@ exports[`renders as expected without conclusion data 1`] = `
                           >
                             segment_2
                             <span
-                              class="makeStyles-excluded-91 makeStyles-root-88"
+                              class="makeStyles-excluded-99 makeStyles-root-94"
                             >
                               Excluded
                             </span>
@@ -2421,7 +2381,7 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <div
-                      class="makeStyles-eventList-94"
+                      class="makeStyles-eventList-102"
                     >
                       <p
                         class="MuiTypography-root MuiTypography-body1"
@@ -2445,7 +2405,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-84 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-90 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Metrics
               </h3>
@@ -2524,7 +2484,7 @@ exports[`renders as expected without conclusion data 1`] = `
                   >
                     metric_1
                     <span
-                      class="makeStyles-primary-83 makeStyles-root-88"
+                      class="makeStyles-primary-89 makeStyles-root-94"
                     >
                       Primary
                     </span>

--- a/components/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/components/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -466,7 +466,16 @@ exports[`renders as expected at large width 1`] = `
                       <td
                         class="MuiTableCell-root MuiTableCell-body"
                       >
-                        control
+                        <a
+                          href="javascript:(() => 
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=control', {credentials: 'include'})
+        .then(() => alert('Successfully set experiment_1 to variation control'))
+        .catch((er) => alert('Unable to set variation: ' + er))
+    )()"
+                          title="Drag this to your bookmarks to make it easier to switch between active variations"
+                        >
+                          control
+                        </a>
                         <span
                           class="makeStyles-default-19 makeStyles-root-17"
                         >
@@ -486,7 +495,16 @@ exports[`renders as expected at large width 1`] = `
                       <td
                         class="MuiTableCell-root MuiTableCell-body"
                       >
-                        test
+                        <a
+                          href="javascript:(() => 
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=test', {credentials: 'include'})
+        .then(() => alert('Successfully set experiment_1 to variation test'))
+        .catch((er) => alert('Unable to set variation: ' + er))
+    )()"
+                          title="Drag this to your bookmarks to make it easier to switch between active variations"
+                        >
+                          test
+                        </a>
                       </td>
                       <td
                         class="MuiTableCell-root MuiTableCell-body"
@@ -885,7 +903,16 @@ exports[`renders as expected at small width 1`] = `
                           <td
                             class="MuiTableCell-root MuiTableCell-body"
                           >
-                            control
+                            <a
+                              href="javascript:(() => 
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=control', {credentials: 'include'})
+        .then(() => alert('Successfully set experiment_1 to variation control'))
+        .catch((er) => alert('Unable to set variation: ' + er))
+    )()"
+                              title="Drag this to your bookmarks to make it easier to switch between active variations"
+                            >
+                              control
+                            </a>
                             <span
                               class="makeStyles-default-42 makeStyles-root-40"
                             >
@@ -905,7 +932,16 @@ exports[`renders as expected at small width 1`] = `
                           <td
                             class="MuiTableCell-root MuiTableCell-body"
                           >
-                            test
+                            <a
+                              href="javascript:(() => 
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=test', {credentials: 'include'})
+        .then(() => alert('Successfully set experiment_1 to variation test'))
+        .catch((er) => alert('Unable to set variation: ' + er))
+    )()"
+                              title="Drag this to your bookmarks to make it easier to switch between active variations"
+                            >
+                              test
+                            </a>
                           </td>
                           <td
                             class="MuiTableCell-root MuiTableCell-body"
@@ -1500,7 +1536,16 @@ exports[`renders as expected with conclusion data 1`] = `
                           <td
                             class="MuiTableCell-root MuiTableCell-body"
                           >
-                            control
+                            <a
+                              href="javascript:(() => 
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=control', {credentials: 'include'})
+        .then(() => alert('Successfully set experiment_1 to variation control'))
+        .catch((er) => alert('Unable to set variation: ' + er))
+    )()"
+                              title="Drag this to your bookmarks to make it easier to switch between active variations"
+                            >
+                              control
+                            </a>
                             <span
                               class="makeStyles-default-67 makeStyles-root-63"
                             >
@@ -1520,7 +1565,16 @@ exports[`renders as expected with conclusion data 1`] = `
                           <td
                             class="MuiTableCell-root MuiTableCell-body"
                           >
-                            test
+                            <a
+                              href="javascript:(() => 
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=test', {credentials: 'include'})
+        .then(() => alert('Successfully set experiment_1 to variation test'))
+        .catch((er) => alert('Unable to set variation: ' + er))
+    )()"
+                              title="Drag this to your bookmarks to make it easier to switch between active variations"
+                            >
+                              test
+                            </a>
                           </td>
                           <td
                             class="MuiTableCell-root MuiTableCell-body"
@@ -2218,7 +2272,16 @@ exports[`renders as expected without conclusion data 1`] = `
                           <td
                             class="MuiTableCell-root MuiTableCell-body"
                           >
-                            control
+                            <a
+                              href="javascript:(() => 
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=control', {credentials: 'include'})
+        .then(() => alert('Successfully set experiment_1 to variation control'))
+        .catch((er) => alert('Unable to set variation: ' + er))
+    )()"
+                              title="Drag this to your bookmarks to make it easier to switch between active variations"
+                            >
+                              control
+                            </a>
                             <span
                               class="makeStyles-default-90 makeStyles-root-88"
                             >
@@ -2238,7 +2301,16 @@ exports[`renders as expected without conclusion data 1`] = `
                           <td
                             class="MuiTableCell-root MuiTableCell-body"
                           >
-                            test
+                            <a
+                              href="javascript:(() => 
+        fetch('https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?experiment_1=test', {credentials: 'include'})
+        .then(() => alert('Successfully set experiment_1 to variation test'))
+        .catch((er) => alert('Unable to set variation: ' + er))
+    )()"
+                              title="Drag this to your bookmarks to make it easier to switch between active variations"
+                            >
+                              test
+                            </a>
                           </td>
                           <td
                             class="MuiTableCell-root MuiTableCell-body"

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -6,7 +6,7 @@ import _ from 'lodash'
 import * as yup from 'yup'
 
 const idSchema = yup.number().integer().positive()
-const nameSchema = yup
+export const nameSchema = yup
   .string()
   .max(128)
   .matches(/^[a-z][a-z0-9_]*[a-z0-9]$/, 'This field must use a basic snake_case.')


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

closes #285 

This makes the variations into links that can be dragged to your bookmarks along with a helpful title. It uses an `alert()` to notify the user that the variation was set successfully.

## How has this been tested?

Snapshots and manual testing in browser.