### PR TITLE
Improve CircleCI setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,11 +52,10 @@ jobs:
       # Reuse the workspace from the build job
       - attach_workspace:
           at: .
-      # Adapted from https://circleci.com/orbs/registry/orb/threetreeslight/puppeteer.
-      # Not using this Orb directly to prevent re-downloading Chromium which was already
-      # done in the build step.
-      # Ideally, we'd use an image/executor that already have these dependencies, but
-      # that's not supported yet.
+      # Adapted from https://circleci.com/orbs/registry/orb/threetreeslight/puppeteer. Not using this Orb directly to
+      # prevent re-downloading Chromium which was already done in the build step.
+      # We only run this step here rather than in the build job because Chrome isn't needed for the other jobs.
+      # Ideally, we'd use an image/executor that already have these dependencies, but that's not supported yet.
       # See https://discuss.circleci.com/t/new-ruby-convenience-image-public-beta/33274/6
       - run:
           name: Install Headless Chrome Dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             sudo apt install -yqq \
             gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
             libexpat1 libfontconfig1 libgbm-dev libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 \
-            libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1
+            libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
             libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
             ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           paths:
             - .
 
-  run-static-checks:
+  static-checks:
     executor:
       name: node/default
       tag: '12.18.4'
@@ -32,7 +32,7 @@ jobs:
           name: Linting
           command: npm run lint
 
-  unit-test:
+  unit-tests:
     executor:
       name: node/default
       tag: '12.18.4'
@@ -44,7 +44,7 @@ jobs:
           name: Unit Testing
           command: npm run test:unit -- -- --ci --maxWorkers 2
 
-  integration-e2e-test:
+  integration-e2e:
     executor:
       name: node/default
       tag: '12.18.4'
@@ -52,19 +52,57 @@ jobs:
       # Reuse the workspace from the build job
       - attach_workspace:
           at: .
-      # Copied from https://circleci.com/orbs/registry/orb/threetreeslight/puppeteer.
+      # Adapted from https://circleci.com/orbs/registry/orb/threetreeslight/puppeteer.
       # Not using this Orb directly to prevent re-downloading Chromium which was already
-      # done in the previous step.
+      # done in the build step.
+      # Ideally, we'd use an image/executor that already have these dependencies, but
+      # that's not supported yet.
+      # See https://discuss.circleci.com/t/new-ruby-convenience-image-public-beta/33274/6
       - run:
           name: Install Headless Chrome Dependencies
           command: |
             sudo apt update -qq
             sudo apt install -yqq \
-            gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-            libexpat1 libfontconfig1 libgbm-dev libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 \
-            libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
-            libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
-            ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+              ca-certificates \
+              fonts-liberation \
+              gconf-service \
+              libappindicator1 \
+              libasound2 \
+              libatk1.0-0 \
+              libatk-bridge2.0-0 \
+              libc6 \
+              libcairo2 \
+              libcups2 \
+              libdbus-1-3 \
+              libexpat1 \
+              libfontconfig1 \
+              libgbm-dev \
+              libgcc1 \
+              libgconf-2-4 \
+              libgdk-pixbuf2.0-0 \
+              libglib2.0-0 \
+              libgtk-3-0 \
+              libnspr4 \
+              libnss3 \
+              libpango-1.0-0 \
+              libpangocairo-1.0-0 \
+              libstdc++6 \
+              libx11-6 \
+              libx11-xcb1 \
+              libxcb1 \
+              libxcomposite1 \
+              libxcursor1 \
+              libxdamage1 \
+              libxext6 \
+              libxfixes3 \
+              libxi6 \
+              libxrandr2 \
+              libxrender1 \
+              libxss1 \
+              libxtst6 \
+              lsb-release \
+              xdg-utils \
+              wget
       - run:
           name: Configure local host mapping
           command: echo 127.0.0.1 a8c-abacus-local | sudo tee -a /etc/hosts
@@ -79,12 +117,12 @@ workflows:
   build-and-test:
     jobs:
       - build
-      - run-static-checks:
+      - static-checks:
           requires:
             - build
-      - unit-test:
+      - unit-tests:
           requires:
             - build
-      - integration-e2e-test:
+      - integration-e2e:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,12 @@ jobs:
           name: Install Headless Chrome Dependencies
           command: |
             sudo apt update -qq
-            sudo apt install -yqq libgbm-dev
+            sudo apt install -yqq \
+            gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
+            libexpat1 libfontconfig1 libgbm-dev libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 \
+            libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
+            libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
+            ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
       - run:
           name: Configure local host mapping
           command: echo 127.0.0.1 a8c-abacus-local | sudo tee -a /etc/hosts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     executor:
       name: node/default
-      tag: '12.18.4'
+      tag: '12.18.4-browsers'
     steps:
       - checkout
       - node/install-packages
@@ -20,7 +20,7 @@ jobs:
   run-static-checks:
     executor:
       name: node/default
-      tag: '12.18.4'
+      tag: '12.18.4-browsers'
     steps:
       # Reuse the workspace from the build job
       - attach_workspace:
@@ -35,7 +35,7 @@ jobs:
   unit-test:
     executor:
       name: node/default
-      tag: '12.18.4'
+      tag: '12.18.4-browsers'
     steps:
       # Reuse the workspace from the build job
       - attach_workspace:
@@ -47,7 +47,7 @@ jobs:
   integration-e2e-test:
     executor:
       name: node/default
-      tag: '12.18.4'
+      tag: '12.18.4-browsers'
     steps:
       # Reuse the workspace from the build job
       - attach_workspace:
@@ -55,16 +55,16 @@ jobs:
       # Copied from https://circleci.com/orbs/registry/orb/threetreeslight/puppeteer.
       # Not using this Orb directly to prevent re-downloading Chromium which was already
       # done in the previous step.
-      - run:
-          name: Install Headless Chrome Dependencies
-          command: |
-            sudo apt update -qq
-            sudo apt install -yqq \
-            gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-            libexpat1 libfontconfig1 libgbm-dev libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 \
-            libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
-            libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
-            ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+      # - run:
+      #    name: Install Headless Chrome Dependencies
+      #    command: |
+      #      sudo apt update -qq
+      #      sudo apt install -yqq \
+      #      gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
+      #      libexpat1 libfontconfig1 libgbm-dev libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 \
+      #      libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
+      #      libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
+      #      ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
       - run:
           name: Configure local host mapping
           command: echo 127.0.0.1 a8c-abacus-local | sudo tee -a /etc/hosts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     executor:
       name: node/default
-      tag: '12.18.4-browsers'
+      tag: '12.18.4'
     steps:
       - checkout
       - node/install-packages
@@ -20,7 +20,7 @@ jobs:
   run-static-checks:
     executor:
       name: node/default
-      tag: '12.18.4-browsers'
+      tag: '12.18.4'
     steps:
       # Reuse the workspace from the build job
       - attach_workspace:
@@ -35,7 +35,7 @@ jobs:
   unit-test:
     executor:
       name: node/default
-      tag: '12.18.4-browsers'
+      tag: '12.18.4'
     steps:
       # Reuse the workspace from the build job
       - attach_workspace:
@@ -47,7 +47,7 @@ jobs:
   integration-e2e-test:
     executor:
       name: node/default
-      tag: '12.18.4-browsers'
+      tag: '12.18.4'
     steps:
       # Reuse the workspace from the build job
       - attach_workspace:
@@ -55,16 +55,16 @@ jobs:
       # Copied from https://circleci.com/orbs/registry/orb/threetreeslight/puppeteer.
       # Not using this Orb directly to prevent re-downloading Chromium which was already
       # done in the previous step.
-      # - run:
-      #    name: Install Headless Chrome Dependencies
-      #    command: |
-      #      sudo apt update -qq
-      #      sudo apt install -yqq \
-      #      gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-      #      libexpat1 libfontconfig1 libgbm-dev libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 \
-      #      libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
-      #      libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
-      #      ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+      - run:
+          name: Install Headless Chrome Dependencies
+          command: |
+            sudo apt update -qq
+            sudo apt install -yqq \
+            gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
+            libexpat1 libfontconfig1 libgbm-dev libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 \
+            libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
+            libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
+            ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
       - run:
           name: Configure local host mapping
           command: echo 127.0.0.1 a8c-abacus-local | sudo tee -a /etc/hosts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,51 +1,47 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@1.1.6
+  node: circleci/node@4.0.1
 
 jobs:
   build-and-verify:
     executor:
       name: node/default
-      tag: '10.18.1'
+      tag: '12.18.4'
     steps:
       - checkout
-      - node/with-cache:
-          steps:
-            - run:
-                name: Install Package Dependencies
-                command: npm install
-            # Copied from https://circleci.com/orbs/registry/orb/threetreeslight/puppeteer.
-            # Not using this Orb directly to prevent re-downloading Chromium which was already
-            # done in the previous step.
-            - run:
-                name: Install Headless Chrome Dependencies
-                command: |
-                  sudo apt update -qq
-                  sudo apt install -yqq \
-                  gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-                  libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
-                  libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 \
-                  libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
-                  fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
-            - run:
-                name: Configure local host mapping
-                command: echo 127.0.0.1 a8c-abacus-local | sudo tee -a /etc/hosts
-            - run:
-                name: Format Checking
-                command: npm run format:check
-            - run:
-                name: Linting
-                command: npm run lint
-            - run:
-                name: Unit Testing
-                command: npm run test:unit -- -- --ci --maxWorkers 2
-            - run:
-                name: Integration Testing
-                command: npm run test:integration -- --ci
-            - run:
-                name: End-to-End Testing
-                command: npm run test:e2e -- --ci
+      - node/install-packages
+      # Copied from https://circleci.com/orbs/registry/orb/threetreeslight/puppeteer.
+      # Not using this Orb directly to prevent re-downloading Chromium which was already
+      # done in the previous step.
+      - run:
+          name: Install Headless Chrome Dependencies
+          command: |
+            sudo apt update -qq
+            sudo apt install -yqq \
+            gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
+            libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
+            libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 \
+            libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
+            fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+      - run:
+          name: Configure local host mapping
+          command: echo 127.0.0.1 a8c-abacus-local | sudo tee -a /etc/hosts
+      - run:
+          name: Format Checking
+          command: npm run format:check
+      - run:
+          name: Linting
+          command: npm run lint
+      - run:
+          name: Unit Testing
+          command: npm run test:unit -- -- --ci --maxWorkers 2
+      - run:
+          name: Integration Testing
+          command: npm run test:integration -- --ci
+      - run:
+          name: End-to-End Testing
+          command: npm run test:e2e -- --ci
 
 workflows:
   build-and-verify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,27 @@ orbs:
   node: circleci/node@4.0.1
 
 jobs:
-  build-and-verify:
+  build:
     executor:
       name: node/default
       tag: '12.18.4'
     steps:
       - checkout
       - node/install-packages
+      # Save workspace for subsequent jobs
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+
+  test:
+    executor:
+      name: node/default
+      tag: '12.18.4'
+    steps:
+      # Reuse the workspace from the build job
+      - attach_workspace:
+          at: .
       # Copied from https://circleci.com/orbs/registry/orb/threetreeslight/puppeteer.
       # Not using this Orb directly to prevent re-downloading Chromium which was already
       # done in the previous step.
@@ -44,6 +58,9 @@ jobs:
           command: npm run test:e2e -- --ci
 
 workflows:
-  build-and-verify:
+  build-and-test:
     jobs:
-      - build-and-verify
+      - build
+      - test:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,12 +59,7 @@ jobs:
           name: Install Headless Chrome Dependencies
           command: |
             sudo apt update -qq
-            sudo apt install -yqq \
-            gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-            libexpat1 libfontconfig1 libgbm-dev libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 \
-            libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
-            libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
-            ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+            sudo apt install -yqq libgbm-dev
       - run:
           name: Configure local host mapping
           command: echo 127.0.0.1 a8c-abacus-local | sudo tee -a /etc/hosts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,34 @@ jobs:
           paths:
             - .
 
-  test:
+  run-static-checks:
+    executor:
+      name: node/default
+      tag: '12.18.4'
+    steps:
+      # Reuse the workspace from the build job
+      - attach_workspace:
+          at: .
+      - run:
+          name: Format Checking
+          command: npm run format:check
+      - run:
+          name: Linting
+          command: npm run lint
+
+  unit-test:
+    executor:
+      name: node/default
+      tag: '12.18.4'
+    steps:
+      # Reuse the workspace from the build job
+      - attach_workspace:
+          at: .
+      - run:
+          name: Unit Testing
+          command: npm run test:unit -- -- --ci --maxWorkers 2
+
+  integration-e2e-test:
     executor:
       name: node/default
       tag: '12.18.4'
@@ -42,15 +69,6 @@ jobs:
           name: Configure local host mapping
           command: echo 127.0.0.1 a8c-abacus-local | sudo tee -a /etc/hosts
       - run:
-          name: Format Checking
-          command: npm run format:check
-      - run:
-          name: Linting
-          command: npm run lint
-      - run:
-          name: Unit Testing
-          command: npm run test:unit -- -- --ci --maxWorkers 2
-      - run:
           name: Integration Testing
           command: npm run test:integration -- --ci
       - run:
@@ -61,6 +79,12 @@ workflows:
   build-and-test:
     jobs:
       - build
-      - test:
+      - run-static-checks:
+          requires:
+            - build
+      - unit-test:
+          requires:
+            - build
+      - integration-e2e-test:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,10 @@ jobs:
             sudo apt update -qq
             sudo apt install -yqq \
             gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-            libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
-            libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 \
-            libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
-            fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+            libexpat1 libfontconfig1 libgbm-dev libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 \
+            libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1
+            libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
+            ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
       - run:
           name: Configure local host mapping
           command: echo 127.0.0.1 a8c-abacus-local | sudo tee -a /etc/hosts


### PR DESCRIPTION
A bunch of improvements to our CircleCI setup:

* Use [the latest Node Orb](https://circleci.com/orbs/registry/orb/circleci/node)
* Change the Node executor version to match what we have in `.nvmrc`
* Use the `node/install-packages` step from the orb, which runs `npm ci` with caching (closes #89)
* Split the workflow into steps that can be run in parallel, which means that "rerun from failed" is now useful. :tada: As noted in https://github.com/Automattic/abacus/issues/331#issuecomment-701865831, I think that this is enough to close #331, as any remaining flakiness would be less of a pain to deal with.

## How has this been tested?

By observing [a faster and more modular CircleCI run](https://app.circleci.com/pipelines/github/Automattic/abacus/1342/workflows/23a46617-3b72-46c8-9f2c-672746eca974):

![Peek 2020-10-01 14-02](https://user-images.githubusercontent.com/3952615/94766327-daa0c080-03ee-11eb-9959-03a39b59e9d5.gif)
