### PR TITLE
Add areas to variant graphs

### DIFF
--- a/src/components/experiment-results/CondensedLatestAnalyses.tsx
+++ b/src/components/experiment-results/CondensedLatestAnalyses.tsx
@@ -434,7 +434,7 @@ function AnalysisDetailPanel({
         <Plot
           layout={{
             ...Visualizations.plotlyLayoutDefault,
-            title: isConversion ? `Conversion rate estimates by variation [%]` : `Revenue estimates by variation [$]`,
+            title: isConversion ? `Conversion rate estimates by variation (%)` : `Revenue estimates by variation ($)`,
           }}
           data={plotlyDataVariationGraph}
           className={classes.metricEstimatePlot}
@@ -442,7 +442,7 @@ function AnalysisDetailPanel({
         <Plot
           layout={{
             ...Visualizations.plotlyLayoutDefault,
-            title: isConversion ? `Conversion rate difference estimates [%]` : `Revenue difference estimates [$]`,
+            title: isConversion ? `Conversion rate difference estimates (%)` : `Revenue difference estimates ($)`,
           }}
           data={plotlyDataDifferenceGraph}
           className={classes.metricEstimatePlot}

--- a/src/components/experiment-results/CondensedLatestAnalyses.tsx
+++ b/src/components/experiment-results/CondensedLatestAnalyses.tsx
@@ -312,6 +312,8 @@ function AnalysisDetailPanel({
           line: {
             color: Visualizations.variantColors[index],
           },
+          fill: 'tonexty' as const,
+          fillcolor: Visualizations.variantColors[index],
           mode: 'lines' as const,
           type: 'scatter' as const,
         },

--- a/src/components/experiment-results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiment-results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -510,6 +510,8 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             ],
           },
           Object {
+            "fill": "tonexty",
+            "fillcolor": "#1f78b488",
             "line": Object {
               "color": "#1f78b488",
             },
@@ -538,6 +540,8 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             ],
           },
           Object {
+            "fill": "tonexty",
+            "fillcolor": "#ff7f0088",
             "line": Object {
               "color": "#ff7f0088",
             },
@@ -1197,6 +1201,8 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             ],
           },
           Object {
+            "fill": "tonexty",
+            "fillcolor": "#1f78b488",
             "line": Object {
               "color": "#1f78b488",
             },
@@ -1225,6 +1231,8 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             ],
           },
           Object {
+            "fill": "tonexty",
+            "fillcolor": "#ff7f0088",
             "line": Object {
               "color": "#ff7f0088",
             },

--- a/src/components/experiment-results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiment-results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -569,7 +569,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             "t": 64,
           },
           "showlegend": false,
-          "title": "Conversion rate estimates by variation [%]",
+          "title": "Conversion rate estimates by variation (%)",
         },
         "style": Object {
           "display": "inline-block",
@@ -663,7 +663,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             "t": 64,
           },
           "showlegend": false,
-          "title": "Conversion rate difference estimates [%]",
+          "title": "Conversion rate difference estimates (%)",
         },
         "style": Object {
           "display": "inline-block",
@@ -1260,7 +1260,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             "t": 64,
           },
           "showlegend": false,
-          "title": "Revenue estimates by variation [$]",
+          "title": "Revenue estimates by variation ($)",
         },
         "style": Object {
           "display": "inline-block",
@@ -1354,7 +1354,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             "t": 64,
           },
           "showlegend": false,
-          "title": "Revenue difference estimates [$]",
+          "title": "Revenue difference estimates ($)",
         },
         "style": Object {
           "display": "inline-block",


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR adds areas to the variant graphs.**

Before:

<img width="1129" alt="Screen Shot 2020-10-14 at 4 17 21 pm" src="https://user-images.githubusercontent.com/971886/95962318-cf12b800-0e38-11eb-8d5d-421c3e75311a.png">

After:

<img width="1133" alt="Screen Shot 2020-10-14 at 4 07 00 pm" src="https://user-images.githubusercontent.com/971886/95961216-53643b80-0e37-11eb-86f6-24edff379fc7.png">

See pbmo2S-vR-p2#comment-1215

Also I rounded the unit brackets which I believe ended up squared by mistake.
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
- Manual testing with mock data (locally or on Vercel)
- Additional manual testing instructions (please specify):
