### PR TITLE
Filter out test data

### DIFF
--- a/components/ExperimentPageView.tsx
+++ b/components/ExperimentPageView.tsx
@@ -26,7 +26,7 @@ import ExperimentDisableButton from '@/components/ExperimentDisableButton'
 import Layout from '@/components/Layout'
 import { Analysis, ExperimentFull, Status } from '@/lib/schemas'
 import { useDataLoadingError, useDataSource } from '@/utils/data-loading'
-import { createUnresolvingPromise, or } from '@/utils/general'
+import { createUnresolvingPromise, or, testDataNamePrefix } from '@/utils/general'
 
 import ExperimentRunButton from './ExperimentRunButton'
 
@@ -111,10 +111,17 @@ export default function ExperimentPageView({
   )
   useDataLoadingError(experimentError, 'Experiment')
 
-  const { isLoading: metricsIsLoading, data: metrics, error: metricsError } = useDataSource(
-    () => MetricsApi.findAll(),
-    [],
-  )
+  const { isLoading: metricsIsLoading, data: metrics, error: metricsError } = useDataSource(async () => {
+    const metrics = await MetricsApi.findAll()
+
+    // We conditionally filter debug data out here
+    // istanbul ignore if
+    if (debugMode) {
+      return metrics
+    } else {
+      return metrics.filter((metric) => !metric.name.startsWith(testDataNamePrefix))
+    }
+  }, [debugMode])
   useDataLoadingError(metricsError, 'Metrics')
 
   const { isLoading: segmentsIsLoading, data: segments, error: segmentsError } = useDataSource(

--- a/pages/experiments/index.tsx
+++ b/pages/experiments/index.tsx
@@ -1,18 +1,31 @@
 import { LinearProgress } from '@material-ui/core'
 import debugFactory from 'debug'
+import { useRouter } from 'next/router'
 import React from 'react'
 
 import ExperimentsApi from '@/api/ExperimentsApi'
 import ExperimentsTable from '@/components/ExperimentsTable'
 import Layout from '@/components/Layout'
 import { useDataLoadingError, useDataSource } from '@/utils/data-loading'
+import { testDataNamePrefix } from '@/utils/general'
 
 const debug = debugFactory('abacus:pages/experiments/index.tsx')
 
 const ExperimentsIndexPage = function () {
   debug('ExperimentsIndexPage#render')
+  const router = useRouter()
+  const debugMode = router.query.debug === 'true'
 
-  const { isLoading, data: experiments, error } = useDataSource(() => ExperimentsApi.findAll(), [])
+  const { isLoading, data: experiments, error } = useDataSource(async () => {
+    const experiments = await ExperimentsApi.findAll()
+
+    // We conditionally filter debug data out here
+    if (debugMode) {
+      return experiments
+    } else {
+      return experiments.filter((experiment) => !experiment.name.startsWith(testDataNamePrefix))
+    }
+  }, [debugMode])
 
   useDataLoadingError(error, 'Experiment')
 

--- a/pages/metrics/index.tsx
+++ b/pages/metrics/index.tsx
@@ -21,6 +21,7 @@ import MetricFormFields from '@/components/MetricFormFields'
 import MetricsTable from '@/components/MetricsTable'
 import { MetricParameterType } from '@/lib/schemas'
 import { useDataLoadingError, useDataSource } from '@/utils/data-loading'
+import { testDataNamePrefix } from '@/utils/general'
 
 const debug = debugFactory('abacus:pages/metrics/index.tsx')
 
@@ -37,12 +38,20 @@ const useStyles = makeStyles((theme: Theme) =>
 const MetricsIndexPage = () => {
   debug('MetricsIndexPage#render')
   const classes = useStyles()
-
-  const { isLoading, data: metrics, error } = useDataSource(() => MetricsApi.findAll(), [])
-  useDataLoadingError(error, 'Metrics')
-
   const router = useRouter()
   const debugMode = router.query.debug === 'true'
+
+  const { isLoading, data: metrics, error } = useDataSource(async () => {
+    const metrics = await MetricsApi.findAll()
+
+    // We conditionally filter debug data out here
+    if (debugMode) {
+      return metrics
+    } else {
+      return metrics.filter((metric) => !metric.name.startsWith(testDataNamePrefix))
+    }
+  }, [debugMode])
+  useDataLoadingError(error, 'Metrics')
 
   const { enqueueSnackbar } = useSnackbar()
 

--- a/utils/general.ts
+++ b/utils/general.ts
@@ -14,3 +14,9 @@ export function or(...xs: unknown[]) {
 export function createUnresolvingPromise<T>() {
   return new Promise<T>(() => null)
 }
+
+/**
+ * A name prefix for our test data.
+ * Mainly used to filter test data out for normal users.
+ */
+export const testDataNamePrefix = 'explat_test_'


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR filters out test data.**
- Filters out experiments and metrics starting with `explat_test_`

Resolves #320 

<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally):
  - Visit `/experiments` with and without `?debug=true`, notice the filtering of `explat_test_`
  - Visit `/metrics` with and without `?debug=true`, notice the filtering of `explat_test_`
  - Visit `/experiments/new` with and without `?debug=true`, notice the filtering of `explat_test_` of metric options
  - Visit `/experiments/20015/wizard-edit` with and without `?debug=true`, notice the filtering of `explat_test_`

