### PR TITLE
Improve metric assignment sorting

### DIFF
--- a/components/MetricAssignmentsPanel.test.tsx
+++ b/components/MetricAssignmentsPanel.test.tsx
@@ -159,18 +159,18 @@ test('renders as expected with all metrics resolvable', () => {
               <td
                 class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-2"
               >
-                4 weeks
+                1 hour
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-2"
               >
-                No
+                Yes
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-2"
               >
                 <span>
-                  $10.50
+                  $0.50
                 </span>
               </td>
             </tr>
@@ -186,18 +186,18 @@ test('renders as expected with all metrics resolvable', () => {
               <td
                 class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-2"
               >
-                1 hour
+                4 weeks
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-2"
               >
-                Yes
+                No
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-2"
               >
                 <span>
-                  $0.50
+                  $10.50
                 </span>
               </td>
             </tr>

--- a/components/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/components/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -316,18 +316,18 @@ exports[`renders as expected at large width 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-14"
                   >
-                    4 weeks
+                    1 hour
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-14"
                   >
-                    No
+                    Yes
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-14"
                   >
                     <span>
-                      $10.50
+                      $0.50
                     </span>
                   </td>
                 </tr>
@@ -343,18 +343,18 @@ exports[`renders as expected at large width 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-14"
                   >
-                    1 hour
+                    4 weeks
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-14"
                   >
-                    Yes
+                    No
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-14"
                   >
                     <span>
-                      $0.50
+                      $10.50
                     </span>
                   </td>
                 </tr>
@@ -1311,18 +1311,18 @@ exports[`renders as expected at small width 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
                   >
-                    4 weeks
+                    1 hour
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
                   >
-                    No
+                    Yes
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
                   >
                     <span>
-                      $10.50
+                      $0.50
                     </span>
                   </td>
                 </tr>
@@ -1338,18 +1338,18 @@ exports[`renders as expected at small width 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
                   >
-                    1 hour
+                    4 weeks
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
                   >
-                    Yes
+                    No
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
                   >
                     <span>
-                      $0.50
+                      $10.50
                     </span>
                   </td>
                 </tr>
@@ -2010,18 +2010,18 @@ exports[`renders as expected with conclusion data 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
                   >
-                    4 weeks
+                    1 hour
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
                   >
-                    No
+                    Yes
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
                   >
                     <span>
-                      $10.50
+                      $0.50
                     </span>
                   </td>
                 </tr>
@@ -2037,18 +2037,18 @@ exports[`renders as expected with conclusion data 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
                   >
-                    1 hour
+                    4 weeks
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
                   >
-                    Yes
+                    No
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
                   >
                     <span>
-                      $0.50
+                      $10.50
                     </span>
                   </td>
                 </tr>
@@ -2809,18 +2809,18 @@ exports[`renders as expected without conclusion data 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
                   >
-                    4 weeks
+                    1 hour
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
                   >
-                    No
+                    Yes
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
                   >
                     <span>
-                      $10.50
+                      $0.50
                     </span>
                   </td>
                 </tr>
@@ -2836,18 +2836,18 @@ exports[`renders as expected without conclusion data 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
                   >
-                    1 hour
+                    4 weeks
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
                   >
-                    Yes
+                    No
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
                   >
                     <span>
-                      $0.50
+                      $10.50
                     </span>
                   </td>
                 </tr>

--- a/components/experiment-results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/components/experiment-results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -168,7 +168,7 @@ exports[`renders the condensed table with some analyses in non-debug mode 1`] = 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      4 weeks
+                      1 hour
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -221,7 +221,7 @@ exports[`renders the condensed table with some analyses in non-debug mode 1`] = 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      1 hour
+                      4 weeks
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -1683,6 +1683,95 @@ exports[`renders the full tables with some analyses in debug mode 3`] = `
       </strong>
        
       with 
+      1 hour
+       attribution,
+       
+      <strong>
+        not analyzed yet
+      </strong>
+    </h6>
+    <div
+      class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+      style="position: relative;"
+    >
+      <div
+        class="Component-horizontalScrollContainer-5"
+        style="overflow-x: auto; position: relative;"
+      >
+        <div>
+          <div
+            style="overflow-y: auto;"
+          >
+            <div>
+              <table
+                class="MuiTable-root"
+                style="table-layout: auto;"
+              >
+                <thead
+                  class="MuiTableHead-root"
+                >
+                  <tr
+                    class="MuiTableRow-root MuiTableRow-head"
+                  >
+                    <th
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                      scope="col"
+                      style="font-weight: 700; box-sizing: border-box;"
+                    >
+                      Strategy
+                    </th>
+                    <th
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                      scope="col"
+                      style="font-weight: 700; box-sizing: border-box;"
+                    >
+                      Participants (not final)
+                    </th>
+                    <th
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                      scope="col"
+                      style="font-weight: 700; box-sizing: border-box;"
+                    >
+                      Difference interval
+                    </th>
+                    <th
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                      scope="col"
+                      style="font-weight: 700; box-sizing: border-box;"
+                    >
+                      Recommendation
+                    </th>
+                    <th
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
+                      scope="col"
+                      style="font-weight: 700; box-sizing: border-box;"
+                    >
+                      Warnings
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  class="MuiTableBody-root"
+                />
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <br />
+  </div>
+  <div>
+    <h6
+      class="MuiTypography-root MuiTypography-subtitle1"
+    >
+      <strong>
+        <code>
+          metric_2
+        </code>
+      </strong>
+       
+      with 
       4 weeks
        attribution,
        
@@ -1794,95 +1883,6 @@ exports[`renders the full tables with some analyses in debug mode 3`] = `
                     </td>
                   </tr>
                 </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <br />
-  </div>
-  <div>
-    <h6
-      class="MuiTypography-root MuiTypography-subtitle1"
-    >
-      <strong>
-        <code>
-          metric_2
-        </code>
-      </strong>
-       
-      with 
-      1 hour
-       attribution,
-       
-      <strong>
-        not analyzed yet
-      </strong>
-    </h6>
-    <div
-      class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
-      style="position: relative;"
-    >
-      <div
-        class="Component-horizontalScrollContainer-5"
-        style="overflow-x: auto; position: relative;"
-      >
-        <div>
-          <div
-            style="overflow-y: auto;"
-          >
-            <div>
-              <table
-                class="MuiTable-root"
-                style="table-layout: auto;"
-              >
-                <thead
-                  class="MuiTableHead-root"
-                >
-                  <tr
-                    class="MuiTableRow-root MuiTableRow-head"
-                  >
-                    <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
-                      scope="col"
-                      style="font-weight: 700; box-sizing: border-box;"
-                    >
-                      Strategy
-                    </th>
-                    <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
-                      scope="col"
-                      style="font-weight: 700; box-sizing: border-box;"
-                    >
-                      Participants (not final)
-                    </th>
-                    <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
-                      scope="col"
-                      style="font-weight: 700; box-sizing: border-box;"
-                    >
-                      Difference interval
-                    </th>
-                    <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
-                      scope="col"
-                      style="font-weight: 700; box-sizing: border-box;"
-                    >
-                      Recommendation
-                    </th>
-                    <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-6 MuiTableCell-alignLeft"
-                      scope="col"
-                      style="font-weight: 700; box-sizing: border-box;"
-                    >
-                      Warnings
-                    </th>
-                  </tr>
-                </thead>
-                <tbody
-                  class="MuiTableBody-root"
-                />
               </table>
             </div>
           </div>

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -9,7 +9,7 @@ module.exports = {
     command:
       'echo "Building app..." && NEXT_PUBLIC_NODE_ENV_OVERRIDE=test npm run build && echo "Starting app..." && npm run start -- -p 3001',
     debug: true, // Allows us to see the output of the above commands.
-    launchTimeout: 60 * 1000,
+    launchTimeout: 120 * 1000,
     port: 3001,
   },
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -40,7 +40,7 @@ module.exports = {
   // Adds special extended assertions to Jest, thus simplifying the tests.
   setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
   testPathIgnorePatterns: ['/__tests__/', '/e2e/', '/node_modules/'],
-  testTimeout: 60000,
+  testTimeout: 120000,
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },

--- a/lib/metric-assignments.test.ts
+++ b/lib/metric-assignments.test.ts
@@ -1,3 +1,5 @@
+import _ from 'lodash'
+
 import Fixtures from '@/test-helpers/fixtures'
 
 import * as MetricAssignments from './metric-assignments'
@@ -16,6 +18,22 @@ describe('lib/metric-assignments.ts module', () => {
           minDifference: 0.1,
         }),
         Fixtures.createMetricAssignment({
+          metricAssignmentId: 127,
+          metricId: 1,
+          attributionWindowSeconds: AttributionWindowSeconds.OneHour,
+          changeExpected: false,
+          isPrimary: false,
+          minDifference: 10.5,
+        }),
+        Fixtures.createMetricAssignment({
+          metricAssignmentId: 126,
+          metricId: 1,
+          attributionWindowSeconds: AttributionWindowSeconds.FourWeeks,
+          changeExpected: false,
+          isPrimary: false,
+          minDifference: 10.5,
+        }),
+        Fixtures.createMetricAssignment({
           metricAssignmentId: 124,
           metricId: 2,
           attributionWindowSeconds: AttributionWindowSeconds.FourWeeks,
@@ -31,15 +49,20 @@ describe('lib/metric-assignments.ts module', () => {
           isPrimary: false,
           minDifference: 0.05,
         }),
+        Fixtures.createMetricAssignment({
+          metricAssignmentId: 200,
+          metricId: 3,
+          attributionWindowSeconds: AttributionWindowSeconds.SixHours,
+          changeExpected: false,
+          isPrimary: false,
+          minDifference: 0.05,
+        }),
       ]
 
       expect(MetricAssignments.sort(sortedMetricAssignments)).toEqual(sortedMetricAssignments)
-      expect(
-        MetricAssignments.sort([sortedMetricAssignments[1], sortedMetricAssignments[0], sortedMetricAssignments[2]]),
-      ).toEqual(sortedMetricAssignments)
-      expect(
-        MetricAssignments.sort([sortedMetricAssignments[2], sortedMetricAssignments[1], sortedMetricAssignments[0]]),
-      ).toEqual(sortedMetricAssignments)
+      _.range(0, 10).forEach(() => {
+        expect(MetricAssignments.sort(_.shuffle(sortedMetricAssignments))).toEqual(sortedMetricAssignments)
+      })
     })
   })
 })

--- a/lib/metric-assignments.ts
+++ b/lib/metric-assignments.ts
@@ -15,8 +15,24 @@ export const AttributionWindowSecondsToHuman: Record<AttributionWindowSeconds, s
 }
 
 /**
- * Return the experiment's variations sorted in the canonical order: Primary first, then by ID.
+ * Return the experiment's metric assignments sorted in a canonical order:
+ * - Primary first
+ * - Assignments with the same metricId are next to each other
+ * - Assignments with the same metricId are ordered by attributionWindow asc
+ * -
  */
 export function sort(metricAssignments: MetricAssignment[]) {
-  return _.orderBy(metricAssignments, ['isPrimary', 'metricAssignmentId'], ['desc', 'asc'])
+  const metricAssignmentsByMetric = Object.values(_.groupBy(metricAssignments, 'metricId'))
+    // Order within groups
+    .map((metricAssignments) =>
+      _.orderBy(metricAssignments, ['isPrimary', 'attributionWindowSeconds'], ['desc', 'asc']),
+    )
+  // Order the groups
+  const orderedMetricAssignmentsByMetric = _.orderBy(
+    metricAssignmentsByMetric,
+    ['[0].isPrimary', '[0].metricId'],
+    ['desc', 'asc'],
+  )
+
+  return _.flatten(orderedMetricAssignmentsByMetric)
 }


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR improves the sorting on Metric Assignments**
- Primary first
- Assignments with the same metricId are next to each other
- Assignments with the same metricId are ordered by attributionWindow asc

This makes it easier to compare metric assignments with the same metric.
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
