### PR TITLE
Improve data flow for results

### DIFF
--- a/components/experiment-results/CondensedLatestAnalyses.tsx
+++ b/components/experiment-results/CondensedLatestAnalyses.tsx
@@ -71,8 +71,6 @@ export default function CondensedLatestAnalyses({
       recommendationConflict: uniqueRecommendations.length > 1,
     }
   })
-  // Lodash is a bit of a pain to reuse sorts for nested entities ¯\_(ツ)_/¯
-  const sortedMetricAssignmentSummaryData = _.orderBy(metricAssignmentSummaryData, ['metricAssignment.isPrimary', 'metricAssignment.metricAssignmentId'], ['desc', 'asc'])
 
   const tableColumns = [
     {
@@ -128,8 +126,8 @@ export default function CondensedLatestAnalyses({
     <div className={classes.root}>
       <MaterialTable
         columns={tableColumns}
-        data={sortedMetricAssignmentSummaryData}
-        options={createStaticTableOptions(sortedMetricAssignmentSummaryData.length)}
+        data={metricAssignmentSummaryData}
+        options={createStaticTableOptions(metricAssignmentSummaryData.length)}
         onRowClick={(_event, rowData, togglePanel) => {
           const { latestDefaultAnalysis, recommendationConflict } = rowData as {
             latestDefaultAnalysis?: Analysis

--- a/components/experiment-results/CondensedLatestAnalyses.tsx
+++ b/components/experiment-results/CondensedLatestAnalyses.tsx
@@ -60,7 +60,12 @@ export default function CondensedLatestAnalyses({
 
   // When will the Javascript pipe operator ever arrive... :'(
   const metricAssignmentSummaryData = allMetricAssignmentAnalysesData.map(({ metricAssignment, metric, analysesByStrategyDateAsc }) => { 
-    const recommendations = Object.values(analysesByStrategyDateAsc).map(analyses => _.last(analyses)?.recommendation).filter(x => !!x)
+    const recommendations = Object.values(analysesByStrategyDateAsc)
+      .map((analyses) => 
+        //  istanbul ignore next; We don't need to test empty analyses as we filter out all undefined values
+        _.last(analyses)?.recommendation
+      )
+      .filter(recommendation => !!recommendation)
     const uniqueRecommendations = _.uniq(recommendations.map(recommendation => JSON.stringify(recommendation)))
 
     return {

--- a/components/experiment-results/CondensedLatestAnalyses.tsx
+++ b/components/experiment-results/CondensedLatestAnalyses.tsx
@@ -66,7 +66,8 @@ export default function CondensedLatestAnalyses({
     return {
       metricAssignment,
       metric,
-      analysis: _.last(analysesByStrategyDateAsc[defaultAnalysisStrategy]),
+      analysesByStrategyDateAsc,
+      latestDefaultAnalysis: _.last(analysesByStrategyDateAsc[defaultAnalysisStrategy]),
       recommendationConflict: uniqueRecommendations.length > 1,
     }
   })
@@ -99,14 +100,14 @@ export default function CondensedLatestAnalyses({
     },
     {
       title: 'Recommendation',
-      render: ({ analysis, recommendationConflict }: { analysis?: Analysis; recommendationConflict?: boolean }) => {
+      render: ({ latestDefaultAnalysis, recommendationConflict }: { latestDefaultAnalysis?: Analysis; recommendationConflict?: boolean }) => {
         if (recommendationConflict) {
           return <>Manual analysis required</>
         }
-        if (!analysis?.recommendation) {
+        if (!latestDefaultAnalysis?.recommendation) {
           return <>Not analyzed yet</>
         }
-        return <RecommendationString recommendation={analysis.recommendation} experiment={experiment} />
+        return <RecommendationString recommendation={latestDefaultAnalysis.recommendation} experiment={experiment} />
       },
       cellStyle: {
         fontFamily: theme.custom.fonts.monospace,
@@ -115,10 +116,10 @@ export default function CondensedLatestAnalyses({
   ]
 
   const DetailPanel = [
-    ({ analysis, recommendationConflict }: { analysis?: Analysis; recommendationConflict?: boolean }) => {
+    ({ latestDefaultAnalysis, recommendationConflict }: { latestDefaultAnalysis?: Analysis; recommendationConflict?: boolean }) => {
       return {
-        render: () => analysis && <AnalysisDetailPanel analysis={analysis} experiment={experiment} />,
-        disabled: !analysis || recommendationConflict,
+        render: () => latestDefaultAnalysis && <AnalysisDetailPanel latestDefaultAnalysis={latestDefaultAnalysis} experiment={experiment} />,
+        disabled: !latestDefaultAnalysis || recommendationConflict,
       }
     },
   ]
@@ -130,11 +131,11 @@ export default function CondensedLatestAnalyses({
         data={sortedMetricAssignmentSummaryData}
         options={createStaticTableOptions(sortedMetricAssignmentSummaryData.length)}
         onRowClick={(_event, rowData, togglePanel) => {
-          const { analysis, recommendationConflict } = rowData as {
-            analysis?: Analysis
+          const { latestDefaultAnalysis, recommendationConflict } = rowData as {
+            latestDefaultAnalysis?: Analysis
             recommendationConflict?: boolean
           }
-          if (togglePanel && analysis && !recommendationConflict) {
+          if (togglePanel && latestDefaultAnalysis && !recommendationConflict) {
             togglePanel()
           }
         }}
@@ -161,7 +162,7 @@ const useAnalysisDetailStyles = makeStyles((theme: Theme) =>
   }),
 )
 
-function AnalysisDetailPanel({ analysis, experiment }: { analysis: Analysis; experiment: ExperimentFull }) {
+function AnalysisDetailPanel({ latestDefaultAnalysis, experiment }: { latestDefaultAnalysis: Analysis; experiment: ExperimentFull }) {
   const classes = useAnalysisDetailStyles()
 
   return (
@@ -173,46 +174,46 @@ function AnalysisDetailPanel({ analysis, experiment }: { analysis: Analysis; exp
               Last analyzed
             </TableCell>
             <TableCell>
-              <DatetimeText datetime={analysis.analysisDatetime} excludeTime={true} />
+              <DatetimeText datetime={latestDefaultAnalysis.analysisDatetime} excludeTime={true} />
             </TableCell>
           </TableRow>
           <TableRow>
             <TableCell component='th' scope='row' variant='head'>
               Analysis strategy
             </TableCell>
-            <TableCell className={classes.dataCell}>{AnalysisStrategyToHuman[analysis.analysisStrategy]}</TableCell>
+            <TableCell className={classes.dataCell}>{AnalysisStrategyToHuman[latestDefaultAnalysis.analysisStrategy]}</TableCell>
           </TableRow>
           <TableRow>
             <TableCell component='th' scope='row' variant='head'>
               Analyzed participants
             </TableCell>
             <TableCell className={classes.dataCell}>
-              {analysis.participantStats.total} ({analysis.participantStats.not_final} not final
+              {latestDefaultAnalysis.participantStats.total} ({latestDefaultAnalysis.participantStats.not_final} not final
               {Variations.sort(experiment.variations).map(({ variationId, name }) => (
                 <span key={variationId}>
-                  ; {analysis.participantStats[`variation_${variationId}`]} in {name}
+                  ; {latestDefaultAnalysis.participantStats[`variation_${variationId}`]} in {name}
                 </span>
               ))}
               )
             </TableCell>
           </TableRow>
-          {analysis.metricEstimates && analysis.recommendation && (
+          {latestDefaultAnalysis.metricEstimates && latestDefaultAnalysis.recommendation && (
             <>
               <TableRow>
                 <TableCell component='th' scope='row' variant='head'>
                   Difference interval
                 </TableCell>
                 <TableCell className={classes.dataCell}>
-                  [{_.round(analysis.metricEstimates.diff.bottom, 4)}, {_.round(analysis.metricEstimates.diff.top, 4)}]
+                  [{_.round(latestDefaultAnalysis.metricEstimates.diff.bottom, 4)}, {_.round(latestDefaultAnalysis.metricEstimates.diff.top, 4)}]
                 </TableCell>
               </TableRow>
-              {analysis.recommendation.warnings.length > 0 && (
+              {latestDefaultAnalysis.recommendation.warnings.length > 0 && (
                 <TableRow>
                   <TableCell component='th' scope='row' variant='head'>
                     Warnings
                   </TableCell>
                   <TableCell className={classes.dataCell}>
-                    {analysis.recommendation.warnings.map((warning) => (
+                    {latestDefaultAnalysis.recommendation.warnings.map((warning) => (
                       <div key={warning}>{RecommendationWarningToHuman[warning]}</div>
                     ))}
                   </TableCell>

--- a/components/experiment-results/CondensedLatestAnalyses.tsx
+++ b/components/experiment-results/CondensedLatestAnalyses.tsx
@@ -46,11 +46,11 @@ const useStyles = makeStyles((theme: Theme) =>
  */
 export default function CondensedLatestAnalyses({
   experiment,
-  metricsById,
+  indexedMetrics,
   metricAssignmentIdToLatestAnalyses,
 }: {
   experiment: ExperimentFull
-  metricsById: { [key: number]: MetricBare }
+  indexedMetrics: { [key: number]: MetricBare }
   metricAssignmentIdToLatestAnalyses: { [key: number]: Analysis[] }
 }) {
   const classes = useStyles()
@@ -63,7 +63,7 @@ export default function CondensedLatestAnalyses({
     const uniqueRecommendations = _.uniq(latestAnalyses.map(({ recommendation }) => JSON.stringify(recommendation)))
     return {
       metricAssignment,
-      metric: metricsById[metricAssignment.metricId],
+      metric: indexedMetrics[metricAssignment.metricId],
       analysis: latestAnalyses.find((analysis) => analysis.analysisStrategy === defaultAnalysisStrategy),
       recommendationConflict: uniqueRecommendations.length > 1,
     }

--- a/components/experiment-results/CondensedLatestAnalyses.tsx
+++ b/components/experiment-results/CondensedLatestAnalyses.tsx
@@ -18,14 +18,13 @@ import React from 'react'
 import DatetimeText from '@/components/DatetimeText'
 import { AnalysisStrategyToHuman, RecommendationWarningToHuman } from '@/lib/analyses'
 import * as Experiments from '@/lib/experiments'
-import * as MetricAssignments from '@/lib/metric-assignments'
 import { AttributionWindowSecondsToHuman } from '@/lib/metric-assignments'
 import { Analysis, ExperimentFull, MetricAssignment, MetricBare } from '@/lib/schemas'
 import * as Variations from '@/lib/variations'
 import { createStaticTableOptions } from '@/utils/material-table'
 
-import RecommendationString from './RecommendationString'
 import { MetricAssignmentAnalysesData } from './ExperimentResults'
+import RecommendationString from './RecommendationString'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -59,23 +58,26 @@ export default function CondensedLatestAnalyses({
   const defaultAnalysisStrategy = Experiments.getDefaultAnalysisStrategy(experiment)
 
   // When will the Javascript pipe operator ever arrive... :'(
-  const metricAssignmentSummaryData = allMetricAssignmentAnalysesData.map(({ metricAssignment, metric, analysesByStrategyDateAsc }) => { 
-    const recommendations = Object.values(analysesByStrategyDateAsc)
-      .map((analyses) => 
-        //  istanbul ignore next; We don't need to test empty analyses as we filter out all undefined values
-        _.last(analyses)?.recommendation
-      )
-      .filter(recommendation => !!recommendation)
-    const uniqueRecommendations = _.uniq(recommendations.map(recommendation => JSON.stringify(recommendation)))
+  const metricAssignmentSummaryData = allMetricAssignmentAnalysesData.map(
+    ({ metricAssignment, metric, analysesByStrategyDateAsc }) => {
+      const recommendations = Object.values(analysesByStrategyDateAsc)
+        .map(
+          (analyses) =>
+            //  istanbul ignore next; We don't need to test empty analyses as we filter out all undefined values
+            _.last(analyses)?.recommendation,
+        )
+        .filter((recommendation) => !!recommendation)
+      const uniqueRecommendations = _.uniq(recommendations.map((recommendation) => JSON.stringify(recommendation)))
 
-    return {
-      metricAssignment,
-      metric,
-      analysesByStrategyDateAsc,
-      latestDefaultAnalysis: _.last(analysesByStrategyDateAsc[defaultAnalysisStrategy]),
-      recommendationConflict: uniqueRecommendations.length > 1,
-    }
-  })
+      return {
+        metricAssignment,
+        metric,
+        analysesByStrategyDateAsc,
+        latestDefaultAnalysis: _.last(analysesByStrategyDateAsc[defaultAnalysisStrategy]),
+        recommendationConflict: uniqueRecommendations.length > 1,
+      }
+    },
+  )
 
   const tableColumns = [
     {
@@ -103,7 +105,13 @@ export default function CondensedLatestAnalyses({
     },
     {
       title: 'Recommendation',
-      render: ({ latestDefaultAnalysis, recommendationConflict }: { latestDefaultAnalysis?: Analysis; recommendationConflict?: boolean }) => {
+      render: ({
+        latestDefaultAnalysis,
+        recommendationConflict,
+      }: {
+        latestDefaultAnalysis?: Analysis
+        recommendationConflict?: boolean
+      }) => {
         if (recommendationConflict) {
           return <>Manual analysis required</>
         }
@@ -119,9 +127,18 @@ export default function CondensedLatestAnalyses({
   ]
 
   const DetailPanel = [
-    ({ latestDefaultAnalysis, recommendationConflict }: { latestDefaultAnalysis?: Analysis; recommendationConflict?: boolean }) => {
+    ({
+      latestDefaultAnalysis,
+      recommendationConflict,
+    }: {
+      latestDefaultAnalysis?: Analysis
+      recommendationConflict?: boolean
+    }) => {
       return {
-        render: () => latestDefaultAnalysis && <AnalysisDetailPanel latestDefaultAnalysis={latestDefaultAnalysis} experiment={experiment} />,
+        render: () =>
+          latestDefaultAnalysis && (
+            <AnalysisDetailPanel latestDefaultAnalysis={latestDefaultAnalysis} experiment={experiment} />
+          ),
         disabled: !latestDefaultAnalysis || recommendationConflict,
       }
     },
@@ -165,7 +182,13 @@ const useAnalysisDetailStyles = makeStyles((theme: Theme) =>
   }),
 )
 
-function AnalysisDetailPanel({ latestDefaultAnalysis, experiment }: { latestDefaultAnalysis: Analysis; experiment: ExperimentFull }) {
+function AnalysisDetailPanel({
+  latestDefaultAnalysis,
+  experiment,
+}: {
+  latestDefaultAnalysis: Analysis
+  experiment: ExperimentFull
+}) {
   const classes = useAnalysisDetailStyles()
 
   return (
@@ -184,14 +207,17 @@ function AnalysisDetailPanel({ latestDefaultAnalysis, experiment }: { latestDefa
             <TableCell component='th' scope='row' variant='head'>
               Analysis strategy
             </TableCell>
-            <TableCell className={classes.dataCell}>{AnalysisStrategyToHuman[latestDefaultAnalysis.analysisStrategy]}</TableCell>
+            <TableCell className={classes.dataCell}>
+              {AnalysisStrategyToHuman[latestDefaultAnalysis.analysisStrategy]}
+            </TableCell>
           </TableRow>
           <TableRow>
             <TableCell component='th' scope='row' variant='head'>
               Analyzed participants
             </TableCell>
             <TableCell className={classes.dataCell}>
-              {latestDefaultAnalysis.participantStats.total} ({latestDefaultAnalysis.participantStats.not_final} not final
+              {latestDefaultAnalysis.participantStats.total} ({latestDefaultAnalysis.participantStats.not_final} not
+              final
               {Variations.sort(experiment.variations).map(({ variationId, name }) => (
                 <span key={variationId}>
                   ; {latestDefaultAnalysis.participantStats[`variation_${variationId}`]} in {name}
@@ -207,7 +233,8 @@ function AnalysisDetailPanel({ latestDefaultAnalysis, experiment }: { latestDefa
                   Difference interval
                 </TableCell>
                 <TableCell className={classes.dataCell}>
-                  [{_.round(latestDefaultAnalysis.metricEstimates.diff.bottom, 4)}, {_.round(latestDefaultAnalysis.metricEstimates.diff.top, 4)}]
+                  [{_.round(latestDefaultAnalysis.metricEstimates.diff.bottom, 4)},{' '}
+                  {_.round(latestDefaultAnalysis.metricEstimates.diff.top, 4)}]
                 </TableCell>
               </TableRow>
               {latestDefaultAnalysis.recommendation.warnings.length > 0 && (

--- a/components/experiment-results/ExperimentResults.tsx
+++ b/components/experiment-results/ExperimentResults.tsx
@@ -3,11 +3,12 @@ import React, { useMemo } from 'react'
 
 import DebugOutput from '@/components/DebugOutput'
 import * as Experiments from '@/lib/experiments'
-import { Analysis, ExperimentFull, MetricBare } from '@/lib/schemas'
+import { Analysis, ExperimentFull, MetricBare, MetricAssignment, AnalysisStrategy } from '@/lib/schemas'
 
 import CondensedLatestAnalyses from './CondensedLatestAnalyses'
 import FullLatestAnalyses from './FullLatestAnalyses'
 import ParticipantCounts from './ParticipantCounts'
+import { indexMetrics } from '@/lib/normalizers'
 
 /**
  * Main component for summarizing experiment results.
@@ -23,7 +24,7 @@ export default function ExperimentResults({
   metrics: MetricBare[]
   debugMode?: boolean
 }) {
-  const metricsById = useMemo(() => _.zipObject(_.map(metrics, 'metricId'), metrics), [metrics])
+  const indexedMetrics = indexMetrics(metrics)
   const metricAssignmentIdToLatestAnalyses = useMemo(
     () =>
       _.mapValues(_.groupBy(analyses, 'metricAssignmentId'), (metricAnalyses) => {
@@ -57,7 +58,7 @@ export default function ExperimentResults({
           <h3>Latest results by metric</h3>
           <FullLatestAnalyses
             experiment={experiment}
-            metricsById={metricsById}
+            indexedMetrics={indexedMetrics}
             metricAssignmentIdToLatestAnalyses={metricAssignmentIdToLatestAnalyses}
           />
         </div>
@@ -72,7 +73,7 @@ export default function ExperimentResults({
     <div className='analysis-latest-results'>
       <CondensedLatestAnalyses
         experiment={experiment}
-        metricsById={metricsById}
+        indexedMetrics={indexedMetrics}
         metricAssignmentIdToLatestAnalyses={metricAssignmentIdToLatestAnalyses}
       />
     </div>

--- a/components/experiment-results/ExperimentResults.tsx
+++ b/components/experiment-results/ExperimentResults.tsx
@@ -1,20 +1,20 @@
 import _ from 'lodash'
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import DebugOutput from '@/components/DebugOutput'
 import * as Experiments from '@/lib/experiments'
 import * as MetricAssignments from '@/lib/metric-assignments'
-import { Analysis, ExperimentFull, MetricBare, MetricAssignment, AnalysisStrategy } from '@/lib/schemas'
+import { indexMetrics } from '@/lib/normalizers'
+import { Analysis, AnalysisStrategy, ExperimentFull, MetricAssignment, MetricBare } from '@/lib/schemas'
 
 import CondensedLatestAnalyses from './CondensedLatestAnalyses'
 import FullLatestAnalyses from './FullLatestAnalyses'
 import ParticipantCounts from './ParticipantCounts'
-import { indexMetrics } from '@/lib/normalizers'
 
-export type MetricAssignmentAnalysesData = { 
-  metricAssignment: MetricAssignment, 
-  metric: MetricBare,
-  analysesByStrategyDateAsc: Record<AnalysisStrategy, Analysis[]> 
+export type MetricAssignmentAnalysesData = {
+  metricAssignment: MetricAssignment
+  metric: MetricBare
+  analysesByStrategyDateAsc: Record<AnalysisStrategy, Analysis[]>
 }
 
 /**
@@ -33,15 +33,19 @@ export default function ExperimentResults({
 }) {
   const indexedMetrics = indexMetrics(metrics)
   const analysesByMetricAssignmentId = _.groupBy(analyses, 'metricAssignmentId')
-  const allMetricAssignmentAnalysesData: MetricAssignmentAnalysesData[] =
-      MetricAssignments.sort(experiment.metricAssignments).map((metricAssignment) => {
-        const metricAssignmentAnalyses = analysesByMetricAssignmentId[metricAssignment.metricAssignmentId] || []
-        return {
-          metricAssignment,
-          metric: indexedMetrics[metricAssignment.metricId],
-          analysesByStrategyDateAsc: _.groupBy(_.orderBy(metricAssignmentAnalyses, ['analysisDatetime'], ['asc']), 'analysisStrategy') as Record<AnalysisStrategy, Analysis[]>
-        }
-      })
+  const allMetricAssignmentAnalysesData: MetricAssignmentAnalysesData[] = MetricAssignments.sort(
+    experiment.metricAssignments,
+  ).map((metricAssignment) => {
+    const metricAssignmentAnalyses = analysesByMetricAssignmentId[metricAssignment.metricAssignmentId] || []
+    return {
+      metricAssignment,
+      metric: indexedMetrics[metricAssignment.metricId],
+      analysesByStrategyDateAsc: _.groupBy(
+        _.orderBy(metricAssignmentAnalyses, ['analysisDatetime'], ['asc']),
+        'analysisStrategy',
+      ) as Record<AnalysisStrategy, Analysis[]>,
+    }
+  })
 
   if (analyses.length === 0) {
     return <p>No analyses yet for {experiment.name}.</p>
@@ -49,7 +53,9 @@ export default function ExperimentResults({
 
   if (debugMode) {
     const primaryMetricAssignmentId = Experiments.getPrimaryMetricAssignmentId(experiment)
-    const primaryMetricAssignmentAnalysesData = allMetricAssignmentAnalysesData.find(({ metricAssignment: { metricAssignmentId }}) => metricAssignmentId === primaryMetricAssignmentId)
+    const primaryMetricAssignmentAnalysesData = allMetricAssignmentAnalysesData.find(
+      ({ metricAssignment: { metricAssignmentId } }) => metricAssignmentId === primaryMetricAssignmentId,
+    )
 
     // istanbul ignore next; Should never occur
     if (!primaryMetricAssignmentAnalysesData) {

--- a/components/experiment-results/ExperimentResults.tsx
+++ b/components/experiment-results/ExperimentResults.tsx
@@ -31,6 +31,9 @@ export default function ExperimentResults({
   debugMode?: boolean
 }) {
   const indexedMetrics = indexMetrics(metrics)
+  /**
+   * @deprecated To be replaced by allMetricAssignmentsAnalysesData
+   */
   const metricAssignmentIdToLatestAnalyses = useMemo(
     () =>
       _.mapValues(_.groupBy(analyses, 'metricAssignmentId'), (metricAnalyses) => {
@@ -59,15 +62,21 @@ export default function ExperimentResults({
   }
 
   if (debugMode) {
+    const primaryMetricAssignmentId = Experiments.getPrimaryMetricAssignmentId(experiment)
+    const primaryMetricAssignmentAnalysesData = allMetricAssignmentAnalysesData.find(({ metricAssignment: { metricAssignmentId }}) => metricAssignmentId === primaryMetricAssignmentId)
+
+    // istanbul ignore next; Should never occur
+    if (!primaryMetricAssignmentAnalysesData) {
+      throw new Error('Missing primary metricAssignment!')
+    }
+
     return (
       <>
         <div className='analysis-participant-counts'>
           <h3>Participant counts for the primary metric</h3>
           <ParticipantCounts
             experiment={experiment}
-            latestPrimaryMetricAnalyses={
-              metricAssignmentIdToLatestAnalyses[Experiments.getPrimaryMetricAssignmentId(experiment) as number]
-            }
+            primaryMetricAssignmentAnalysesData={primaryMetricAssignmentAnalysesData}
           />
         </div>
 

--- a/components/experiment-results/ExperimentResults.tsx
+++ b/components/experiment-results/ExperimentResults.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from 'react'
 
 import DebugOutput from '@/components/DebugOutput'
 import * as Experiments from '@/lib/experiments'
+import * as MetricAssignments from '@/lib/metric-assignments'
 import { Analysis, ExperimentFull, MetricBare, MetricAssignment, AnalysisStrategy } from '@/lib/schemas'
 
 import CondensedLatestAnalyses from './CondensedLatestAnalyses'
@@ -31,25 +32,10 @@ export default function ExperimentResults({
   debugMode?: boolean
 }) {
   const indexedMetrics = indexMetrics(metrics)
-  /**
-   * @deprecated To be replaced by allMetricAssignmentsAnalysesData
-   */
-  const metricAssignmentIdToLatestAnalyses = useMemo(
-    () =>
-      _.mapValues(_.groupBy(analyses, 'metricAssignmentId'), (metricAnalyses) => {
-        metricAnalyses = _.orderBy(metricAnalyses, ['analysisDatetime'], ['desc'])
-        return _.sortBy(
-          _.filter(metricAnalyses, ['analysisDatetime', metricAnalyses[0].analysisDatetime]),
-          'analysisStrategy',
-        )
-      }),
-    [analyses],
-  )
-
   const analysesByMetricAssignmentId = _.groupBy(analyses, 'metricAssignmentId')
   const allMetricAssignmentAnalysesData: MetricAssignmentAnalysesData[] =
-      experiment.metricAssignments.map((metricAssignment) => {
-        const metricAssignmentAnalyses = analysesByMetricAssignmentId[metricAssignment.metricAssignmentId]
+      MetricAssignments.sort(experiment.metricAssignments).map((metricAssignment) => {
+        const metricAssignmentAnalyses = analysesByMetricAssignmentId[metricAssignment.metricAssignmentId] || []
         return {
           metricAssignment,
           metric: indexedMetrics[metricAssignment.metricId],
@@ -84,8 +70,7 @@ export default function ExperimentResults({
           <h3>Latest results by metric</h3>
           <FullLatestAnalyses
             experiment={experiment}
-            indexedMetrics={indexedMetrics}
-            metricAssignmentIdToLatestAnalyses={metricAssignmentIdToLatestAnalyses}
+            allMetricAssignmentAnalysesData={allMetricAssignmentAnalysesData}
           />
         </div>
 

--- a/components/experiment-results/ExperimentResults.tsx
+++ b/components/experiment-results/ExperimentResults.tsx
@@ -10,6 +10,12 @@ import FullLatestAnalyses from './FullLatestAnalyses'
 import ParticipantCounts from './ParticipantCounts'
 import { indexMetrics } from '@/lib/normalizers'
 
+export type MetricAssignmentAnalysesData = { 
+  metricAssignment: MetricAssignment, 
+  metric: MetricBare,
+  analysesByStrategy: Record<AnalysisStrategy, Analysis[]> 
+}
+
 /**
  * Main component for summarizing experiment results.
  */
@@ -36,6 +42,17 @@ export default function ExperimentResults({
       }),
     [analyses],
   )
+
+  const analysesByMetricAssignmentId = _.groupBy(analyses, 'metricAssignmentId')
+  const allMetricAssignmentAnalysisData: MetricAssignmentAnalysesData[] =
+      experiment.metricAssignments.map((metricAssignment) => {
+        const metricAssignmentAnalyses = analysesByMetricAssignmentId[metricAssignment.metricAssignmentId]
+        return {
+          metricAssignment,
+          metric: indexedMetrics[metricAssignment.metricId],
+          analysesByStrategy: _.groupBy(metricAssignmentAnalyses, 'analysisStrategy') as Record<AnalysisStrategy, Analysis[]>
+        }
+      })
 
   if (analyses.length === 0) {
     return <p>No analyses yet for {experiment.name}.</p>

--- a/components/experiment-results/ExperimentResults.tsx
+++ b/components/experiment-results/ExperimentResults.tsx
@@ -13,7 +13,7 @@ import { indexMetrics } from '@/lib/normalizers'
 export type MetricAssignmentAnalysesData = { 
   metricAssignment: MetricAssignment, 
   metric: MetricBare,
-  analysesByStrategy: Record<AnalysisStrategy, Analysis[]> 
+  analysesByStrategyDateAsc: Record<AnalysisStrategy, Analysis[]> 
 }
 
 /**
@@ -44,13 +44,13 @@ export default function ExperimentResults({
   )
 
   const analysesByMetricAssignmentId = _.groupBy(analyses, 'metricAssignmentId')
-  const allMetricAssignmentAnalysisData: MetricAssignmentAnalysesData[] =
+  const allMetricAssignmentAnalysesData: MetricAssignmentAnalysesData[] =
       experiment.metricAssignments.map((metricAssignment) => {
         const metricAssignmentAnalyses = analysesByMetricAssignmentId[metricAssignment.metricAssignmentId]
         return {
           metricAssignment,
           metric: indexedMetrics[metricAssignment.metricId],
-          analysesByStrategy: _.groupBy(metricAssignmentAnalyses, 'analysisStrategy') as Record<AnalysisStrategy, Analysis[]>
+          analysesByStrategyDateAsc: _.groupBy(_.orderBy(metricAssignmentAnalyses, ['analysisDatetime'], ['asc']), 'analysisStrategy') as Record<AnalysisStrategy, Analysis[]>
         }
       })
 
@@ -90,8 +90,7 @@ export default function ExperimentResults({
     <div className='analysis-latest-results'>
       <CondensedLatestAnalyses
         experiment={experiment}
-        indexedMetrics={indexedMetrics}
-        metricAssignmentIdToLatestAnalyses={metricAssignmentIdToLatestAnalyses}
+        allMetricAssignmentAnalysesData={allMetricAssignmentAnalysesData}
       />
     </div>
   )

--- a/components/experiment-results/FullLatestAnalyses.tsx
+++ b/components/experiment-results/FullLatestAnalyses.tsx
@@ -16,11 +16,11 @@ import { createStaticTableOptions } from '@/utils/material-table'
  */
 export default function FullLatestAnalyses({
   experiment,
-  metricsById,
+  indexedMetrics,
   metricAssignmentIdToLatestAnalyses,
 }: {
   experiment: ExperimentFull
-  metricsById: { [key: number]: MetricBare }
+  indexedMetrics: { [key: number]: MetricBare }
   metricAssignmentIdToLatestAnalyses: { [key: number]: Analysis[] }
 }) {
   // Sort the assignments for consistency and collect the data we need to render the component.
@@ -28,11 +28,11 @@ export default function FullLatestAnalyses({
     return MetricAssignments.sort(experiment.metricAssignments).map((metricAssignment) => {
       return {
         metricAssignment,
-        metric: metricsById[metricAssignment.metricId],
+        metric: indexedMetrics[metricAssignment.metricId],
         latestAnalyses: metricAssignmentIdToLatestAnalyses[metricAssignment.metricAssignmentId] || [],
       }
     })
-  }, [experiment, metricsById, metricAssignmentIdToLatestAnalyses])
+  }, [experiment, indexedMetrics, metricAssignmentIdToLatestAnalyses])
   const tableColumns = [
     { title: 'Strategy', render: ({ analysisStrategy }: Analysis) => AnalysisStrategyToHuman[analysisStrategy] },
     {

--- a/components/experiment-results/FullLatestAnalyses.tsx
+++ b/components/experiment-results/FullLatestAnalyses.tsx
@@ -10,29 +10,27 @@ import * as MetricAssignments from '@/lib/metric-assignments'
 import { AttributionWindowSecondsToHuman } from '@/lib/metric-assignments'
 import { Analysis, ExperimentFull, MetricBare } from '@/lib/schemas'
 import { createStaticTableOptions } from '@/utils/material-table'
+import { MetricAssignmentAnalysesData } from './ExperimentResults'
 
 /**
  * Render the latest analyses for the experiment for each metric assignment.
  */
 export default function FullLatestAnalyses({
   experiment,
-  indexedMetrics,
-  metricAssignmentIdToLatestAnalyses,
+  allMetricAssignmentAnalysesData,
 }: {
   experiment: ExperimentFull
-  indexedMetrics: { [key: number]: MetricBare }
-  metricAssignmentIdToLatestAnalyses: { [key: number]: Analysis[] }
+  allMetricAssignmentAnalysesData: MetricAssignmentAnalysesData[]
 }) {
-  // Sort the assignments for consistency and collect the data we need to render the component.
-  const resultSummaries = useMemo(() => {
-    return MetricAssignments.sort(experiment.metricAssignments).map((metricAssignment) => {
-      return {
-        metricAssignment,
-        metric: indexedMetrics[metricAssignment.metricId],
-        latestAnalyses: metricAssignmentIdToLatestAnalyses[metricAssignment.metricAssignmentId] || [],
-      }
-    })
-  }, [experiment, indexedMetrics, metricAssignmentIdToLatestAnalyses])
+  const metricAssignmentSummaries = allMetricAssignmentAnalysesData.map(({ metricAssignment, metric, analysesByStrategyDateAsc }) => { 
+    return {
+      metricAssignment,
+      metric,
+      analysesByStrategyDateAsc,
+      latestAnalyses: Object.values(analysesByStrategyDateAsc).map(_.last) as Analysis[],
+    }
+  })
+
   const tableColumns = [
     { title: 'Strategy', render: ({ analysisStrategy }: Analysis) => AnalysisStrategyToHuman[analysisStrategy] },
     {
@@ -69,7 +67,7 @@ export default function FullLatestAnalyses({
   ]
   return (
     <>
-      {resultSummaries.map(({ metricAssignment, metric, latestAnalyses }) => (
+      {metricAssignmentSummaries.map(({ metricAssignment, metric, latestAnalyses }) => (
         <div key={metricAssignment.metricAssignmentId}>
           <Typography variant={'subtitle1'}>
             <strong>

--- a/components/experiment-results/FullLatestAnalyses.tsx
+++ b/components/experiment-results/FullLatestAnalyses.tsx
@@ -1,15 +1,15 @@
 import { Typography } from '@material-ui/core'
-import _ from 'lodash'
+import _, { last } from 'lodash'
 import MaterialTable from 'material-table'
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import DatetimeText from '@/components/DatetimeText'
 import RecommendationString from '@/components/experiment-results/RecommendationString'
 import { AnalysisStrategyToHuman, RecommendationWarningToHuman } from '@/lib/analyses'
-import * as MetricAssignments from '@/lib/metric-assignments'
 import { AttributionWindowSecondsToHuman } from '@/lib/metric-assignments'
-import { Analysis, ExperimentFull, MetricBare } from '@/lib/schemas'
+import { Analysis, ExperimentFull } from '@/lib/schemas'
 import { createStaticTableOptions } from '@/utils/material-table'
+
 import { MetricAssignmentAnalysesData } from './ExperimentResults'
 
 /**
@@ -22,14 +22,16 @@ export default function FullLatestAnalyses({
   experiment: ExperimentFull
   allMetricAssignmentAnalysesData: MetricAssignmentAnalysesData[]
 }) {
-  const metricAssignmentSummaries = allMetricAssignmentAnalysesData.map(({ metricAssignment, metric, analysesByStrategyDateAsc }) => { 
-    return {
-      metricAssignment,
-      metric,
-      analysesByStrategyDateAsc,
-      latestAnalyses: Object.values(analysesByStrategyDateAsc).map(_.last) as Analysis[],
-    }
-  })
+  const metricAssignmentSummaries = allMetricAssignmentAnalysesData.map(
+    ({ metricAssignment, metric, analysesByStrategyDateAsc }) => {
+      return {
+        metricAssignment,
+        metric,
+        analysesByStrategyDateAsc,
+        latestAnalyses: Object.values(analysesByStrategyDateAsc).map(last) as Analysis[],
+      }
+    },
+  )
 
   const tableColumns = [
     { title: 'Strategy', render: ({ analysisStrategy }: Analysis) => AnalysisStrategyToHuman[analysisStrategy] },

--- a/components/experiment-results/ParticipantCounts.tsx
+++ b/components/experiment-results/ParticipantCounts.tsx
@@ -1,31 +1,37 @@
 import MaterialTable from 'material-table'
 import React from 'react'
+import _ from 'lodash'
 
 import { AnalysisStrategyToHuman } from '@/lib/analyses'
 import { Analysis, ExperimentFull } from '@/lib/schemas'
 import * as Variations from '@/lib/variations'
 import { createStaticTableOptions } from '@/utils/material-table'
+import { MetricAssignmentAnalysesData } from './ExperimentResults'
 
 /**
  * Render a table of participant counts based on the latest metric analyses for the given experiment.
  */
 export default function ParticipantCounts({
   experiment,
-  latestPrimaryMetricAnalyses,
+  primaryMetricAssignmentAnalysesData,
 }: {
   experiment: ExperimentFull
-  latestPrimaryMetricAnalyses: Analysis[]
+  primaryMetricAssignmentAnalysesData: MetricAssignmentAnalysesData,
 }) {
+  const latestPrimaryMetricAnalyses = Object.values(primaryMetricAssignmentAnalysesData.analysesByStrategyDateAsc).map(_.last) as Analysis[]
+
   const tableColumns = [
     { title: 'Strategy', render: ({ analysisStrategy }: Analysis) => AnalysisStrategyToHuman[analysisStrategy] },
     { title: 'Total', render: ({ participantStats }: Analysis) => participantStats.total },
   ]
+
   Variations.sort(experiment.variations).forEach(({ variationId, name }) => {
     tableColumns.push({
       title: name,
       render: ({ participantStats }: Analysis) => participantStats[`variation_${variationId}`] || 0,
     })
   })
+
   return (
     <MaterialTable
       columns={tableColumns}

--- a/components/experiment-results/ParticipantCounts.tsx
+++ b/components/experiment-results/ParticipantCounts.tsx
@@ -1,11 +1,12 @@
+import { last } from 'lodash'
 import MaterialTable from 'material-table'
 import React from 'react'
-import _ from 'lodash'
 
 import { AnalysisStrategyToHuman } from '@/lib/analyses'
 import { Analysis, ExperimentFull } from '@/lib/schemas'
 import * as Variations from '@/lib/variations'
 import { createStaticTableOptions } from '@/utils/material-table'
+
 import { MetricAssignmentAnalysesData } from './ExperimentResults'
 
 /**
@@ -16,9 +17,11 @@ export default function ParticipantCounts({
   primaryMetricAssignmentAnalysesData,
 }: {
   experiment: ExperimentFull
-  primaryMetricAssignmentAnalysesData: MetricAssignmentAnalysesData,
+  primaryMetricAssignmentAnalysesData: MetricAssignmentAnalysesData
 }) {
-  const latestPrimaryMetricAnalyses = Object.values(primaryMetricAssignmentAnalysesData.analysesByStrategyDateAsc).map(_.last) as Analysis[]
+  const latestPrimaryMetricAnalyses = Object.values(primaryMetricAssignmentAnalysesData.analysesByStrategyDateAsc).map(
+    last,
+  ) as Analysis[]
 
   const tableColumns = [
     { title: 'Strategy', render: ({ analysisStrategy }: Analysis) => AnalysisStrategyToHuman[analysisStrategy] },

--- a/components/experiment-results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/components/experiment-results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -391,7 +391,8 @@ exports[`renders the condensed table with some analyses in non-debug mode 2`] = 
         >
           [
           -0.01
-          , 
+          ,
+           
           0.01
           ]
         </td>


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR improves the data management in the results page to prepare it for graphing.**
- Rename `metricsById` to `indexedMetrics` for consistency.
- Add `MetricAssignmentAnalysesData` type.
   - Should hold all the data we would need for any analysis of a metricAssignment.
   - Should be the main data structure involved, lets pass it down to the bottom where we can.
   - Allows all analyses to be passed down
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This is pretty similar to #236 so you may have seen it before, I am doing basically the same thing but without the normalised experiment. This will actually simplify normalising the data later on.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
