### PR TITLE
Fix the graph title for the difference interval

### DIFF
--- a/components/experiment-results/CondensedLatestAnalyses.tsx
+++ b/components/experiment-results/CondensedLatestAnalyses.tsx
@@ -407,7 +407,7 @@ function AnalysisDetailPanel({
         <Plot
           layout={{
             ...plotlyLayoutDefault,
-            title: isConversion ? `Conversation rate difference estimates [%]` : `Revenue difference estimates [$]`,
+            title: isConversion ? `Conversion rate difference estimates [%]` : `Revenue difference estimates [$]`,
           }}
           data={plotlyDataDifferenceGraph}
           className={classes.plot}

--- a/components/experiment-results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/components/experiment-results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -596,7 +596,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             "t": 64,
           },
           "showlegend": false,
-          "title": "Conversation rate difference estimates [%]",
+          "title": "Conversion rate difference estimates [%]",
         },
         "style": Object {
           "display": "inline-block",


### PR DESCRIPTION
Currently reads "Conversation" when it should read "Conversion". 😄

## How has this been tested?

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
