### PR TITLE
Fix some test console warnings

### DIFF
--- a/components/GeneralPanel.test.tsx
+++ b/components/GeneralPanel.test.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/require-await */
-import { act, fireEvent, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react'
+import { fireEvent, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react'
 import { noop } from 'lodash'
 import MockDate from 'mockdate'
 import * as notistack from 'notistack'
@@ -211,6 +210,7 @@ test('opens, submits and cancels edit dialog with running experiment', async () 
   mockedExperimentsApi.patch.mockReset()
   // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
   // @ts-ignore
+  // eslint-disable-next-line @typescript-eslint/require-await
   mockedExperimentsApi.patch.mockImplementationOnce(async () => experiment)
 
   const editButton = screen.getByRole('button', { name: /Edit/ })
@@ -218,12 +218,10 @@ test('opens, submits and cancels edit dialog with running experiment', async () 
 
   await waitFor(() => screen.getByRole('button', { name: /Save/ }))
 
-  changeFieldByRole('textbox', /Experiment description/, 'Edited description.')
+  await changeFieldByRole('textbox', /Experiment description/, 'Edited description.')
   // This date was picked as it is after the fixture start date.
-  await act(async () => {
-    fireEvent.change(screen.getByLabelText(/End date/), { target: { value: '2020-10-20' } })
-  })
-  changeFieldByRole('textbox', /Owner/, 'changed_test_a11n')
+  fireEvent.change(screen.getByLabelText(/End date/), { target: { value: '2020-10-20' } })
+  await changeFieldByRole('textbox', /Owner/, 'changed_test_a11n')
 
   const saveButton = screen.getByRole('button', { name: /Save/ })
   fireEvent.click(saveButton)
@@ -269,6 +267,7 @@ test('checks edit dialog does not allow end datetime changes with disabled exper
   mockedExperimentsApi.patch.mockReset()
   // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
   // @ts-ignore
+  // eslint-disable-next-line @typescript-eslint/require-await
   mockedExperimentsApi.patch.mockImplementationOnce(async () => experiment)
 
   const editButton = screen.getByRole('button', { name: /Edit/ })
@@ -276,9 +275,9 @@ test('checks edit dialog does not allow end datetime changes with disabled exper
 
   await waitFor(() => screen.getByRole('button', { name: /Save/ }))
 
-  changeFieldByRole('textbox', /Experiment description/, 'Edited description.')
+  await changeFieldByRole('textbox', /Experiment description/, 'Edited description.')
   expect(screen.getByLabelText(/End date/)).toBeDisabled()
-  changeFieldByRole('textbox', /Owner/, 'changed_test_a11n')
+  await changeFieldByRole('textbox', /Owner/, 'changed_test_a11n')
 
   const saveButton = screen.getByRole('button', { name: /Save/ })
   fireEvent.click(saveButton)

--- a/components/experiment-creation/BasicInfo.test.tsx
+++ b/components/experiment-creation/BasicInfo.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-irregular-whitespace */
 import { act, fireEvent, getByLabelText, render } from '@testing-library/react'
 import MockDate from 'mockdate'
 import React from 'react'
@@ -21,7 +20,7 @@ test('renders as expected', () => {
 test('renders sensible dates as expected', () => {
   MockDate.set('2020-07-21')
   const { container } = render(
-    <MockFormik>
+    <MockFormik initialValues={{ experiment: { startDatetime: '', endDatetime: '' } }}>
       <BasicInfo />
     </MockFormik>,
   )
@@ -38,7 +37,7 @@ test('renders sensible dates as expected', () => {
 test('renders date validation errors as expected', () => {
   MockDate.set('2020-07-21')
   const { container } = render(
-    <MockFormik>
+    <MockFormik initialValues={{ experiment: { startDatetime: '', endDatetime: '' } }}>
       <BasicInfo />
     </MockFormik>,
   )
@@ -46,15 +45,11 @@ test('renders date validation errors as expected', () => {
   const endDateInput = getByLabelText(container, /End date/)
 
   // Start date before today
-  act(() => {
-    fireEvent.change(startDateInput, { target: { value: '2020-07-20' } })
-  })
+  fireEvent.change(startDateInput, { target: { value: '2020-07-20' } })
   expect(container).toMatchSnapshot()
 
   // Start date too far into the future
-  act(() => {
-    fireEvent.change(startDateInput, { target: { value: '2025-07-20' } })
-  })
+  fireEvent.change(startDateInput, { target: { value: '2025-07-20' } })
   expect(container).toMatchSnapshot()
 
   // End date before start date
@@ -65,8 +60,6 @@ test('renders date validation errors as expected', () => {
   expect(container).toMatchSnapshot()
 
   // End date too far into the future
-  act(() => {
-    fireEvent.change(endDateInput, { target: { value: '2025-07-21' } })
-  })
+  fireEvent.change(endDateInput, { target: { value: '2025-07-21' } })
   expect(container).toMatchSnapshot()
 })

--- a/test-helpers/test-utils.tsx
+++ b/test-helpers/test-utils.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, Queries, render as actualRender, RenderOptions, screen } from '@testing-library/react'
 import mediaQuery from 'css-mediaquery'
-import { Formik } from 'formik'
+import { Formik, FormikValues } from 'formik'
 import React from 'react'
 import { ValidationError } from 'yup'
 
@@ -46,9 +46,15 @@ export function createMatchMedia(width: number) {
 /**
  * Mock Formik for rendering Formik components when you don't care about the formik connection.
  */
-export const MockFormik = ({ children }: { children: React.ReactNode }) => {
+export const MockFormik = ({
+  children,
+  initialValues = {},
+}: {
+  children: React.ReactNode
+  initialValues?: FormikValues
+}) => {
   return (
-    <Formik initialValues={{}} onSubmit={() => undefined}>
+    <Formik initialValues={initialValues} onSubmit={() => undefined}>
       {children}
     </Formik>
   )


### PR DESCRIPTION
Fix some tests console warnings (taken out from #310). 

## How has this been tested?

Ran `npm run test:unit` and verified that some console warnings were eliminated. Unfortunately, a bunch of new ones were added since #310. :disappointed: 