### PR TITLE
Improve results page

### DIFF
--- a/src/components/experiment-results/CondensedLatestAnalyses.tsx
+++ b/src/components/experiment-results/CondensedLatestAnalyses.tsx
@@ -156,6 +156,7 @@ export default function CondensedLatestAnalyses({
     }),
   ]
 
+  // istanbul ignore next; We shouldn't be showing any analysis in the case of no analysis
   const finalizedPercentage =
     100 - (latestAnalysis?.participantStats.not_final ?? 0) / (latestAnalysis?.participantStats.total ?? 1)
 

--- a/src/components/experiment-results/CondensedLatestAnalyses.tsx
+++ b/src/components/experiment-results/CondensedLatestAnalyses.tsx
@@ -239,7 +239,7 @@ export default function CondensedLatestAnalyses({
     <div className={classes.root}>
       <div className={classes.summary}>
         <Paper className={classes.participantsPlotPaper}>
-          <Typography variant='h3' color='primary' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             Participants by Variation
           </Typography>
           <Plot

--- a/src/components/experiment-results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiment-results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiPaper-root makeStyles-participantsPlotPaper-10 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
-          class="MuiTypography-root MuiTypography-h3 MuiTypography-colorPrimary MuiTypography-gutterBottom"
+          class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
         >
           Participants by Variation
         </h3>
@@ -767,7 +767,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiPaper-root makeStyles-participantsPlotPaper-34 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
-          class="MuiTypography-root MuiTypography-h3 MuiTypography-colorPrimary MuiTypography-gutterBottom"
+          class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
         >
           Participants by Variation
         </h3>

--- a/src/components/experiment-results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiment-results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -8,14 +8,81 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     class="makeStyles-root-1"
   >
     <div
-      class="MuiPaper-root makeStyles-summary-3 MuiPaper-elevation1 MuiPaper-rounded"
-    />
+      class="makeStyles-summary-3"
+    >
+      <div
+        class="MuiPaper-root makeStyles-participantsPlotPaper-10 MuiPaper-elevation1 MuiPaper-rounded"
+      >
+        <h3
+          class="MuiTypography-root MuiTypography-h3 MuiTypography-colorPrimary MuiTypography-gutterBottom"
+        >
+          Participants by Variation
+        </h3>
+      </div>
+      <div
+        class="MuiPaper-root makeStyles-summaryStatsPaper-4 MuiPaper-elevation1 MuiPaper-rounded"
+      >
+        <div
+          class="makeStyles-summaryStatsPart-5"
+        >
+          <h1
+            class="MuiTypography-root makeStyles-summaryStatsTotalNumber-7 MuiTypography-h1 MuiTypography-colorPrimary"
+          >
+            700
+          </h1>
+          <h6
+            class="MuiTypography-root MuiTypography-subtitle1"
+          >
+            <strong>
+              total participants
+            </strong>
+             as at 
+            2020-05-10
+          </h6>
+        </div>
+        <div
+          class="makeStyles-summaryStatsPart-5"
+        >
+          <h1
+            class="MuiTypography-root makeStyles-summaryStatsFinalizedNumber-8 MuiTypography-h1 MuiTypography-colorPrimary"
+          >
+            99.9
+            %
+          </h1>
+          <h6
+            class="MuiTypography-root MuiTypography-subtitle1"
+          >
+            of participants are 
+            <strong>
+              finalized
+            </strong>
+          </h6>
+        </div>
+        <div
+          class="makeStyles-summaryStatsPartStrategy-6"
+        >
+          <h5
+            class="MuiTypography-root makeStyles-summaryStatsStrategyTitle-9 MuiTypography-h5 MuiTypography-colorPrimary"
+          >
+            Exposed without crossovers and spammers
+          </h5>
+          <h6
+            class="MuiTypography-root MuiTypography-subtitle1"
+          >
+            <strong>
+              strategy
+            </strong>
+             in use
+          </h6>
+        </div>
+      </div>
+    </div>
     <div
       class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-9"
+        class="Component-horizontalScrollContainer-16"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -34,26 +101,26 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-10 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-17 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-10 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-17 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-10 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-17 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Attribution window
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-10 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-17 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -302,7 +369,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
 
 exports[`renders the condensed table with some analyses in non-debug mode for a Conversion Metric 2`] = `
 <div
-  class="MuiTableContainer-root makeStyles-root-11 analysis-detail-panel"
+  class="MuiTableContainer-root makeStyles-root-18 analysis-detail-panel"
 >
   <table
     class="MuiTable-root"
@@ -324,7 +391,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           class="MuiTableCell-root MuiTableCell-body"
         >
           <span
-            class="makeStyles-root-17"
+            class="makeStyles-root-24"
             title="09/05/2020, 20:00:00"
           >
             2020-05-10
@@ -342,7 +409,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           Analysis strategy
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-dataCell-13"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-dataCell-20"
         >
           Exposed without crossovers and spammers
         </td>
@@ -358,7 +425,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           Analyzed participants
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-dataCell-13"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-dataCell-20"
         >
           1400
            (
@@ -390,7 +457,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           Difference interval
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-dataCell-13"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-dataCell-20"
         >
           [
           -0.01
@@ -410,7 +477,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           Warnings
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-dataCell-13"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-dataCell-20"
         >
           <div>
             Experiment period is too short. Wait a few days to be safer.
@@ -423,7 +490,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </tbody>
   </table>
   <div
-    class="makeStyles-metricEstimatePlots-14"
+    class="makeStyles-metricEstimatePlots-21"
   />
 </div>
 `;
@@ -433,13 +500,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-4",
+        "className": "makeStyles-participantsPlot-11",
         "data": Array [
           Object {
             "line": Object {
               "color": "#1f78b488",
             },
-            "mode": "lines",
+            "mode": "lines+markers",
             "name": "test",
             "type": "scatter",
             "x": Array [
@@ -455,7 +522,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             "line": Object {
               "color": "#ff7f0088",
             },
-            "mode": "lines",
+            "mode": "lines+markers",
             "name": "control",
             "type": "scatter",
             "x": Array [
@@ -476,12 +543,11 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           },
           "margin": Object {
             "b": 48,
-            "l": 32,
+            "l": 24,
             "r": 16,
-            "t": 64,
+            "t": 0,
           },
           "showlegend": false,
-          "title": "Participants (Exposed without crossovers and spammers)",
         },
         "style": Object {
           "display": "inline-block",
@@ -493,7 +559,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-15",
+        "className": "makeStyles-metricEstimatePlot-22",
         "data": Array [
           Object {
             "line": Object {
@@ -577,7 +643,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-15",
+        "className": "makeStyles-metricEstimatePlot-22",
         "data": Array [
           Object {
             "line": Object {
@@ -692,17 +758,84 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-18"
+    class="makeStyles-root-25"
   >
     <div
-      class="MuiPaper-root makeStyles-summary-20 MuiPaper-elevation1 MuiPaper-rounded"
-    />
+      class="makeStyles-summary-27"
+    >
+      <div
+        class="MuiPaper-root makeStyles-participantsPlotPaper-34 MuiPaper-elevation1 MuiPaper-rounded"
+      >
+        <h3
+          class="MuiTypography-root MuiTypography-h3 MuiTypography-colorPrimary MuiTypography-gutterBottom"
+        >
+          Participants by Variation
+        </h3>
+      </div>
+      <div
+        class="MuiPaper-root makeStyles-summaryStatsPaper-28 MuiPaper-elevation1 MuiPaper-rounded"
+      >
+        <div
+          class="makeStyles-summaryStatsPart-29"
+        >
+          <h1
+            class="MuiTypography-root makeStyles-summaryStatsTotalNumber-31 MuiTypography-h1 MuiTypography-colorPrimary"
+          >
+            700
+          </h1>
+          <h6
+            class="MuiTypography-root MuiTypography-subtitle1"
+          >
+            <strong>
+              total participants
+            </strong>
+             as at 
+            2020-05-10
+          </h6>
+        </div>
+        <div
+          class="makeStyles-summaryStatsPart-29"
+        >
+          <h1
+            class="MuiTypography-root makeStyles-summaryStatsFinalizedNumber-32 MuiTypography-h1 MuiTypography-colorPrimary"
+          >
+            99.9
+            %
+          </h1>
+          <h6
+            class="MuiTypography-root MuiTypography-subtitle1"
+          >
+            of participants are 
+            <strong>
+              finalized
+            </strong>
+          </h6>
+        </div>
+        <div
+          class="makeStyles-summaryStatsPartStrategy-30"
+        >
+          <h5
+            class="MuiTypography-root makeStyles-summaryStatsStrategyTitle-33 MuiTypography-h5 MuiTypography-colorPrimary"
+          >
+            Exposed without crossovers and spammers
+          </h5>
+          <h6
+            class="MuiTypography-root MuiTypography-subtitle1"
+          >
+            <strong>
+              strategy
+            </strong>
+             in use
+          </h6>
+        </div>
+      </div>
+    </div>
     <div
       class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-26"
+        class="Component-horizontalScrollContainer-40"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -721,26 +854,26 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-27 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-41 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-27 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-41 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-27 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-41 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Attribution window
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-27 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-41 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -792,7 +925,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                        
                       <div
                         aria-disabled="true"
-                        class="MuiChip-root makeStyles-primaryChip-19 MuiChip-outlined Mui-disabled"
+                        class="MuiChip-root makeStyles-primaryChip-26 MuiChip-outlined Mui-disabled"
                       >
                         <span
                           class="MuiChip-label"
@@ -989,7 +1122,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
 
 exports[`renders the condensed table with some analyses in non-debug mode for a Revenue Metric 2`] = `
 <div
-  class="MuiTableContainer-root makeStyles-root-28 analysis-detail-panel"
+  class="MuiTableContainer-root makeStyles-root-42 analysis-detail-panel"
 >
   <table
     class="MuiTable-root"
@@ -1011,7 +1144,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           class="MuiTableCell-root MuiTableCell-body"
         >
           <span
-            class="makeStyles-root-34"
+            class="makeStyles-root-48"
             title="09/05/2020, 20:00:00"
           >
             2020-05-10
@@ -1029,7 +1162,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           Analysis strategy
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-dataCell-30"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-dataCell-44"
         >
           Exposed without crossovers and spammers
         </td>
@@ -1045,7 +1178,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           Analyzed participants
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-dataCell-30"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-dataCell-44"
         >
           1400
            (
@@ -1077,7 +1210,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           Difference interval
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-dataCell-30"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-dataCell-44"
         >
           [
           -0.01
@@ -1097,7 +1230,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           Warnings
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-dataCell-30"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-dataCell-44"
         >
           <div>
             Experiment period is too short. Wait a few days to be safer.
@@ -1110,7 +1243,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </tbody>
   </table>
   <div
-    class="makeStyles-metricEstimatePlots-31"
+    class="makeStyles-metricEstimatePlots-45"
   />
 </div>
 `;
@@ -1120,13 +1253,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-21",
+        "className": "makeStyles-participantsPlot-35",
         "data": Array [
           Object {
             "line": Object {
               "color": "#1f78b488",
             },
-            "mode": "lines",
+            "mode": "lines+markers",
             "name": "test",
             "type": "scatter",
             "x": Array [
@@ -1142,7 +1275,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             "line": Object {
               "color": "#ff7f0088",
             },
-            "mode": "lines",
+            "mode": "lines+markers",
             "name": "control",
             "type": "scatter",
             "x": Array [
@@ -1163,12 +1296,11 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           },
           "margin": Object {
             "b": 48,
-            "l": 32,
+            "l": 24,
             "r": 16,
-            "t": 64,
+            "t": 0,
           },
           "showlegend": false,
-          "title": "Participants (Exposed without crossovers and spammers)",
         },
         "style": Object {
           "display": "inline-block",
@@ -1180,7 +1312,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-32",
+        "className": "makeStyles-metricEstimatePlot-46",
         "data": Array [
           Object {
             "line": Object {
@@ -1264,7 +1396,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-32",
+        "className": "makeStyles-metricEstimatePlot-46",
         "data": Array [
           Object {
             "line": Object {


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR improves on the top level results display.**

I felt something wasn't quite right here and at the same time I wanted to get the total and not-final data in. Then I got inspired by Storytelling with Data, why not just put the figures on the page.

I also add in the `lines+markers` to partially fix #355. 
Hiding the graphs will come next.

See the latest image on slack: p1602687608015800-slack-G01BQ5WMR
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)