### PR TITLE
Add exclusion tags display

### DIFF
--- a/src/components/AudiencePanel.test.tsx
+++ b/src/components/AudiencePanel.test.tsx
@@ -8,7 +8,19 @@ import AudiencePanel from './AudiencePanel'
 
 test('renders as expected with no segment assignments', () => {
   const experiment = Fixtures.createExperimentFull({ segmentAssignments: [] })
-  const { container } = render(<AudiencePanel experiment={experiment} segments={[]} />)
+  const tags = Fixtures.createTagBares(5)
+  const { container } = render(<AudiencePanel experiment={experiment} segments={[]} tags={tags} />)
+
+  expect(container).toMatchSnapshot()
+})
+
+test('renders as expected with no exclusion groups', () => {
+  const experiment = Fixtures.createExperimentFull({
+    segmentAssignments: [],
+  })
+  experiment.exclusionGroupTagIds = undefined
+  const tags = Fixtures.createTagBares(5)
+  const { container } = render(<AudiencePanel experiment={experiment} segments={[]} tags={tags} />)
 
   expect(container).toMatchSnapshot()
 })
@@ -18,7 +30,8 @@ test('renders as expected with existing users allowed', () => {
     segmentAssignments: [],
     existingUsersAllowed: true,
   })
-  const { container } = render(<AudiencePanel experiment={experiment} segments={[]} />)
+  const tags = Fixtures.createTagBares(5)
+  const { container } = render(<AudiencePanel experiment={experiment} segments={[]} tags={tags} />)
 
   expect(container).toMatchSnapshot()
 })
@@ -34,7 +47,8 @@ test('renders as expected with all segments resolvable', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 5, segmentId: 5 }),
     ],
   })
-  const { container } = render(<AudiencePanel experiment={experiment} segments={segments} />)
+  const tags = Fixtures.createTagBares(5)
+  const { container } = render(<AudiencePanel experiment={experiment} segments={segments} tags={tags} />)
 
   expect(container).toMatchSnapshot()
 })
@@ -50,6 +64,7 @@ test('throws an error when some segments not resolvable', () => {
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 5, segmentId: 10 }),
     ],
   })
+  const tags = Fixtures.createTagBares(5)
 
   // Note: This console.error spy is mainly used to suppress the output that the
   // `render` function outputs.
@@ -57,7 +72,9 @@ test('throws an error when some segments not resolvable', () => {
   const consoleErrorSpy = jest.spyOn(global.console, 'error').mockImplementation(() => {})
   try {
     render(
-      <RenderErrorBoundary>{() => <AudiencePanel experiment={experiment} segments={segments} />}</RenderErrorBoundary>,
+      <RenderErrorBoundary>
+        {() => <AudiencePanel experiment={experiment} segments={segments} tags={tags} />}
+      </RenderErrorBoundary>,
     )
     expect(false).toBe(true) // Should never be reached
   } catch (err) {
@@ -79,7 +96,8 @@ test('Shows exposure events', () => {
       },
     ],
   })
-  const { container } = render(<AudiencePanel experiment={experiment} segments={[]} />)
+  const tags = Fixtures.createTagBares(5)
+  const { container } = render(<AudiencePanel experiment={experiment} segments={[]} tags={tags} />)
   expect(container).toMatchSnapshot()
 })
 
@@ -88,7 +106,8 @@ test('Empty array shows no exposure events', () => {
     segmentAssignments: [],
     exposureEvents: [],
   })
-  const { container } = render(<AudiencePanel experiment={experiment} segments={[]} />)
+  const tags = Fixtures.createTagBares(5)
+  const { container } = render(<AudiencePanel experiment={experiment} segments={[]} tags={tags} />)
   expect(container).toMatchSnapshot()
 })
 
@@ -97,6 +116,7 @@ test('null shows no exposure events', () => {
     segmentAssignments: [],
     exposureEvents: null,
   })
-  const { container } = render(<AudiencePanel experiment={experiment} segments={[]} />)
+  const tags = Fixtures.createTagBares(5)
+  const { container } = render(<AudiencePanel experiment={experiment} segments={[]} tags={tags} />)
   expect(container).toMatchSnapshot()
 })

--- a/src/components/AudiencePanel.tsx
+++ b/src/components/AudiencePanel.tsx
@@ -132,6 +132,7 @@ function AudiencePanel({
   const exclusionGroupTags = (experiment.exclusionGroupTagIds ?? []).map((tagId) => {
     const tag = tags.find((tag) => tag.tagId === tagId)
 
+    // istanbul ignore next
     if (tag === undefined) {
       throw new Error(`Can't find tag for exclusion group id: ${tagId}`)
     }
@@ -182,10 +183,10 @@ function AudiencePanel({
       value: (
         <>
           {exclusionGroupTags.map((tag) => (
-            <>
+            <React.Fragment key={tag.tagId}>
               <Chip label={tag.name} disabled />
               &nbsp;
-            </>
+            </React.Fragment>
           ))}
         </>
       ),

--- a/src/components/AudiencePanel.tsx
+++ b/src/components/AudiencePanel.tsx
@@ -113,7 +113,15 @@ function ExposureEventsTable({ experiment: { exposureEvents } }: { experiment: E
  * @param segments - The segments to look up (aka resolve) the segment IDs
  *   of the experiment's segment assignments.
  */
-function AudiencePanel({ experiment, segments, tags }: { experiment: ExperimentFull; segments: Segment[]; tags: TagBare[] }): JSX.Element {
+function AudiencePanel({
+  experiment,
+  segments,
+  tags,
+}: {
+  experiment: ExperimentFull
+  segments: Segment[]
+  tags: TagBare[]
+}): JSX.Element {
   const classes = useStyles()
 
   const segmentsByType = useMemo(
@@ -122,7 +130,7 @@ function AudiencePanel({ experiment, segments, tags }: { experiment: ExperimentF
   )
 
   const exclusionGroupTags = experiment.exclusionGroupTagIds.map((tagId) => {
-    const tag = tags.find(tag => tag.tagId === tagId)
+    const tag = tags.find((tag) => tag.tagId === tagId)
 
     if (tag === undefined) {
       throw new Error(`Can't find tag for exclusion group id: ${tagId}`)
@@ -170,7 +178,12 @@ function AudiencePanel({ experiment, segments, tags }: { experiment: ExperimentF
       label: 'Exclusion Groups',
       value: (
         <>
-        {exclusionGroupTags.map(tag => <><Chip label={tag.name} disabled />&nbsp;</>)}
+          {exclusionGroupTags.map((tag) => (
+            <>
+              <Chip label={tag.name} disabled />
+              &nbsp;
+            </>
+          ))}
         </>
       ),
     },
@@ -178,12 +191,17 @@ function AudiencePanel({ experiment, segments, tags }: { experiment: ExperimentF
 
   if (exclusionGroupTags.length > 0) {
     data.push({
-        label: 'Exclusion Groups',
-        value: (
-          <>
-          {exclusionGroupTags.map(tag => <><Chip label={tag.name} disabled />&nbsp;</>)}
-          </>
-        ),
+      label: 'Exclusion Groups',
+      value: (
+        <>
+          {exclusionGroupTags.map((tag) => (
+            <>
+              <Chip label={tag.name} disabled />
+              &nbsp;
+            </>
+          ))}
+        </>
+      ),
     })
   }
 

--- a/src/components/AudiencePanel.tsx
+++ b/src/components/AudiencePanel.tsx
@@ -121,7 +121,7 @@ function AudiencePanel({ experiment, segments, tags }: { experiment: ExperimentF
     [experiment.segmentAssignments, segments],
   )
 
-  const exclusionGroupTags = experiment.exclusiveGroupTagIds.map((tagId) => {
+  const exclusionGroupTags = experiment.exclusionGroupTagIds.map((tagId) => {
     const tag = tags.find(tag => tag.tagId === tagId)
 
     if (tag === undefined) {

--- a/src/components/AudiencePanel.tsx
+++ b/src/components/AudiencePanel.tsx
@@ -6,7 +6,7 @@ import React, { useMemo } from 'react'
 import LabelValueTable from 'src/components/LabelValueTable'
 import SegmentsTable from 'src/components/SegmentsTable'
 import VariationsTable from 'src/components/VariationsTable'
-import { ExperimentFull, Segment, SegmentAssignment, SegmentType } from 'src/lib/schemas'
+import { ExperimentFull, Segment, SegmentAssignment, SegmentType, TagBare } from 'src/lib/schemas'
 import theme from 'src/styles/theme'
 
 /**
@@ -113,7 +113,7 @@ function ExposureEventsTable({ experiment: { exposureEvents } }: { experiment: E
  * @param segments - The segments to look up (aka resolve) the segment IDs
  *   of the experiment's segment assignments.
  */
-function AudiencePanel({ experiment, segments }: { experiment: ExperimentFull; segments: Segment[] }): JSX.Element {
+function AudiencePanel({ experiment, segments, tags }: { experiment: ExperimentFull; segments: Segment[]; tags: TagBare[] }): JSX.Element {
   const classes = useStyles()
 
   const segmentsByType = useMemo(

--- a/src/components/AudiencePanel.tsx
+++ b/src/components/AudiencePanel.tsx
@@ -129,7 +129,7 @@ function AudiencePanel({
     [experiment.segmentAssignments, segments],
   )
 
-  const exclusionGroupTags = experiment.exclusionGroupTagIds.map((tagId) => {
+  const exclusionGroupTags = (experiment.exclusionGroupTagIds ?? []).map((tagId) => {
     const tag = tags.find((tag) => tag.tagId === tagId)
 
     if (tag === undefined) {
@@ -173,19 +173,6 @@ function AudiencePanel({
     {
       label: 'Exposure Events',
       value: <ExposureEventsTable experiment={experiment} />,
-    },
-    {
-      label: 'Exclusion Groups',
-      value: (
-        <>
-          {exclusionGroupTags.map((tag) => (
-            <>
-              <Chip label={tag.name} disabled />
-              &nbsp;
-            </>
-          ))}
-        </>
-      ),
     },
   ]
 

--- a/src/components/AudiencePanel.tsx
+++ b/src/components/AudiencePanel.tsx
@@ -1,4 +1,4 @@
-import { createStyles, makeStyles, Paper, Toolbar, Typography } from '@material-ui/core'
+import { Chip, createStyles, makeStyles, Paper, Toolbar, Typography } from '@material-ui/core'
 import { TableCellProps } from '@material-ui/core/TableCell'
 import _ from 'lodash'
 import React, { useMemo } from 'react'
@@ -121,6 +121,16 @@ function AudiencePanel({ experiment, segments, tags }: { experiment: ExperimentF
     [experiment.segmentAssignments, segments],
   )
 
+  const exclusionGroupTags = experiment.exclusiveGroupTagIds.map((tagId) => {
+    const tag = tags.find(tag => tag.tagId === tagId)
+
+    if (tag === undefined) {
+      throw new Error(`Can't find tag for exclusion group id: ${tagId}`)
+    }
+
+    return tag
+  })
+
   const data = [
     { label: 'Platform', value: <span className={classes.monospace}>{experiment.platform}</span> },
     {
@@ -156,7 +166,27 @@ function AudiencePanel({ experiment, segments, tags }: { experiment: ExperimentF
       label: 'Exposure Events',
       value: <ExposureEventsTable experiment={experiment} />,
     },
+    {
+      label: 'Exclusion Groups',
+      value: (
+        <>
+        {exclusionGroupTags.map(tag => <><Chip label={tag.name} disabled />&nbsp;</>)}
+        </>
+      ),
+    },
   ]
+
+  if (exclusionGroupTags.length > 0) {
+    data.push({
+        label: 'Exclusion Groups',
+        value: (
+          <>
+          {exclusionGroupTags.map(tag => <><Chip label={tag.name} disabled />&nbsp;</>)}
+          </>
+        ),
+    })
+  }
+
   return (
     <Paper>
       <Toolbar>

--- a/src/components/ExperimentDetails.test.tsx
+++ b/src/components/ExperimentDetails.test.tsx
@@ -30,6 +30,7 @@ test('renders as expected at large width', () => {
 
   const metrics = Fixtures.createMetricBares()
   const segments = Fixtures.createSegments(5)
+  const tags = Fixtures.createTagBares(5)
   const experiment = Fixtures.createExperimentFull({
     segmentAssignments: [
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 101, segmentId: 1 }),
@@ -42,6 +43,7 @@ test('renders as expected at large width', () => {
       metrics={metrics}
       segments={segments}
       experimentReloadRef={experimentReloadRef}
+      tags={tags}
     />,
   )
 
@@ -52,6 +54,7 @@ test('renders as expected at small width', () => {
   window.matchMedia = createMatchMedia(600)
   const metrics = Fixtures.createMetricBares()
   const segments = Fixtures.createSegments(5)
+  const tags = Fixtures.createTagBares(5)
   const experiment = Fixtures.createExperimentFull({
     segmentAssignments: [
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 101, segmentId: 1 }),
@@ -63,6 +66,7 @@ test('renders as expected at small width', () => {
       experiment={experiment}
       metrics={metrics}
       segments={segments}
+      tags={tags}
       experimentReloadRef={experimentReloadRef}
     />,
   )
@@ -73,6 +77,7 @@ test('renders as expected at small width', () => {
 test('renders as expected with conclusion data', () => {
   const metrics = Fixtures.createMetricBares()
   const segments = Fixtures.createSegments(5)
+  const tags = Fixtures.createTagBares(5)
   const experiment = Fixtures.createExperimentFull({
     conclusionUrl: 'https://betterexperiments.wordpress.com/experiment_1/conclusion',
     deployedVariationId: 2,
@@ -88,6 +93,7 @@ test('renders as expected with conclusion data', () => {
       experiment={experiment}
       metrics={metrics}
       segments={segments}
+      tags={tags}
       experimentReloadRef={experimentReloadRef}
     />,
   )
@@ -98,6 +104,7 @@ test('renders as expected with conclusion data', () => {
 test('renders as expected without conclusion data', () => {
   const metrics = Fixtures.createMetricBares()
   const segments = Fixtures.createSegments(5)
+  const tags = Fixtures.createTagBares(5)
   const experiment = Fixtures.createExperimentFull({
     segmentAssignments: [
       Fixtures.createSegmentAssignment({ segmentAssignmentId: 101, segmentId: 1 }),
@@ -109,6 +116,7 @@ test('renders as expected without conclusion data', () => {
       experiment={experiment}
       metrics={metrics}
       segments={segments}
+      tags={tags}
       experimentReloadRef={experimentReloadRef}
     />,
   )

--- a/src/components/ExperimentDetails.tsx
+++ b/src/components/ExperimentDetails.tsx
@@ -8,7 +8,7 @@ import AudiencePanel from 'src/components/AudiencePanel'
 import ConclusionsPanel from 'src/components/ConclusionsPanel'
 import GeneralPanel from 'src/components/GeneralPanel'
 import MetricAssignmentsPanel from 'src/components/MetricAssignmentsPanel'
-import { ExperimentFull, MetricBare, Segment, Status } from 'src/lib/schemas'
+import { ExperimentFull, MetricBare, Segment, Status, TagBare } from 'src/lib/schemas'
 
 const debug = debugFactory('abacus:components/ExperimentDetails.tsx')
 
@@ -19,11 +19,13 @@ function ExperimentDetails({
   experiment,
   metrics,
   segments,
+  tags,
   experimentReloadRef,
 }: {
   experiment: ExperimentFull
   metrics: MetricBare[]
   segments: Segment[]
+  tags: TagBare[]
   experimentReloadRef: React.MutableRefObject<() => void>
 }): JSX.Element {
   debug('ExperimentDetails#render')
@@ -39,7 +41,7 @@ function ExperimentDetails({
           </Grid>
           {isMdDown && (
             <Grid item>
-              <AudiencePanel experiment={experiment} segments={segments} />
+              <AudiencePanel {...{ experiment, segments, tags }} />
             </Grid>
           )}
           <Grid item>
@@ -54,7 +56,7 @@ function ExperimentDetails({
       </Grid>
       {!isMdDown && (
         <Grid item lg={5}>
-          <AudiencePanel experiment={experiment} segments={segments} />
+          <AudiencePanel {...{ experiment, segments, tags }} />
         </Grid>
       )}
     </Grid>

--- a/src/components/ExperimentPageView.test.tsx
+++ b/src/components/ExperimentPageView.test.tsx
@@ -8,6 +8,7 @@ import AnalysesApi from 'src/api/AnalysesApi'
 import ExperimentsApi from 'src/api/ExperimentsApi'
 import MetricsApi from 'src/api/MetricsApi'
 import SegmentsApi from 'src/api/SegmentsApi'
+import TagsApi from 'src/api/TagsApi'
 import { Status } from 'src/lib/schemas'
 import Fixtures from 'src/test-helpers/fixtures'
 import { render } from 'src/test-helpers/test-utils'
@@ -28,6 +29,9 @@ const mockedSegmentsApi = SegmentsApi as jest.Mocked<typeof SegmentsApi>
 jest.mock('src/api/AnalysesApi')
 const mockedAnalysesApi = AnalysesApi as jest.Mocked<typeof AnalysesApi>
 
+jest.mock('src/api/TagsApi')
+const mockedTagsApi = TagsApi as jest.Mocked<typeof TagsApi>
+
 jest.mock('notistack')
 const mockedNotistack = notistack as jest.Mocked<typeof notistack>
 mockedNotistack.useSnackbar.mockImplementation(() => ({
@@ -47,6 +51,9 @@ const renderExperimentPageView = async ({ experiment: experimentOverrides = {} }
 
   const analyses = Fixtures.createAnalyses()
   mockedAnalysesApi.findByExperimentId.mockImplementationOnce(async () => analyses)
+
+  const tags = Fixtures.createTagBares(5)
+  mockedTagsApi.findAll.mockImplementationOnce(async () => tags)
 
   const debug = view === ExperimentView.Debug
 

--- a/src/components/ExperimentPageView.tsx
+++ b/src/components/ExperimentPageView.tsx
@@ -212,7 +212,7 @@ export default function ExperimentPageView({
           </div>
         </div>
         {isLoading && <LinearProgress />}
-        {experiment && metrics && segments && analyses && (
+        {experiment && metrics && segments && analyses && tags && (
           <>
             {view === ExperimentView.Overview && (
               <ExperimentDetails {...{ experiment, metrics, segments, tags, experimentReloadRef }} />

--- a/src/components/ExperimentPageView.tsx
+++ b/src/components/ExperimentPageView.tsx
@@ -19,6 +19,7 @@ import AnalysesApi from 'src/api/AnalysesApi'
 import ExperimentsApi from 'src/api/ExperimentsApi'
 import MetricsApi from 'src/api/MetricsApi'
 import SegmentsApi from 'src/api/SegmentsApi'
+import TagsApi from 'src/api/TagsApi'
 import ExperimentCodeSetup from 'src/components/ExperimentCodeSetup'
 import ExperimentDetails from 'src/components/ExperimentDetails'
 import ExperimentDisableButton from 'src/components/ExperimentDisableButton'
@@ -128,13 +129,19 @@ export default function ExperimentPageView({
   )
   useDataLoadingError(segmentsError, 'Segments')
 
+  const { isLoading: tagsIsLoading, data: tags, error: tagsError } = useDataSource(
+    () => TagsApi.findAll(),
+    [],
+  )
+  useDataLoadingError(tagsError, 'Tags')
+
   const { isLoading: analysesIsLoading, data: analyses, error: analysesError } = useDataSource(
     () => (experimentId ? AnalysesApi.findByExperimentId(experimentId) : createUnresolvingPromise<Analysis[]>()),
     [experimentId],
   )
   useDataLoadingError(analysesError, 'Analyses')
 
-  const isLoading = or(experimentIsLoading, metricsIsLoading, segmentsIsLoading, analysesIsLoading)
+  const isLoading = or(experimentIsLoading, metricsIsLoading, segmentsIsLoading, tagsIsLoading, analysesIsLoading)
 
   const canEditInWizard = experiment && experiment.status === Status.Staging
 
@@ -211,7 +218,7 @@ export default function ExperimentPageView({
         {experiment && metrics && segments && analyses && (
           <>
             {view === ExperimentView.Overview && (
-              <ExperimentDetails {...{ experiment, metrics, segments, experimentReloadRef }} />
+              <ExperimentDetails {...{ experiment, metrics, segments, tags, experimentReloadRef }} />
             )}
             {view === ExperimentView.Results && (
               <NoSsrExperimentResults {...{ experiment, metrics, analyses, debugMode }} />

--- a/src/components/ExperimentPageView.tsx
+++ b/src/components/ExperimentPageView.tsx
@@ -129,10 +129,7 @@ export default function ExperimentPageView({
   )
   useDataLoadingError(segmentsError, 'Segments')
 
-  const { isLoading: tagsIsLoading, data: tags, error: tagsError } = useDataSource(
-    () => TagsApi.findAll(),
-    [],
-  )
+  const { isLoading: tagsIsLoading, data: tags, error: tagsError } = useDataSource(() => TagsApi.findAll(), [])
   useDataLoadingError(tagsError, 'Tags')
 
   const { isLoading: analysesIsLoading, data: analyses, error: analysesError } = useDataSource(

--- a/src/components/__snapshots__/AudiencePanel.test.tsx.snap
+++ b/src/components/__snapshots__/AudiencePanel.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Empty array shows no exposure events 1`] = `
       class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
     >
       <h3
-        class="MuiTypography-root makeStyles-title-46 MuiTypography-h3 MuiTypography-colorTextPrimary"
+        class="MuiTypography-root makeStyles-title-61 MuiTypography-h3 MuiTypography-colorTextPrimary"
       >
         Audience
       </h3>
@@ -34,7 +34,7 @@ exports[`Empty array shows no exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <span
-              class="makeStyles-monospace-47"
+              class="makeStyles-monospace-62"
             >
               calypso
             </span>
@@ -54,7 +54,7 @@ exports[`Empty array shows no exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <span
-              class="makeStyles-monospace-47"
+              class="makeStyles-monospace-62"
             >
               New users only
             </span>
@@ -74,7 +74,7 @@ exports[`Empty array shows no exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <table
-              class="MuiTable-root makeStyles-root-61"
+              class="MuiTable-root makeStyles-root-76"
             >
               <thead
                 class="MuiTableHead-root"
@@ -105,10 +105,10 @@ exports[`Empty array shows no exposure events 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-81"
                   >
                     <span
-                      class="makeStyles-variation-64"
+                      class="makeStyles-variation-79"
                     >
                       control
                     </span>
@@ -125,7 +125,7 @@ exports[`Empty array shows no exposure events 1`] = `
                     </div>
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-81"
                   >
                     60
                     %
@@ -135,17 +135,17 @@ exports[`Empty array shows no exposure events 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-81"
                   >
                     <span
-                      class="makeStyles-variation-64"
+                      class="makeStyles-variation-79"
                     >
                       test
                     </span>
                      
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-81"
                   >
                     40
                     %
@@ -169,7 +169,7 @@ exports[`Empty array shows no exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <table
-              class="MuiTable-root makeStyles-root-67"
+              class="MuiTable-root makeStyles-root-82"
             >
               <thead
                 class="MuiTableHead-root"
@@ -193,7 +193,7 @@ exports[`Empty array shows no exposure events 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-69"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-84"
                   >
                     All 
                     locales
@@ -203,7 +203,7 @@ exports[`Empty array shows no exposure events 1`] = `
               </tbody>
             </table>
             <table
-              class="MuiTable-root makeStyles-root-67"
+              class="MuiTable-root makeStyles-root-82"
             >
               <thead
                 class="MuiTableHead-root"
@@ -227,7 +227,7 @@ exports[`Empty array shows no exposure events 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-69"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-84"
                   >
                     All 
                     countries
@@ -252,14 +252,40 @@ exports[`Empty array shows no exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <div
-              class="makeStyles-eventList-72"
+              class="makeStyles-eventList-87"
             >
               <span
-                class="makeStyles-monospace-73"
+                class="makeStyles-monospace-88"
               >
                 No exposure events defined
               </span>
             </div>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Exclusion Groups
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <div
+              aria-disabled="true"
+              class="MuiChip-root Mui-disabled"
+            >
+              <span
+                class="MuiChip-label"
+              >
+                tag_1
+              </span>
+            </div>
+             
           </td>
         </tr>
       </tbody>
@@ -269,6 +295,605 @@ exports[`Empty array shows no exposure events 1`] = `
 `;
 
 exports[`Shows exposure events 1`] = `
+<div>
+  <div
+    class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
+  >
+    <div
+      class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
+    >
+      <h3
+        class="MuiTypography-root makeStyles-title-61 MuiTypography-h3 MuiTypography-colorTextPrimary"
+      >
+        Audience
+      </h3>
+    </div>
+    <table
+      class="MuiTable-root"
+    >
+      <tbody
+        class="MuiTableBody-root"
+      >
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Platform
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <span
+              class="makeStyles-monospace-62"
+            >
+              calypso
+            </span>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            User Type
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <span
+              class="makeStyles-monospace-62"
+            >
+              New users only
+            </span>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Variations
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <table
+              class="MuiTable-root makeStyles-root-63"
+            >
+              <thead
+                class="MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Name
+                  </th>
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Percent
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root"
+              >
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68"
+                  >
+                    <span
+                      class="makeStyles-variation-66"
+                    >
+                      control
+                    </span>
+                     
+                    <div
+                      aria-disabled="true"
+                      class="MuiChip-root MuiChip-outlined Mui-disabled"
+                    >
+                      <span
+                        class="MuiChip-label"
+                      >
+                        Default
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68"
+                  >
+                    60
+                    %
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68"
+                  >
+                    <span
+                      class="makeStyles-variation-66"
+                    >
+                      test
+                    </span>
+                     
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68"
+                  >
+                    40
+                    %
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Segments
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <table
+              class="MuiTable-root makeStyles-root-69"
+            >
+              <thead
+                class="MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Locales
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root"
+              >
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-71"
+                  >
+                    All 
+                    locales
+                     included
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <table
+              class="MuiTable-root makeStyles-root-69"
+            >
+              <thead
+                class="MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Countries
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root"
+              >
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-71"
+                  >
+                    All 
+                    countries
+                     included
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Exposure Events
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <div
+              class="makeStyles-eventList-74"
+            >
+              <p
+                class="MuiTypography-root makeStyles-monospace-75 MuiTypography-body1"
+              >
+                <span
+                  class="makeStyles-eventName-73"
+                >
+                  test
+                </span>
+                <span
+                  class="makeStyles-entry-72"
+                >
+                  prop1
+                  : 
+                  value1
+                </span>
+              </p>
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Exclusion Groups
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <div
+              aria-disabled="true"
+              class="MuiChip-root Mui-disabled"
+            >
+              <span
+                class="MuiChip-label"
+              >
+                tag_1
+              </span>
+            </div>
+             
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`null shows no exposure events 1`] = `
+<div>
+  <div
+    class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
+  >
+    <div
+      class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
+    >
+      <h3
+        class="MuiTypography-root makeStyles-title-61 MuiTypography-h3 MuiTypography-colorTextPrimary"
+      >
+        Audience
+      </h3>
+    </div>
+    <table
+      class="MuiTable-root"
+    >
+      <tbody
+        class="MuiTableBody-root"
+      >
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Platform
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <span
+              class="makeStyles-monospace-62"
+            >
+              calypso
+            </span>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            User Type
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <span
+              class="makeStyles-monospace-62"
+            >
+              New users only
+            </span>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Variations
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <table
+              class="MuiTable-root makeStyles-root-89"
+            >
+              <thead
+                class="MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Name
+                  </th>
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Percent
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root"
+              >
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-94"
+                  >
+                    <span
+                      class="makeStyles-variation-92"
+                    >
+                      control
+                    </span>
+                     
+                    <div
+                      aria-disabled="true"
+                      class="MuiChip-root MuiChip-outlined Mui-disabled"
+                    >
+                      <span
+                        class="MuiChip-label"
+                      >
+                        Default
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-94"
+                  >
+                    60
+                    %
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-94"
+                  >
+                    <span
+                      class="makeStyles-variation-92"
+                    >
+                      test
+                    </span>
+                     
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-94"
+                  >
+                    40
+                    %
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Segments
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <table
+              class="MuiTable-root makeStyles-root-95"
+            >
+              <thead
+                class="MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Locales
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root"
+              >
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-97"
+                  >
+                    All 
+                    locales
+                     included
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <table
+              class="MuiTable-root makeStyles-root-95"
+            >
+              <thead
+                class="MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    Countries
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root"
+              >
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-97"
+                  >
+                    All 
+                    countries
+                     included
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Exposure Events
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <div
+              class="makeStyles-eventList-100"
+            >
+              <span
+                class="makeStyles-monospace-101"
+              >
+                No exposure events defined
+              </span>
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Exclusion Groups
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <div
+              aria-disabled="true"
+              class="MuiChip-root Mui-disabled"
+            >
+              <span
+                class="MuiChip-label"
+              >
+                tag_1
+              </span>
+            </div>
+             
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`renders as expected with all segments resolvable 1`] = `
 <div>
   <div
     class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
@@ -463,9 +1088,38 @@ exports[`Shows exposure events 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56"
                   >
-                    All 
-                    locales
-                     included
+                    segment_1
+                     
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56"
+                  >
+                    segment_3
+                     
+                    <div
+                      aria-disabled="true"
+                      class="MuiChip-root MuiChip-outlined Mui-disabled"
+                    >
+                      <span
+                        class="MuiChip-label"
+                      >
+                        Excluded
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56"
+                  >
+                    segment_5
+                     
                   </td>
                 </tr>
               </tbody>
@@ -497,9 +1151,28 @@ exports[`Shows exposure events 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56"
                   >
-                    All 
-                    countries
-                     included
+                    segment_2
+                     
+                    <div
+                      aria-disabled="true"
+                      class="MuiChip-root MuiChip-outlined Mui-disabled"
+                    >
+                      <span
+                        class="MuiChip-label"
+                      >
+                        Excluded
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56"
+                  >
+                    segment_4
+                     
                   </td>
                 </tr>
               </tbody>
@@ -528,45 +1201,33 @@ exports[`Shows exposure events 1`] = `
                 <span
                   class="makeStyles-eventName-58"
                 >
-                  test
+                  event_name
                 </span>
                 <span
                   class="makeStyles-entry-57"
                 >
-                  prop1
+                  additionalProp1
                   : 
-                  value1
+                  prop1Value
+                </span>
+                <span
+                  class="makeStyles-entry-57"
+                >
+                  additionalProp2
+                  : 
+                  prop2Value
+                </span>
+                <span
+                  class="makeStyles-entry-57"
+                >
+                  additionalProp3
+                  : 
+                  prop3Value
                 </span>
               </p>
             </div>
           </td>
         </tr>
-      </tbody>
-    </table>
-  </div>
-</div>
-`;
-
-exports[`null shows no exposure events 1`] = `
-<div>
-  <div
-    class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
-  >
-    <div
-      class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
-    >
-      <h3
-        class="MuiTypography-root makeStyles-title-46 MuiTypography-h3 MuiTypography-colorTextPrimary"
-      >
-        Audience
-      </h3>
-    </div>
-    <table
-      class="MuiTable-root"
-    >
-      <tbody
-        class="MuiTableBody-root"
-      >
         <tr
           class="MuiTableRow-root"
         >
@@ -575,238 +1236,22 @@ exports[`null shows no exposure events 1`] = `
             role="cell"
             scope="row"
           >
-            Platform
-          </th>
-          <td
-            class="MuiTableCell-root MuiTableCell-body"
-          >
-            <span
-              class="makeStyles-monospace-47"
-            >
-              calypso
-            </span>
-          </td>
-        </tr>
-        <tr
-          class="MuiTableRow-root"
-        >
-          <th
-            class="MuiTableCell-root MuiTableCell-head"
-            role="cell"
-            scope="row"
-          >
-            User Type
-          </th>
-          <td
-            class="MuiTableCell-root MuiTableCell-body"
-          >
-            <span
-              class="makeStyles-monospace-47"
-            >
-              New users only
-            </span>
-          </td>
-        </tr>
-        <tr
-          class="MuiTableRow-root"
-        >
-          <th
-            class="MuiTableCell-root MuiTableCell-head"
-            role="cell"
-            scope="row"
-          >
-            Variations
-          </th>
-          <td
-            class="MuiTableCell-root MuiTableCell-body"
-          >
-            <table
-              class="MuiTable-root makeStyles-root-74"
-            >
-              <thead
-                class="MuiTableHead-root"
-              >
-                <tr
-                  class="MuiTableRow-root MuiTableRow-head"
-                >
-                  <th
-                    class="MuiTableCell-root MuiTableCell-head"
-                    role="columnheader"
-                    scope="col"
-                  >
-                    Name
-                  </th>
-                  <th
-                    class="MuiTableCell-root MuiTableCell-head"
-                    role="columnheader"
-                    scope="col"
-                  >
-                    Percent
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                class="MuiTableBody-root"
-              >
-                <tr
-                  class="MuiTableRow-root"
-                >
-                  <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-79"
-                  >
-                    <span
-                      class="makeStyles-variation-77"
-                    >
-                      control
-                    </span>
-                     
-                    <div
-                      aria-disabled="true"
-                      class="MuiChip-root MuiChip-outlined Mui-disabled"
-                    >
-                      <span
-                        class="MuiChip-label"
-                      >
-                        Default
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-79"
-                  >
-                    60
-                    %
-                  </td>
-                </tr>
-                <tr
-                  class="MuiTableRow-root"
-                >
-                  <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-79"
-                  >
-                    <span
-                      class="makeStyles-variation-77"
-                    >
-                      test
-                    </span>
-                     
-                  </td>
-                  <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-79"
-                  >
-                    40
-                    %
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </td>
-        </tr>
-        <tr
-          class="MuiTableRow-root"
-        >
-          <th
-            class="MuiTableCell-root MuiTableCell-head"
-            role="cell"
-            scope="row"
-          >
-            Segments
-          </th>
-          <td
-            class="MuiTableCell-root MuiTableCell-body"
-          >
-            <table
-              class="MuiTable-root makeStyles-root-80"
-            >
-              <thead
-                class="MuiTableHead-root"
-              >
-                <tr
-                  class="MuiTableRow-root MuiTableRow-head"
-                >
-                  <th
-                    class="MuiTableCell-root MuiTableCell-head"
-                    role="columnheader"
-                    scope="col"
-                  >
-                    Locales
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                class="MuiTableBody-root"
-              >
-                <tr
-                  class="MuiTableRow-root"
-                >
-                  <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
-                  >
-                    All 
-                    locales
-                     included
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <table
-              class="MuiTable-root makeStyles-root-80"
-            >
-              <thead
-                class="MuiTableHead-root"
-              >
-                <tr
-                  class="MuiTableRow-root MuiTableRow-head"
-                >
-                  <th
-                    class="MuiTableCell-root MuiTableCell-head"
-                    role="columnheader"
-                    scope="col"
-                  >
-                    Countries
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                class="MuiTableBody-root"
-              >
-                <tr
-                  class="MuiTableRow-root"
-                >
-                  <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
-                  >
-                    All 
-                    countries
-                     included
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </td>
-        </tr>
-        <tr
-          class="MuiTableRow-root"
-        >
-          <th
-            class="MuiTableCell-root MuiTableCell-head"
-            role="cell"
-            scope="row"
-          >
-            Exposure Events
+            Exclusion Groups
           </th>
           <td
             class="MuiTableCell-root MuiTableCell-body"
           >
             <div
-              class="makeStyles-eventList-85"
+              aria-disabled="true"
+              class="MuiChip-root Mui-disabled"
             >
               <span
-                class="makeStyles-monospace-86"
+                class="MuiChip-label"
               >
-                No exposure events defined
+                tag_1
               </span>
             </div>
+             
           </td>
         </tr>
       </tbody>
@@ -815,7 +1260,7 @@ exports[`null shows no exposure events 1`] = `
 </div>
 `;
 
-exports[`renders as expected with all segments resolvable 1`] = `
+exports[`renders as expected with existing users allowed 1`] = `
 <div>
   <div
     class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
@@ -871,7 +1316,7 @@ exports[`renders as expected with all segments resolvable 1`] = `
             <span
               class="makeStyles-monospace-32"
             >
-              New users only
+              All users (new + existing)
             </span>
           </td>
         </tr>
@@ -1010,38 +1455,9 @@ exports[`renders as expected with all segments resolvable 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-41"
                   >
-                    segment_1
-                     
-                  </td>
-                </tr>
-                <tr
-                  class="MuiTableRow-root"
-                >
-                  <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-41"
-                  >
-                    segment_3
-                     
-                    <div
-                      aria-disabled="true"
-                      class="MuiChip-root MuiChip-outlined Mui-disabled"
-                    >
-                      <span
-                        class="MuiChip-label"
-                      >
-                        Excluded
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr
-                  class="MuiTableRow-root"
-                >
-                  <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-41"
-                  >
-                    segment_5
-                     
+                    All 
+                    locales
+                     included
                   </td>
                 </tr>
               </tbody>
@@ -1073,28 +1489,9 @@ exports[`renders as expected with all segments resolvable 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-41"
                   >
-                    segment_2
-                     
-                    <div
-                      aria-disabled="true"
-                      class="MuiChip-root MuiChip-outlined Mui-disabled"
-                    >
-                      <span
-                        class="MuiChip-label"
-                      >
-                        Excluded
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr
-                  class="MuiTableRow-root"
-                >
-                  <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-41"
-                  >
-                    segment_4
-                     
+                    All 
+                    countries
+                     included
                   </td>
                 </tr>
               </tbody>
@@ -1150,13 +1547,39 @@ exports[`renders as expected with all segments resolvable 1`] = `
             </div>
           </td>
         </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Exclusion Groups
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <div
+              aria-disabled="true"
+              class="MuiChip-root Mui-disabled"
+            >
+              <span
+                class="MuiChip-label"
+              >
+                tag_1
+              </span>
+            </div>
+             
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>
 </div>
 `;
 
-exports[`renders as expected with existing users allowed 1`] = `
+exports[`renders as expected with no exclusion groups 1`] = `
 <div>
   <div
     class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
@@ -1212,7 +1635,7 @@ exports[`renders as expected with existing users allowed 1`] = `
             <span
               class="makeStyles-monospace-17"
             >
-              All users (new + existing)
+              New users only
             </span>
           </td>
         </tr>
@@ -1734,6 +2157,32 @@ exports[`renders as expected with no segment assignments 1`] = `
                 </span>
               </p>
             </div>
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head"
+            role="cell"
+            scope="row"
+          >
+            Exclusion Groups
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body"
+          >
+            <div
+              aria-disabled="true"
+              class="MuiChip-root Mui-disabled"
+            >
+              <span
+                class="MuiChip-label"
+              >
+                tag_1
+              </span>
+            </div>
+             
           </td>
         </tr>
       </tbody>

--- a/src/components/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/src/components/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -687,6 +687,32 @@ exports[`renders as expected at large width 1`] = `
                 </div>
               </td>
             </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <th
+                class="MuiTableCell-root MuiTableCell-head"
+                role="cell"
+                scope="row"
+              >
+                Exclusion Groups
+              </th>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <div
+                  aria-disabled="true"
+                  class="MuiChip-root Mui-disabled"
+                >
+                  <span
+                    class="MuiChip-label"
+                  >
+                    tag_1
+                  </span>
+                </div>
+                 
+              </td>
+            </tr>
           </tbody>
         </table>
       </div>
@@ -1172,6 +1198,32 @@ exports[`renders as expected at small width 1`] = `
                         </span>
                       </p>
                     </div>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="cell"
+                    scope="row"
+                  >
+                    Exclusion Groups
+                  </th>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    <div
+                      aria-disabled="true"
+                      class="MuiChip-root Mui-disabled"
+                    >
+                      <span
+                        class="MuiChip-label"
+                      >
+                        tag_1
+                      </span>
+                    </div>
+                     
                   </td>
                 </tr>
               </tbody>
@@ -1869,6 +1921,32 @@ exports[`renders as expected with conclusion data 1`] = `
                         </span>
                       </p>
                     </div>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="cell"
+                    scope="row"
+                  >
+                    Exclusion Groups
+                  </th>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    <div
+                      aria-disabled="true"
+                      class="MuiChip-root Mui-disabled"
+                    >
+                      <span
+                        class="MuiChip-label"
+                      >
+                        tag_1
+                      </span>
+                    </div>
+                     
                   </td>
                 </tr>
               </tbody>
@@ -2670,6 +2748,32 @@ exports[`renders as expected without conclusion data 1`] = `
                         </span>
                       </p>
                     </div>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="cell"
+                    scope="row"
+                  >
+                    Exclusion Groups
+                  </th>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    <div
+                      aria-disabled="true"
+                      class="MuiChip-root Mui-disabled"
+                    >
+                      <span
+                        class="MuiChip-label"
+                      >
+                        tag_1
+                      </span>
+                    </div>
+                     
                   </td>
                 </tr>
               </tbody>

--- a/src/lib/form-data.test.ts
+++ b/src/lib/form-data.test.ts
@@ -13,6 +13,7 @@ describe('lib/form-data.test.ts module', () => {
         Object {
           "description": "",
           "endDatetime": "",
+          "exclusionGroupTagIds": undefined,
           "existingUsersAllowed": "true",
           "exposureEvents": Array [],
           "metricAssignments": Array [],
@@ -44,6 +45,9 @@ describe('lib/form-data.test.ts module', () => {
         Object {
           "description": "Experiment with things. Change stuff. Profit.",
           "endDatetime": "2020-12-13",
+          "exclusionGroupTagIds": Array [
+            1,
+          ],
           "existingUsersAllowed": "false",
           "exposureEvents": Array [
             Object {

--- a/src/lib/form-data.ts
+++ b/src/lib/form-data.ts
@@ -86,6 +86,7 @@ export function experimentToFormData(
   platform: string
   p2Url: string
   ownerLogin: string
+  exclusionGroupTagIds?: number[]
 } {
   return {
     p2Url: experiment.p2Url ?? '',
@@ -110,6 +111,7 @@ export function experimentToFormData(
           { name: 'treatment', isDefault: false, allocatedPercentage: '50' },
         ],
     exposureEvents: experiment.exposureEvents ? experiment.exposureEvents.map(exposureEventToFormData) : [],
+    exclusionGroupTagIds: experiment.exclusionGroupTagIds,
   }
 }
 export type ExperimentFormData = ReturnType<typeof experimentToFormData>

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -292,7 +292,7 @@ export const experimentFullSchema = experimentBareSchema
     metricAssignments: yup.array(metricAssignmentSchema).defined().min(1),
     segmentAssignments: yup.array(segmentAssignmentSchema).defined(),
     variations: yup.array<Variation>(variationSchema).defined().min(2),
-    exclusiveGroupTagIds: yup.array(idSchema.defined()).defined(),
+    exclusionGroupTagIds: yup.array(idSchema.defined()).defined(),
   })
   .defined()
   .camelCase()

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -292,6 +292,7 @@ export const experimentFullSchema = experimentBareSchema
     metricAssignments: yup.array(metricAssignmentSchema).defined().min(1),
     segmentAssignments: yup.array(segmentAssignmentSchema).defined(),
     variations: yup.array<Variation>(variationSchema).defined().min(2),
+    exclusiveGroupTagIds: yup.array(idSchema.defined()).defined(),
   })
   .defined()
   .camelCase()

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -292,7 +292,7 @@ export const experimentFullSchema = experimentBareSchema
     metricAssignments: yup.array(metricAssignmentSchema).defined().min(1),
     segmentAssignments: yup.array(segmentAssignmentSchema).defined(),
     variations: yup.array<Variation>(variationSchema).defined().min(2),
-    exclusionGroupTagIds: yup.array(idSchema.defined()).defined(),
+    exclusionGroupTagIds: yup.array(idSchema.defined()),
   })
   .defined()
   .camelCase()

--- a/src/test-helpers/fixtures.ts
+++ b/src/test-helpers/fixtures.ts
@@ -415,6 +415,7 @@ function createExperimentFull(fieldOverrides: Partial<ExperimentFull> = {}): Exp
         },
       },
     ],
+    exclusionGroupTagIds: [1],
     ...existingExperimentFieldOverrides,
   }
 }


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR displays experiment exclusion tags.**

<img width="1324" alt="97146725-50583c00-17a3-11eb-9620-d4f4051fdae9" src="https://user-images.githubusercontent.com/971886/97450296-8e08c080-196d-11eb-871e-04818b0d44f4.png">

Part of #361 
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
- Manual testing with mock data (locally or on Vercel)
(Swagger needs to be updated for you to see the exclusion groups: 474-gh-experimentation-platform)