### PR TITLE
Reduce errors in unit tests

### DIFF
--- a/components/ExperimentPageView.test.tsx
+++ b/components/ExperimentPageView.test.tsx
@@ -83,11 +83,11 @@ const getButtonStates = () => {
 }
 
 test('experiment page view renders results without crashing', async () => {
-  const { container: _container } = await renderExperimentPageView({}, ExperimentView.Results)
+  await renderExperimentPageView({}, ExperimentView.Results)
 })
 
 test('experiment page view renders code-setup without crashing', async () => {
-  const { container: _container } = await renderExperimentPageView({}, ExperimentView.CodeSetup)
+  await renderExperimentPageView({}, ExperimentView.CodeSetup)
 })
 
 test('experiment page view renders with null experimentId without crashing', async () => {
@@ -104,10 +104,7 @@ test('experiment page view renders with null experimentId without crashing', asy
 })
 
 test('staging experiment shows correct features enabled in overview', async () => {
-  const { container: _container } = await renderExperimentPageView(
-    { experiment: { status: Status.Staging } },
-    ExperimentView.Overview,
-  )
+  await renderExperimentPageView({ experiment: { status: Status.Staging } }, ExperimentView.Overview)
 
   await waitFor(() => screen.getByRole('button', { name: /Assign Metric/ }))
 
@@ -122,10 +119,7 @@ test('staging experiment shows correct features enabled in overview', async () =
 })
 
 test('running experiment shows correct features enabled in overview', async () => {
-  const { container: _container } = await renderExperimentPageView(
-    { experiment: { status: Status.Running } },
-    ExperimentView.Overview,
-  )
+  await renderExperimentPageView({ experiment: { status: Status.Running } }, ExperimentView.Overview)
 
   await waitFor(() => screen.getByRole('button', { name: /Assign Metric/ }))
 
@@ -140,10 +134,7 @@ test('running experiment shows correct features enabled in overview', async () =
 })
 
 test('completed experiment shows correct features enabled in overview', async () => {
-  const { container: _container } = await renderExperimentPageView(
-    { experiment: { status: Status.Completed } },
-    ExperimentView.Overview,
-  )
+  await renderExperimentPageView({ experiment: { status: Status.Completed } }, ExperimentView.Overview)
 
   await waitFor(() => screen.getByRole('button', { name: /Assign Metric/ }))
 
@@ -158,10 +149,7 @@ test('completed experiment shows correct features enabled in overview', async ()
 })
 
 test('disabled experiment shows correct features enabled in overview', async () => {
-  const { container: _container } = await renderExperimentPageView(
-    { experiment: { status: Status.Disabled } },
-    ExperimentView.Overview,
-  )
+  await renderExperimentPageView({ experiment: { status: Status.Disabled } }, ExperimentView.Overview)
 
   await waitFor(() => screen.getByRole('button', { name: /Assign Metric/ }))
 

--- a/components/ExperimentPageView.test.tsx
+++ b/components/ExperimentPageView.test.tsx
@@ -49,13 +49,10 @@ const renderExperimentPageView = async ({ experiment: experimentOverrides = {} }
   const analyses = Fixtures.createAnalyses()
   mockedAnalysesApi.findByExperimentId.mockImplementationOnce(async () => analyses)
 
-  // This is needed to fix warnings:
-  let renderResult = null
+  // This `act` is needed to fix warnings:
   await act(async () => {
-    renderResult = render(<ExperimentPageView experimentId={experiment.experimentId} view={view} debugMode={false} />)
+    render(<ExperimentPageView experimentId={experiment.experimentId} view={view} debugMode={false} />)
   })
-
-  return renderResult as ReturnType<typeof render>
 }
 
 /**


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR reduces the unit test warnings**
- Fixes the act warnings

There only remains a `forwardRef` warning I haven't been able to figure out in the time-box for this:

<img width="959" alt="Screen Shot 2020-09-23 at 1 11 04 am" src="https://user-images.githubusercontent.com/971886/93914820-a7e53100-fd39-11ea-897a-af3aa221ec72.png">

<!-- Remember to include context: Why is this change required? What problem does it solve? -->
Part of a series on #229
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
