### PR TITLE
Eliminate console warnings when running tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
                 command: npm run lint
             - run:
                 name: Unit Testing
-                command: npm run test:unit -- -- --ci --maxWorkers 2
+                command: npm run test:unit -- -- --ci --runInBand
             - run:
                 name: Integration Testing
                 command: npm run test:integration -- --ci

--- a/components/GeneralPanel.test.tsx
+++ b/components/GeneralPanel.test.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/require-await */
-import { act, fireEvent, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react'
+import { fireEvent, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react'
 import { noop } from 'lodash'
 import MockDate from 'mockdate'
 import * as notistack from 'notistack'
@@ -198,6 +197,7 @@ test('opens, submits and cancels edit dialog with running experiment', async () 
   mockedExperimentsApi.patch.mockReset()
   // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
   // @ts-ignore
+  // eslint-disable-next-line @typescript-eslint/require-await
   mockedExperimentsApi.patch.mockImplementationOnce(async () => experiment)
 
   const editButton = screen.getByRole('button', { name: /Edit/ })
@@ -205,12 +205,10 @@ test('opens, submits and cancels edit dialog with running experiment', async () 
 
   await waitFor(() => screen.getByRole('button', { name: /Save/ }))
 
-  changeFieldByRole('textbox', /Experiment description/, 'Edited description.')
+  await changeFieldByRole('textbox', /Experiment description/, 'Edited description.')
   // This date was picked as it is after the fixture start date.
-  await act(async () => {
-    fireEvent.change(screen.getByLabelText(/End date/), { target: { value: '2020-10-20' } })
-  })
-  changeFieldByRole('textbox', /Owner/, 'changed_test_a11n')
+  fireEvent.change(screen.getByLabelText(/End date/), { target: { value: '2020-10-20' } })
+  await changeFieldByRole('textbox', /Owner/, 'changed_test_a11n')
 
   const saveButton = screen.getByRole('button', { name: /Save/ })
   fireEvent.click(saveButton)
@@ -256,6 +254,7 @@ test('checks edit dialog does not allow end datetime changes with disabled exper
   mockedExperimentsApi.patch.mockReset()
   // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
   // @ts-ignore
+  // eslint-disable-next-line @typescript-eslint/require-await
   mockedExperimentsApi.patch.mockImplementationOnce(async () => experiment)
 
   const editButton = screen.getByRole('button', { name: /Edit/ })
@@ -263,9 +262,9 @@ test('checks edit dialog does not allow end datetime changes with disabled exper
 
   await waitFor(() => screen.getByRole('button', { name: /Save/ }))
 
-  changeFieldByRole('textbox', /Experiment description/, 'Edited description.')
+  await changeFieldByRole('textbox', /Experiment description/, 'Edited description.')
   expect(screen.getByLabelText(/End date/)).toBeDisabled()
-  changeFieldByRole('textbox', /Owner/, 'changed_test_a11n')
+  await changeFieldByRole('textbox', /Owner/, 'changed_test_a11n')
 
   const saveButton = screen.getByRole('button', { name: /Save/ })
   fireEvent.click(saveButton)

--- a/components/experiment-creation/BasicInfo.test.tsx
+++ b/components/experiment-creation/BasicInfo.test.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable no-irregular-whitespace */
-import { act, fireEvent, getByLabelText, render } from '@testing-library/react'
+import { fireEvent, getByLabelText, render } from '@testing-library/react'
 import MockDate from 'mockdate'
 import React from 'react'
 
@@ -21,24 +20,22 @@ test('renders as expected', () => {
 test('renders sensible dates as expected', () => {
   MockDate.set('2020-07-21')
   const { container } = render(
-    <MockFormik>
+    <MockFormik initialValues={{ experiment: { startDatetime: '', endDatetime: '' } }}>
       <BasicInfo />
     </MockFormik>,
   )
   const startDateInput = getByLabelText(container, /Start date/)
   const endDateInput = getByLabelText(container, /End date/)
 
-  act(() => {
-    fireEvent.change(startDateInput, { target: { value: '2020-07-28' } })
-    fireEvent.change(endDateInput, { target: { value: '2020-10-28' } })
-  })
+  fireEvent.change(startDateInput, { target: { value: '2020-07-28' } })
+  fireEvent.change(endDateInput, { target: { value: '2020-10-28' } })
   expect(container).toMatchSnapshot()
 })
 
 test('renders date validation errors as expected', () => {
   MockDate.set('2020-07-21')
   const { container } = render(
-    <MockFormik>
+    <MockFormik initialValues={{ experiment: { startDatetime: '', endDatetime: '' } }}>
       <BasicInfo />
     </MockFormik>,
   )
@@ -46,27 +43,19 @@ test('renders date validation errors as expected', () => {
   const endDateInput = getByLabelText(container, /End date/)
 
   // Start date before today
-  act(() => {
-    fireEvent.change(startDateInput, { target: { value: '2020-07-20' } })
-  })
+  fireEvent.change(startDateInput, { target: { value: '2020-07-20' } })
   expect(container).toMatchSnapshot()
 
   // Start date too far into the future
-  act(() => {
-    fireEvent.change(startDateInput, { target: { value: '2025-07-20' } })
-  })
+  fireEvent.change(startDateInput, { target: { value: '2025-07-20' } })
   expect(container).toMatchSnapshot()
 
   // End date before start date
-  act(() => {
-    fireEvent.change(startDateInput, { target: { value: '2020-07-28' } })
-    fireEvent.change(endDateInput, { target: { value: '2020-07-20' } })
-  })
+  fireEvent.change(startDateInput, { target: { value: '2020-07-28' } })
+  fireEvent.change(endDateInput, { target: { value: '2020-07-20' } })
   expect(container).toMatchSnapshot()
 
   // End date too far into the future
-  act(() => {
-    fireEvent.change(endDateInput, { target: { value: '2025-07-21' } })
-  })
+  fireEvent.change(endDateInput, { target: { value: '2025-07-21' } })
   expect(container).toMatchSnapshot()
 })

--- a/jest.config.js
+++ b/jest.config.js
@@ -37,6 +37,7 @@ module.exports = {
     '@/(.*)': '<rootDir>/$1',
   },
   preset: 'ts-jest',
+  setupFiles: ['./test-helpers/jest-setup.ts'],
   // Adds special extended assertions to Jest, thus simplifying the tests.
   setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
   testPathIgnorePatterns: ['/__tests__/', '/e2e/', '/node_modules/'],

--- a/jest.e2e.config.js
+++ b/jest.e2e.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   preset: 'jest-puppeteer',
+  setupFiles: ['./test-helpers/jest-setup.ts'],
   testMatch: ['**/e2e/**/?(*.)+(spec|test).ts?(x)'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest',

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -33,6 +33,7 @@ module.exports = {
     '@/(.*)': '<rootDir>/$1',
   },
   preset: 'ts-jest',
+  setupFiles: ['./test-helpers/jest-setup.ts'],
   setupFilesAfterEnv: ['isomorphic-fetch'],
   testMatch: ['**/__tests__/**/?(*.)+(spec|test).ts?(x)'],
 }

--- a/test-helpers/jest-setup.ts
+++ b/test-helpers/jest-setup.ts
@@ -1,0 +1,10 @@
+import { format } from 'util'
+
+// Throw errors on any console logging.
+// Adapted from https://github.com/facebook/jest/issues/6121#issuecomment-529591574
+;['error', 'info', 'log', 'warn'].forEach((funcName) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(global.console as any)[funcName] = function (message?: any, ...optionalParams: any[]) {
+    throw new Error(format(message, optionalParams))
+  }
+})

--- a/test-helpers/test-utils.tsx
+++ b/test-helpers/test-utils.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, Queries, render as actualRender, RenderOptions, screen } from '@testing-library/react'
 import mediaQuery from 'css-mediaquery'
-import { Formik } from 'formik'
+import { Formik, FormikValues } from 'formik'
 import React from 'react'
 import { ValidationError } from 'yup'
 
@@ -46,9 +46,15 @@ export function createMatchMedia(width: number) {
 /**
  * Mock Formik for rendering Formik components when you don't care about the formik connection.
  */
-export const MockFormik = ({ children }: { children: React.ReactNode }) => {
+export const MockFormik = ({
+  children,
+  initialValues,
+}: {
+  children: React.ReactNode
+  initialValues?: FormikValues
+}) => {
   return (
-    <Formik initialValues={{}} onSubmit={() => undefined}>
+    <Formik initialValues={initialValues ?? {}} onSubmit={() => undefined}>
       {children}
     </Formik>
   )


### PR DESCRIPTION
Fix #229 by making tests fail if anything is logged to the console and fixing all the existing console warnings.

## How has this been tested?

Ran `npm run verify` before and after adding `jest-setup.ts` and fixing existing warnings, and verified that all the console warnings are gone and that the existing warnings fail the test with the new ``jest-setup.ts`.