### PR TITLE
Add debug query parameter to requests in debug mode

### DIFF
--- a/api/ExperimentsApi.ts
+++ b/api/ExperimentsApi.ts
@@ -15,6 +15,7 @@ import {
   Status,
   yupPick,
 } from '@/lib/schemas'
+import { isDebugMode } from '@/utils/general'
 
 import { fetchApi } from './utils'
 
@@ -106,7 +107,8 @@ async function assignMetric(experiment: ExperimentFull, metricAssignment: Metric
  * @throws UnauthorizedError
  */
 async function findAll(): Promise<ExperimentBare[]> {
-  const { experiments } = await fetchApi('GET', '/experiments')
+  // istanbul ignore next; debug only
+  const { experiments } = await fetchApi('GET', isDebugMode() ? '/experiments?debug=true' : '/experiments')
   return await yup.array(experimentBareSchema).defined().validate(experiments, { abortEarly: false })
 }
 

--- a/api/MetricsApi.ts
+++ b/api/MetricsApi.ts
@@ -10,6 +10,7 @@ import {
   metricFullNewSchema,
   metricFullSchema,
 } from '@/lib/schemas'
+import { isDebugMode } from '@/utils/general'
 
 import { fetchApi } from './utils'
 
@@ -49,7 +50,8 @@ async function put(metricId: number, newMetric: MetricFullNew) {
  * @throws UnauthorizedError
  */
 async function findAll(): Promise<MetricBare[]> {
-  const { metrics } = await fetchApi('GET', '/metrics')
+  // istanbul ignore next; debug only
+  const { metrics } = await fetchApi('GET', isDebugMode() ? '/metrics?debug=true' : '/metrics')
   return await yup.array(metricBareSchema).defined().validate(metrics, { abortEarly: false })
 }
 


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR adds debug query parameter to requests in debug mode to allow the server to known when to filter requests.**
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Successor of #319 

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover existing functionality
- Manual testing with production data (locally)
   - Checked that debug parameter was being applied in debug more and not applied in non-debug mode
   - I also checked that the filtering behaviour was as expected in my sandbox