### PR TITLE
Add PUT to "Edit in Wizard"

### DIFF
--- a/__tests__/api/ExperimentsApi.test.ts
+++ b/__tests__/api/ExperimentsApi.test.ts
@@ -8,63 +8,64 @@ import { formatIsoDate } from '@/utils/time'
 
 MockDate.set('2020-08-13')
 
+const now = new Date()
+now.setDate(now.getDate() + 1)
+const nextWeek = new Date()
+nextWeek.setDate(now.getDate() + 7)
+
+const createRawNewExperiment = () => ({
+  p2Url: 'http://example.com/',
+  name: 'test_experiment_name',
+  description: 'experiment description',
+  startDatetime: formatIsoDate(now),
+  endDatetime: formatIsoDate(nextWeek),
+  ownerLogin: 'owner-nickname',
+  platform: 'wpcom',
+  existingUsersAllowed: 'true',
+  exposureEvents: [
+    {
+      event: 'event_name',
+      props: [
+        {
+          key: 'key',
+          value: 'value',
+        },
+      ],
+    },
+  ],
+  segmentAssignments: [
+    {
+      isExcluded: false,
+      segmentId: 3,
+    },
+  ],
+  variations: [
+    {
+      allocatedPercentage: 50,
+      isDefault: true,
+      name: 'control',
+    },
+    {
+      allocatedPercentage: 50,
+      isDefault: false,
+      name: 'treatment',
+    },
+  ],
+  metricAssignments: [
+    {
+      attributionWindowSeconds: '86400',
+      changeExpected: false,
+      isPrimary: true,
+      metricId: 10,
+      minDifference: 0.01,
+    },
+  ],
+})
+
 describe('ExperimentsApi.ts module', () => {
   describe('create', () => {
     it('should transform a new experiment into a valid outbound form', () => {
-      const now = new Date()
-      now.setDate(now.getDate() + 1)
-      const nextWeek = new Date()
-      nextWeek.setDate(now.getDate() + 7)
-      const rawNewExperiment = {
-        p2Url: 'http://example.com/',
-        name: 'test_experiment_name',
-        description: 'experiment description',
-        startDatetime: formatIsoDate(now),
-        endDatetime: formatIsoDate(nextWeek),
-        ownerLogin: 'owner-nickname',
-        platform: 'wpcom',
-        existingUsersAllowed: 'true',
-        exposureEvents: [
-          {
-            event: 'event_name',
-            props: [
-              {
-                key: 'key',
-                value: 'value',
-              },
-            ],
-          },
-        ],
-        segmentAssignments: [
-          {
-            isExcluded: false,
-            segmentId: 3,
-          },
-        ],
-        variations: [
-          {
-            allocatedPercentage: 50,
-            isDefault: true,
-            name: 'control',
-          },
-          {
-            allocatedPercentage: 50,
-            isDefault: false,
-            name: 'treatment',
-          },
-        ],
-        metricAssignments: [
-          {
-            attributionWindowSeconds: '86400',
-            changeExpected: false,
-            isPrimary: true,
-            metricId: 10,
-            minDifference: 0.01,
-          },
-        ],
-      }
-
-      const newExperiment = experimentFullNewOutboundSchema.cast(rawNewExperiment)
+      const newExperiment = experimentFullNewOutboundSchema.cast(createRawNewExperiment())
 
       expect(newExperiment).toEqual({
         description: 'experiment description',
@@ -115,71 +116,24 @@ describe('ExperimentsApi.ts module', () => {
     })
 
     it('should create a new experiment', async () => {
-      const now = new Date()
-      now.setDate(now.getDate() + 1)
-      const nextWeek = new Date()
-      nextWeek.setDate(now.getDate() + 7)
-      const rawNewExperiment = {
-        p2Url: 'http://example.com/',
-        name: 'test_experiment_name',
-        description: 'experiment description',
-        startDatetime: formatIsoDate(now),
-        endDatetime: formatIsoDate(nextWeek),
-        ownerLogin: 'owner-nickname',
-        platform: 'wpcom',
-        existingUsersAllowed: 'true',
-        exposureEvents: [
-          {
-            event: 'event_name',
-            props: [
-              {
-                key: 'key',
-                value: 'value',
-              },
-            ],
-          },
-        ],
-        segmentAssignments: [
-          {
-            isExcluded: false,
-            segmentId: 3,
-          },
-        ],
-        variations: [
-          {
-            allocatedPercentage: 50,
-            isDefault: true,
-            name: 'control',
-          },
-          {
-            allocatedPercentage: 50,
-            isDefault: false,
-            name: 'treatment',
-          },
-        ],
-        metricAssignments: [
-          {
-            attributionWindowSeconds: '86400',
-            changeExpected: false,
-            isPrimary: true,
-            metricId: 10,
-            minDifference: 0.01,
-          },
-        ],
-      }
       const returnedExperiment = await validationErrorDisplayer(
-        ExperimentsApi.create((rawNewExperiment as unknown) as ExperimentFullNew),
+        ExperimentsApi.create((createRawNewExperiment() as unknown) as ExperimentFullNew),
       )
       expect(returnedExperiment.experimentId).toBeGreaterThan(0)
     })
   })
 
+  describe('put', () => {
+    it('should put an existing experiment', async () => {
+      const returnedExperiment = await validationErrorDisplayer(
+        ExperimentsApi.put(1, (createRawNewExperiment() as unknown) as ExperimentFullNew),
+      )
+      expect(returnedExperiment.experimentId).toEqual(1)
+    })
+  })
+
   describe('patch', () => {
     it('should patch an existing experiment', async () => {
-      const now = new Date()
-      now.setDate(now.getDate() + 1)
-      const nextWeek = new Date()
-      nextWeek.setDate(now.getDate() + 7)
       const rawNewExperiment = {
         description: 'experiment description',
         endDatetime: formatIsoDate(nextWeek),

--- a/api/ExperimentsApi.ts
+++ b/api/ExperimentsApi.ts
@@ -31,6 +31,18 @@ async function create(newExperiment: ExperimentFullNew) {
 }
 
 /**
+ * Attempts to PUT an experiment, overwriting the existing experiment.
+ *
+ * Note: Be sure to handle any errors that may be thrown.
+ */
+async function put(experimentId: number, experiment: ExperimentFullNew) {
+  const validatedExperiment = await experimentFullNewSchema.validate(experiment, { abortEarly: false })
+  const outboundExperiment = experimentFullNewOutboundSchema.cast(validatedExperiment)
+  const returnedExperiment = await fetchApi('PUT', `/experiments/${experimentId}`, outboundExperiment)
+  return await experimentFullSchema.validate(returnedExperiment)
+}
+
+/**
  * Attempts to patch an experiment.
  *
  * Doesn't work with nested fields.
@@ -110,6 +122,7 @@ async function findById(id: number): Promise<ExperimentFull> {
 
 const ExperimentsApi = {
   create,
+  put,
   patch,
   assignMetric,
   changeStatus,

--- a/pages/experiments/[id]/wizard-edit.tsx
+++ b/pages/experiments/[id]/wizard-edit.tsx
@@ -13,7 +13,7 @@ import ExperimentForm from '@/components/experiment-creation/ExperimentForm'
 import Layout from '@/components/Layout'
 import { experimentToFormData } from '@/lib/form-data'
 import * as Normalizers from '@/lib/normalizers'
-import { ExperimentFull } from '@/lib/schemas'
+import { ExperimentFull, ExperimentFullNew } from '@/lib/schemas'
 import { useDataLoadingError, useDataSource } from '@/utils/data-loading'
 import { createUnresolvingPromise, or } from '@/utils/general'
 
@@ -47,10 +47,11 @@ export default function WizardEditPage() {
   const { enqueueSnackbar } = useSnackbar()
   const onSubmit = async (formData: unknown) => {
     try {
-      // TODO: submission
-      // const { experiment } = formData as { experiment: ExperimentFullNew }
-      // const receivedExperiment = await ExperimentsApi.put(experiment)
-      // TEMPORARY:
+      if (!_.isNumber(experimentId)) {
+        throw Error('This should never occur: Missing experimentId')
+      }
+      const { experiment } = formData as { experiment: ExperimentFullNew }
+      await ExperimentsApi.put(experimentId, experiment)
       await new Promise((resolve) => setTimeout(resolve, 500))
       enqueueSnackbar('Experiment Updated!', { variant: 'success' })
       router.push('/experiments/[id]?freshly_wizard_edited', `/experiments/${experimentId}?freshly_wizard_edited`)

--- a/pages/experiments/[id]/wizard-edit.tsx
+++ b/pages/experiments/[id]/wizard-edit.tsx
@@ -52,7 +52,6 @@ export default function WizardEditPage() {
       }
       const { experiment } = formData as { experiment: ExperimentFullNew }
       await ExperimentsApi.put(experimentId, experiment)
-      await new Promise((resolve) => setTimeout(resolve, 500))
       enqueueSnackbar('Experiment Updated!', { variant: 'success' })
       router.push('/experiments/[id]?freshly_wizard_edited', `/experiments/${experimentId}?freshly_wizard_edited`)
     } catch (error) {


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR adds the `PUT` request to wizard editing.**
- Basically a copy of the `POST` request.
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
  - Changed every field and saw that the data was updated correctly
