### PR TITLE
Add an autocomplete component

### DIFF
--- a/components/Autocomplete.test.tsx
+++ b/components/Autocomplete.test.tsx
@@ -1,0 +1,239 @@
+/* eslint-disable @typescript-eslint/require-await */
+import { InputAdornment, TextField as MuiTextField } from '@material-ui/core'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { Field } from 'formik'
+import { Autocomplete, AutocompleteRenderInputParams } from 'formik-material-ui-lab'
+import React from 'react'
+
+import AbacusAutocomplete, {
+  autocompleteAttributes,
+  autocompleteInputProps,
+  getOptionValue,
+} from '@/components/Autocomplete'
+import { AutocompleteItem } from '@/lib/schemas'
+import { changeFieldByRole, MockFormik } from '@/test-helpers/test-utils'
+
+// Needed for testing the autocomplete popper
+document.createRange = () => ({
+  setStart: () => undefined,
+  setEnd: () => undefined,
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  // @ts-ignore; This is just for mocking
+  commonAncestorContainer: {
+    nodeName: 'BODY',
+    ownerDocument: document,
+  },
+})
+
+test('An autocomplete component can be rendered', async () => {
+  const isLoading = false
+  const options = [
+    {
+      value: 'stuff',
+      name: 'Stuff',
+    },
+    {
+      value: 'other_stuff',
+      name: 'Other Stuff',
+    },
+  ]
+
+  const { container } = render(
+    <MockFormik initialValues={{ name: 'other_stuff' }}>
+      <Field
+        component={AbacusAutocomplete}
+        name='name'
+        id='name'
+        fullWidth
+        options={options}
+        loading={isLoading}
+        renderInput={(params: AutocompleteRenderInputParams) => {
+          return (
+            <MuiTextField
+              {...params}
+              placeholder='wp_username'
+              helperText='Use WordPress.com username.'
+              variant='outlined'
+              required
+              label='Owner'
+              InputProps={{
+                ...autocompleteInputProps(params, isLoading),
+                startAdornment: <InputAdornment position='start'>@</InputAdornment>,
+              }}
+              InputLabelProps={{
+                shrink: true,
+              }}
+            />
+          )
+        }}
+      />
+    </MockFormik>,
+  )
+  expect(container).toMatchSnapshot('initial render')
+
+  const textbox = screen.getByRole('textbox')
+  expect(textbox).toMatchInlineSnapshot(`
+    <input
+      aria-autocomplete="list"
+      aria-describedby="name-helper-text"
+      aria-invalid="false"
+      autocapitalize="none"
+      autocomplete="off"
+      class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+      id="name"
+      placeholder="wp_username"
+      required=""
+      spellcheck="false"
+      type="text"
+      value="other_stuff"
+    />
+  `)
+
+  await act(async () => {
+    fireEvent.click(textbox)
+  })
+  expect(container).toMatchSnapshot('clicked textbox')
+
+  await act(async () => {
+    await changeFieldByRole('textbox', /Owner/, 'stuff')
+  })
+  expect(container).toMatchSnapshot('entered value')
+
+  await act(async () => {
+    fireEvent.click(screen.getByText('Stuff'))
+  })
+  expect(container).toMatchSnapshot('clicked result')
+  expect(textbox).toMatchInlineSnapshot(`
+    <input
+      aria-autocomplete="list"
+      aria-describedby="name-helper-text"
+      aria-invalid="false"
+      autocapitalize="none"
+      autocomplete="off"
+      class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+      id="name"
+      placeholder="wp_username"
+      required=""
+      spellcheck="false"
+      type="text"
+      value="stuff"
+    />
+  `)
+
+  await act(async () => {
+    fireEvent.click(textbox)
+  })
+  expect(container).toMatchSnapshot('ensure stuff is selected')
+})
+
+test('it shows as loading data', () => {
+  const isLoading = true
+  const options: AutocompleteItem[] = []
+
+  const { container } = render(
+    <MockFormik initialValues={{ name: 'no_name' }}>
+      <Field
+        component={Autocomplete}
+        name='name'
+        id='name'
+        fullWidth
+        options={options}
+        loading={isLoading}
+        renderInput={(params: AutocompleteRenderInputParams) => {
+          return (
+            <MuiTextField
+              {...params}
+              placeholder='wp_username'
+              helperText='Use WordPress.com username.'
+              variant='outlined'
+              required
+              label='Owner'
+              InputProps={{
+                ...autocompleteInputProps(params, isLoading),
+                startAdornment: <InputAdornment position='start'>@</InputAdornment>,
+              }}
+              InputLabelProps={{
+                shrink: true,
+              }}
+            />
+          )
+        }}
+      />
+    </MockFormik>,
+  )
+  expect(container).toMatchSnapshot('loading')
+})
+
+test('null is a valid value', async () => {
+  const isLoading = false
+  const options: AutocompleteItem[] = [
+    {
+      name: 'Hello World',
+      value: 'hello_world',
+    },
+  ]
+
+  const { container } = render(
+    <MockFormik initialValues={{ name: null }}>
+      <Field
+        component={Autocomplete}
+        name='name'
+        id='name'
+        fullWidth
+        options={options}
+        loading={isLoading}
+        renderInput={(params: AutocompleteRenderInputParams) => {
+          return (
+            <MuiTextField
+              {...params}
+              placeholder='wp_username'
+              helperText='Use WordPress.com username.'
+              variant='outlined'
+              required
+              label='Owner'
+              InputProps={{
+                ...autocompleteInputProps(params, isLoading),
+                startAdornment: <InputAdornment position='start'>@</InputAdornment>,
+              }}
+              InputLabelProps={{
+                shrink: true,
+              }}
+            />
+          )
+        }}
+      />
+    </MockFormik>,
+  )
+  await act(async () => {
+    fireEvent.click(screen.getByRole('textbox'))
+  })
+  expect(container).toMatchSnapshot('selected no value')
+})
+
+test('attributes handle labels correctly', () => {
+  const attributes = autocompleteAttributes
+
+  expect(attributes.getOptionLabel('opt1')).toStrictEqual('opt1')
+  expect(attributes.getOptionLabel({ name: 'Opt1', value: 'opt1' })).toStrictEqual('Opt1')
+  expect(attributes.getOptionLabel(null)).toStrictEqual('')
+})
+
+test('attributes handle selection correctly', () => {
+  const attributes = autocompleteAttributes
+  const option = {
+    name: 'Hello World',
+    value: 'hello_world',
+  }
+  expect(attributes.getOptionSelected(option, '')).toBe(false)
+  expect(attributes.getOptionSelected(option, option)).toBe(true)
+})
+
+test('get option value works', () => {
+  const option = {
+    name: 'Hello World',
+    value: 'hello_world',
+  }
+  expect(getOptionValue(option)).toStrictEqual('hello_world')
+  expect(getOptionValue('hello')).toStrictEqual('hello')
+  expect(getOptionValue(null)).toStrictEqual('')
+})

--- a/components/Autocomplete.tsx
+++ b/components/Autocomplete.tsx
@@ -5,14 +5,6 @@ import React, { useCallback } from 'react'
 
 import { AutocompleteItem } from '@/lib/schemas'
 
-export interface AutocompleteAttributes {
-  renderInput: (params: AutocompleteRenderInputParams) => unknown
-  getOptionSelected: (option: AutocompleteItem, value: string | AutocompleteItem) => boolean
-  options: AutocompleteItem[]
-  loading: boolean
-  getOptionLabel: (option: AutocompleteItem | string | null) => string
-}
-
 export const getOptionValue = (option: AutocompleteItem | string | null) =>
   (typeof option === 'string' ? option : option?.value) ?? ''
 

--- a/components/Autocomplete.tsx
+++ b/components/Autocomplete.tsx
@@ -5,6 +5,7 @@ import React, { useCallback } from 'react'
 
 import { AutocompleteItem } from '@/lib/schemas'
 
+// break out these functions to achieve 100% coverage
 export const getOptionValue = (option: AutocompleteItem | string | null) =>
   (typeof option === 'string' ? option : option?.value) ?? ''
 

--- a/components/Autocomplete.tsx
+++ b/components/Autocomplete.tsx
@@ -5,7 +5,8 @@ import React, { useCallback } from 'react'
 
 import { AutocompleteItem } from '@/lib/schemas'
 
-// break out these functions to achieve 100% coverage
+// We need to handle the cases where the form is initialized with a string, or when we have a specific value selected.
+// Also, it's possible that the option is null, though typescript asserts that it isn't possible.
 export const getOptionValue = (option: AutocompleteItem | string | null) =>
   (typeof option === 'string' ? option : option?.value) ?? ''
 

--- a/components/Autocomplete.tsx
+++ b/components/Autocomplete.tsx
@@ -1,0 +1,56 @@
+import { CircularProgress } from '@material-ui/core'
+import { Autocomplete } from '@material-ui/lab'
+import { AutocompleteProps, AutocompleteRenderInputParams, fieldToAutocomplete } from 'formik-material-ui-lab'
+import React, { useCallback } from 'react'
+
+import { AutocompleteItem } from '@/lib/schemas'
+
+export interface AutocompleteAttributes {
+  renderInput: (params: AutocompleteRenderInputParams) => unknown
+  getOptionSelected: (option: AutocompleteItem, value: string | AutocompleteItem) => boolean
+  options: AutocompleteItem[]
+  loading: boolean
+  getOptionLabel: (option: AutocompleteItem | string | null) => string
+}
+
+export const getOptionValue = (option: AutocompleteItem | string | null) =>
+  (typeof option === 'string' ? option : option?.value) ?? ''
+
+export const getOptionLabel = (option: AutocompleteItem | string | null) =>
+  (typeof option === 'string' ? option : option?.name) ?? ''
+
+export const getOptionSelected = (option: AutocompleteItem, value: string | AutocompleteItem) =>
+  typeof value === 'string' ? value === option.value : value.value === option.value
+
+export const autocompleteAttributes = {
+  getOptionLabel: getOptionLabel,
+  getOptionSelected: getOptionSelected,
+}
+
+export const autocompleteInputProps = (params: AutocompleteRenderInputParams, loading: boolean) => {
+  return {
+    ...params.InputProps,
+    endAdornment: (
+      <>
+        {loading ? <CircularProgress color='inherit' size={20} /> : null}
+        {params.InputProps.endAdornment}
+      </>
+    ),
+  }
+}
+
+export default function AbacusAutocomplete(props: AutocompleteProps<AutocompleteItem, false, false, false>) {
+  const {
+    form: { setFieldValue },
+    field: { name },
+  } = props
+
+  const onChange = useCallback(
+    (ev, option: AutocompleteItem | string | null) => {
+      setFieldValue(name, getOptionValue(option))
+    },
+    [setFieldValue, name],
+  )
+
+  return <Autocomplete {...fieldToAutocomplete(props)} {...autocompleteAttributes} onChange={onChange} />
+}

--- a/components/__snapshots__/Autocomplete.test.tsx.snap
+++ b/components/__snapshots__/Autocomplete.test.tsx.snap
@@ -1,0 +1,940 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`An autocomplete component can be rendered: clicked result 1`] = `
+<div>
+  <div
+    aria-expanded="false"
+    class="MuiAutocomplete-root Mui-focused MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+    name="name"
+    role="combobox"
+  >
+    <div
+      class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+    >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled Mui-focused Mui-focused Mui-required Mui-required"
+        data-shrink="true"
+        for="name"
+        id="name-label"
+      >
+        Owner
+        <span
+          aria-hidden="true"
+          class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+        >
+           
+          *
+        </span>
+      </label>
+      <div
+        class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth Mui-focused Mui-focused MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+      >
+        <div
+          class="MuiInputAdornment-root MuiInputAdornment-positionStart"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
+          >
+            @
+          </p>
+        </div>
+        <input
+          aria-autocomplete="list"
+          aria-describedby="name-helper-text"
+          aria-invalid="false"
+          autocapitalize="none"
+          autocomplete="off"
+          class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+          id="name"
+          placeholder="wp_username"
+          required=""
+          spellcheck="false"
+          type="text"
+          value="stuff"
+        />
+        <div
+          class="MuiAutocomplete-endAdornment"
+        >
+          <button
+            aria-label="Clear"
+            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator MuiAutocomplete-clearIndicatorDirty"
+            tabindex="-1"
+            title="Clear"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            aria-label="Open"
+            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+            tabindex="-1"
+            title="Open"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M7 10l5 5 5-5z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+        <fieldset
+          aria-hidden="true"
+          class="PrivateNotchedOutline-root-1 MuiOutlinedInput-notchedOutline"
+        >
+          <legend
+            class="PrivateNotchedOutline-legendLabelled-3 PrivateNotchedOutline-legendNotched-4"
+          >
+            <span>
+              Owner
+               *
+            </span>
+          </legend>
+        </fieldset>
+      </div>
+      <p
+        class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-focused Mui-required"
+        id="name-helper-text"
+      >
+        Use WordPress.com username.
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`An autocomplete component can be rendered: clicked textbox 1`] = `
+<div>
+  <div
+    aria-expanded="false"
+    class="MuiAutocomplete-root Mui-focused MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+    name="name"
+    role="combobox"
+  >
+    <div
+      class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+    >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled Mui-focused Mui-focused Mui-required Mui-required"
+        data-shrink="true"
+        for="name"
+        id="name-label"
+      >
+        Owner
+        <span
+          aria-hidden="true"
+          class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+        >
+           
+          *
+        </span>
+      </label>
+      <div
+        class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth Mui-focused Mui-focused MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+      >
+        <div
+          class="MuiInputAdornment-root MuiInputAdornment-positionStart"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
+          >
+            @
+          </p>
+        </div>
+        <input
+          aria-autocomplete="list"
+          aria-describedby="name-helper-text"
+          aria-invalid="false"
+          autocapitalize="none"
+          autocomplete="off"
+          class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+          id="name"
+          placeholder="wp_username"
+          required=""
+          spellcheck="false"
+          type="text"
+          value="other_stuff"
+        />
+        <div
+          class="MuiAutocomplete-endAdornment"
+        >
+          <button
+            aria-label="Clear"
+            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator MuiAutocomplete-clearIndicatorDirty"
+            tabindex="-1"
+            title="Clear"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            aria-label="Open"
+            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+            tabindex="-1"
+            title="Open"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M7 10l5 5 5-5z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+        <fieldset
+          aria-hidden="true"
+          class="PrivateNotchedOutline-root-1 MuiOutlinedInput-notchedOutline"
+        >
+          <legend
+            class="PrivateNotchedOutline-legendLabelled-3 PrivateNotchedOutline-legendNotched-4"
+          >
+            <span>
+              Owner
+               *
+            </span>
+          </legend>
+        </fieldset>
+      </div>
+      <p
+        class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-focused Mui-required"
+        id="name-helper-text"
+      >
+        Use WordPress.com username.
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`An autocomplete component can be rendered: ensure stuff is selected 1`] = `
+<div>
+  <div
+    aria-expanded="false"
+    class="MuiAutocomplete-root Mui-focused MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+    name="name"
+    role="combobox"
+  >
+    <div
+      class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+    >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled Mui-focused Mui-focused Mui-required Mui-required"
+        data-shrink="true"
+        for="name"
+        id="name-label"
+      >
+        Owner
+        <span
+          aria-hidden="true"
+          class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+        >
+           
+          *
+        </span>
+      </label>
+      <div
+        class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth Mui-focused Mui-focused MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+      >
+        <div
+          class="MuiInputAdornment-root MuiInputAdornment-positionStart"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
+          >
+            @
+          </p>
+        </div>
+        <input
+          aria-autocomplete="list"
+          aria-describedby="name-helper-text"
+          aria-invalid="false"
+          autocapitalize="none"
+          autocomplete="off"
+          class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+          id="name"
+          placeholder="wp_username"
+          required=""
+          spellcheck="false"
+          type="text"
+          value="stuff"
+        />
+        <div
+          class="MuiAutocomplete-endAdornment"
+        >
+          <button
+            aria-label="Clear"
+            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator MuiAutocomplete-clearIndicatorDirty"
+            tabindex="-1"
+            title="Clear"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            aria-label="Open"
+            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+            tabindex="-1"
+            title="Open"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M7 10l5 5 5-5z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+        <fieldset
+          aria-hidden="true"
+          class="PrivateNotchedOutline-root-1 MuiOutlinedInput-notchedOutline"
+        >
+          <legend
+            class="PrivateNotchedOutline-legendLabelled-3 PrivateNotchedOutline-legendNotched-4"
+          >
+            <span>
+              Owner
+               *
+            </span>
+          </legend>
+        </fieldset>
+      </div>
+      <p
+        class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-focused Mui-required"
+        id="name-helper-text"
+      >
+        Use WordPress.com username.
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`An autocomplete component can be rendered: entered value 1`] = `
+<div>
+  <div
+    aria-expanded="true"
+    aria-owns="name-popup"
+    class="MuiAutocomplete-root Mui-focused MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+    name="name"
+    role="combobox"
+  >
+    <div
+      class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+    >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled Mui-focused Mui-focused Mui-required Mui-required"
+        data-shrink="true"
+        for="name"
+        id="name-label"
+      >
+        Owner
+        <span
+          aria-hidden="true"
+          class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+        >
+           
+          *
+        </span>
+      </label>
+      <div
+        class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth Mui-focused Mui-focused MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+      >
+        <div
+          class="MuiInputAdornment-root MuiInputAdornment-positionStart"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
+          >
+            @
+          </p>
+        </div>
+        <input
+          aria-activedescendant="name-option-1"
+          aria-autocomplete="list"
+          aria-controls="name-popup"
+          aria-describedby="name-helper-text"
+          aria-invalid="false"
+          autocapitalize="none"
+          autocomplete="off"
+          class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+          id="name"
+          placeholder="wp_username"
+          required=""
+          spellcheck="false"
+          type="text"
+          value="stuff"
+        />
+        <div
+          class="MuiAutocomplete-endAdornment"
+        >
+          <button
+            aria-label="Clear"
+            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator MuiAutocomplete-clearIndicatorDirty"
+            tabindex="-1"
+            title="Clear"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            aria-label="Close"
+            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator MuiAutocomplete-popupIndicatorOpen"
+            tabindex="-1"
+            title="Close"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M7 10l5 5 5-5z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+        <fieldset
+          aria-hidden="true"
+          class="PrivateNotchedOutline-root-1 MuiOutlinedInput-notchedOutline"
+        >
+          <legend
+            class="PrivateNotchedOutline-legendLabelled-3 PrivateNotchedOutline-legendNotched-4"
+          >
+            <span>
+              Owner
+               *
+            </span>
+          </legend>
+        </fieldset>
+      </div>
+      <p
+        class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-focused Mui-required"
+        id="name-helper-text"
+      >
+        Use WordPress.com username.
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`An autocomplete component can be rendered: initial render 1`] = `
+<div>
+  <div
+    aria-expanded="false"
+    class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+    name="name"
+    role="combobox"
+  >
+    <div
+      class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+    >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled Mui-required Mui-required"
+        data-shrink="true"
+        for="name"
+        id="name-label"
+      >
+        Owner
+        <span
+          aria-hidden="true"
+          class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+        >
+           
+          *
+        </span>
+      </label>
+      <div
+        class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+      >
+        <div
+          class="MuiInputAdornment-root MuiInputAdornment-positionStart"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
+          >
+            @
+          </p>
+        </div>
+        <input
+          aria-autocomplete="list"
+          aria-describedby="name-helper-text"
+          aria-invalid="false"
+          autocapitalize="none"
+          autocomplete="off"
+          class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+          id="name"
+          placeholder="wp_username"
+          required=""
+          spellcheck="false"
+          type="text"
+          value="other_stuff"
+        />
+        <div
+          class="MuiAutocomplete-endAdornment"
+        >
+          <button
+            aria-label="Clear"
+            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator MuiAutocomplete-clearIndicatorDirty"
+            tabindex="-1"
+            title="Clear"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            aria-label="Open"
+            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+            tabindex="-1"
+            title="Open"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M7 10l5 5 5-5z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+        <fieldset
+          aria-hidden="true"
+          class="PrivateNotchedOutline-root-1 MuiOutlinedInput-notchedOutline"
+        >
+          <legend
+            class="PrivateNotchedOutline-legendLabelled-3 PrivateNotchedOutline-legendNotched-4"
+          >
+            <span>
+              Owner
+               *
+            </span>
+          </legend>
+        </fieldset>
+      </div>
+      <p
+        class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
+        id="name-helper-text"
+      >
+        Use WordPress.com username.
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`it shows as loading data: loading 1`] = `
+<div>
+  <div
+    aria-expanded="false"
+    class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+    name="name"
+    role="combobox"
+  >
+    <div
+      class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+    >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled Mui-required Mui-required"
+        data-shrink="true"
+        for="name"
+        id="name-label"
+      >
+        Owner
+        <span
+          aria-hidden="true"
+          class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+        >
+           
+          *
+        </span>
+      </label>
+      <div
+        class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+      >
+        <div
+          class="MuiInputAdornment-root MuiInputAdornment-positionStart"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
+          >
+            @
+          </p>
+        </div>
+        <input
+          aria-autocomplete="list"
+          aria-describedby="name-helper-text"
+          aria-invalid="false"
+          autocapitalize="none"
+          autocomplete="off"
+          class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+          id="name"
+          placeholder="wp_username"
+          required=""
+          spellcheck="false"
+          type="text"
+          value="no_name"
+        />
+        <div
+          class="MuiCircularProgress-root MuiCircularProgress-indeterminate"
+          role="progressbar"
+          style="width: 20px; height: 20px;"
+        >
+          <svg
+            class="MuiCircularProgress-svg"
+            viewBox="22 22 44 44"
+          >
+            <circle
+              class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate"
+              cx="44"
+              cy="44"
+              fill="none"
+              r="20.2"
+              stroke-width="3.6"
+            />
+          </svg>
+        </div>
+        <div
+          class="MuiAutocomplete-endAdornment"
+        >
+          <button
+            aria-label="Clear"
+            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator MuiAutocomplete-clearIndicatorDirty"
+            tabindex="-1"
+            title="Clear"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            aria-label="Open"
+            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+            tabindex="-1"
+            title="Open"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M7 10l5 5 5-5z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+        <fieldset
+          aria-hidden="true"
+          class="PrivateNotchedOutline-root-5 MuiOutlinedInput-notchedOutline"
+        >
+          <legend
+            class="PrivateNotchedOutline-legendLabelled-7 PrivateNotchedOutline-legendNotched-8"
+          >
+            <span>
+              Owner
+               *
+            </span>
+          </legend>
+        </fieldset>
+      </div>
+      <p
+        class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
+        id="name-helper-text"
+      >
+        Use WordPress.com username.
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`null is a valid value: selected no value 1`] = `
+<div>
+  <div
+    aria-expanded="false"
+    class="MuiAutocomplete-root Mui-focused MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+    name="name"
+    role="combobox"
+  >
+    <div
+      class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+    >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-focused Mui-focused Mui-required Mui-required"
+        data-shrink="true"
+        for="name"
+        id="name-label"
+      >
+        Owner
+        <span
+          aria-hidden="true"
+          class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+        >
+           
+          *
+        </span>
+      </label>
+      <div
+        class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth Mui-focused Mui-focused MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+      >
+        <div
+          class="MuiInputAdornment-root MuiInputAdornment-positionStart"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
+          >
+            @
+          </p>
+        </div>
+        <input
+          aria-autocomplete="list"
+          aria-describedby="name-helper-text"
+          aria-invalid="false"
+          autocapitalize="none"
+          autocomplete="off"
+          class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+          id="name"
+          placeholder="wp_username"
+          required=""
+          spellcheck="false"
+          type="text"
+          value=""
+        />
+        <div
+          class="MuiAutocomplete-endAdornment"
+        >
+          <button
+            aria-label="Clear"
+            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
+            tabindex="-1"
+            title="Clear"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            aria-label="Open"
+            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+            tabindex="-1"
+            title="Open"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M7 10l5 5 5-5z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+        <fieldset
+          aria-hidden="true"
+          class="PrivateNotchedOutline-root-9 MuiOutlinedInput-notchedOutline"
+        >
+          <legend
+            class="PrivateNotchedOutline-legendLabelled-11 PrivateNotchedOutline-legendNotched-12"
+          >
+            <span>
+              Owner
+               *
+            </span>
+          </legend>
+        </fieldset>
+      </div>
+      <p
+        class="MuiFormHelperText-root MuiFormHelperText-contained Mui-focused Mui-required"
+        id="name-helper-text"
+      >
+        Use WordPress.com username.
+      </p>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
This component is a simple wrapper around the material UI autocomplete component See tests on how to use.

## How has this been tested?

Storybook