### PR TITLE
Order debug result tables by strategy

### DIFF
--- a/components/experiment-results/FullLatestAnalyses.tsx
+++ b/components/experiment-results/FullLatestAnalyses.tsx
@@ -86,7 +86,7 @@ export default function FullLatestAnalyses({
           </Typography>
           <MaterialTable
             columns={tableColumns}
-            data={latestAnalyses}
+            data={_.sortBy(latestAnalyses, 'analysisStrategy')}
             options={createStaticTableOptions(latestAnalyses.length)}
           />
           <br />

--- a/components/experiment-results/ParticipantCounts.tsx
+++ b/components/experiment-results/ParticipantCounts.tsx
@@ -1,4 +1,4 @@
-import { last } from 'lodash'
+import _, { last } from 'lodash'
 import MaterialTable from 'material-table'
 import React from 'react'
 
@@ -38,7 +38,7 @@ export default function ParticipantCounts({
   return (
     <MaterialTable
       columns={tableColumns}
-      data={latestPrimaryMetricAnalyses}
+      data={_.sortBy(latestPrimaryMetricAnalyses, 'analysisStrategy')}
       options={createStaticTableOptions(latestPrimaryMetricAnalyses.length)}
     />
   )


### PR DESCRIPTION
The refactoring in #333 removed the ordering of the debug result tables by strategy. This PR brings it back, as it makes the total participant counts be roughly in descending order.

Before:

![image](https://user-images.githubusercontent.com/3952615/95170271-85521e00-07f7-11eb-84f5-58856b32a5ee.png)

After:

![image](https://user-images.githubusercontent.com/3952615/95170338-a155bf80-07f7-11eb-8ce8-a0ba88e0300b.png)


## How has this been tested?

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)