### PR TITLE
Use React Router (Redo): Pt 2/3: Use React-Router Page Params into /real-pages

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,9 +1,8 @@
 require('dotenv').config()
-const { toBool } = require('qc-to_bool')
 
 module.exports = {
   launch: {
-    headless: toBool(process.env.PUPPETEER_HEADLESS, true),
+    headless: process.env.PUPPETEER_HEADLESS === 'false' ? false : true,
   },
   server: {
     command:

--- a/package-lock.json
+++ b/package-lock.json
@@ -24228,30 +24228,6 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
     },
-    "qc-round": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/qc-round/-/qc-round-0.0.6.tgz",
-      "integrity": "sha1-RaaNBoYUQsQWJYK2QNH6JsUfPuM="
-    },
-    "qc-to_bool": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/qc-to_bool/-/qc-to_bool-1.1.2.tgz",
-      "integrity": "sha1-/Huybq610TOh35r3nTTsVIjNIIw="
-    },
-    "qc-to_int": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/qc-to_int/-/qc-to_int-1.0.1.tgz",
-      "integrity": "sha1-kh+iDmCJIiOYwNeyJzUOUR55xWg=",
-      "requires": {
-        "qc-round": "^0.0.6",
-        "qc-to_num": "^1.0.2"
-      }
-    },
-    "qc-to_num": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/qc-to_num/-/qc-to_num-1.0.2.tgz",
-      "integrity": "sha1-ML9Cl03HhubJWSxVsylKDO8Rln0="
-    },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,6 @@
     "normalizr": "^3.6.0",
     "notistack": "^1.0.0",
     "plotly.js": "^1.55.2",
-    "qc-to_bool": "^1.1.2",
-    "qc-to_int": "^1.0.1",
     "querystring": "^0.2.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/components/ExperimentPageView.test.tsx
+++ b/src/components/ExperimentPageView.test.tsx
@@ -70,7 +70,7 @@ const renderExperimentPageView = async ({ experiment: experimentOverrides = {} }
  * - null: not on screen
  */
 const getButtonStates = () => {
-  const editInWizard = screen.getByRole('link', { name: /Edit In Wizard/ })
+  const editInWizard = screen.getByRole('button', { name: /Edit In Wizard/ })
   const run = screen.getByRole('button', { name: /Run/ })
   const disable = screen.getByRole('button', { name: /Disable/ })
   const generalPanelEdit = screen.getByRole('button', { name: /Edit Experiment General Data/ })

--- a/src/components/ExperimentPageView.tsx
+++ b/src/components/ExperimentPageView.tsx
@@ -11,9 +11,8 @@ import {
   Typography,
 } from '@material-ui/core'
 import { Skeleton } from '@material-ui/lab'
-import dynamic from 'next/dynamic'
-import Link from 'next/link'
 import React from 'react'
+import { Link } from 'react-router-dom'
 
 import AnalysesApi from 'src/api/AnalysesApi'
 import ExperimentsApi from 'src/api/ExperimentsApi'
@@ -29,30 +28,8 @@ import { useDataLoadingError, useDataSource } from 'src/utils/data-loading'
 import { createUnresolvingPromise, or } from 'src/utils/general'
 
 import ExperimentDebug from './experiment-results/ExperimentDebug'
+import ExperimentResults from './experiment-results/ExperimentResults'
 import ExperimentRunButton from './ExperimentRunButton'
-
-const NoSsrExperimentResults = dynamic(() => import('src/components/experiment-results/ExperimentResults'), {
-  ssr: false,
-})
-
-const NextMuiLink = React.forwardRef(
-  // istanbul ignore next; Just the trivial className = undefined path that is missing
-  // Should be refactored soon anyway
-  (
-    {
-      className = undefined,
-      href,
-      hrefAs,
-      children,
-      prefetch = false,
-    }: { className?: string; href: string; hrefAs: string; children?: React.ReactNode; prefetch?: boolean },
-    ref,
-  ) => (
-    <Link {...{ href, as: hrefAs, prefetch, ref }}>
-      <a className={className}>{children}</a>
-    </Link>
-  ),
-)
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -161,35 +138,31 @@ export default function ExperimentPageView({
               className={classes.topBarTab}
               label='Overview'
               value={ExperimentView.Overview}
-              component={NextMuiLink}
-              href='/experiments/[id]'
-              hrefAs={`/experiments/${experimentId}`}
+              component={Link}
+              to={`/experiments/${experimentId}`}
             />
             <Tab
               className={classes.topBarTab}
               label='Results'
               value={ExperimentView.Results}
-              component={NextMuiLink}
-              href='/experiments/[id]/results'
-              hrefAs={`/experiments/${experimentId}/results`}
+              component={Link}
+              to={`/experiments/${experimentId}/results`}
             />
             {debugMode && (
               <Tab
                 className={classes.topBarTab}
                 label='Debug'
                 value={ExperimentView.Debug}
-                component={NextMuiLink}
-                href='/experiments/[id]/debug'
-                hrefAs={`/experiments/${experimentId}/debug`}
+                component={Link}
+                to={`/experiments/${experimentId}/debug`}
               />
             )}
             <Tab
               className={classes.topBarTab}
               label='Code Setup'
               value={ExperimentView.CodeSetup}
-              component={NextMuiLink}
-              href='/experiments/[id]/code-setup'
-              hrefAs={`/experiments/${experimentId}/code-setup`}
+              component={Link}
+              to={`/experiments/${experimentId}/code-setup`}
             />
           </Tabs>
           <div className={classes.topBarActions}>
@@ -198,9 +171,8 @@ export default function ExperimentPageView({
                 <Button
                   variant='outlined'
                   color='primary'
-                  component={NextMuiLink}
-                  href={`/experiments/[id]/wizard-edit`}
-                  hrefAs={`/experiments/${experimentId}/wizard-edit`}
+                  component={Link}
+                  to={`/experiments/${experimentId}/wizard-edit`}
                   disabled={!canEditInWizard}
                 >
                   Edit In Wizard
@@ -217,9 +189,7 @@ export default function ExperimentPageView({
             {view === ExperimentView.Overview && (
               <ExperimentDetails {...{ experiment, metrics, segments, tags, experimentReloadRef }} />
             )}
-            {view === ExperimentView.Results && (
-              <NoSsrExperimentResults {...{ experiment, metrics, analyses, debugMode }} />
-            )}
+            {view === ExperimentView.Results && <ExperimentResults {...{ experiment, metrics, analyses, debugMode }} />}
             {view === ExperimentView.Debug && debugMode && (
               <ExperimentDebug {...{ experiment, metrics, analyses, debugMode }} />
             )}

--- a/src/components/ExperimentsTable.tsx
+++ b/src/components/ExperimentsTable.tsx
@@ -1,8 +1,8 @@
 import { useTheme } from '@material-ui/core'
 import debugFactory from 'debug'
 import MaterialTable from 'material-table'
-import { useRouter } from 'next/router'
 import React from 'react'
+import { useHistory } from 'react-router-dom'
 
 import DatetimeText from 'src/components/DatetimeText'
 import { ExperimentBare } from 'src/lib/schemas'
@@ -17,12 +17,15 @@ const debug = debugFactory('abacus:components/ExperimentsTable.tsx')
  */
 const ExperimentsTable = ({ experiments }: { experiments: ExperimentBare[] }): JSX.Element => {
   debug('ExperimentsTable#render')
-  const router = useRouter()
+  const history = useHistory()
   const theme = useTheme()
 
   /* istanbul ignore next; to be handled by an e2e test */
   const handleRowClick = (event?: React.MouseEvent, rowData?: ExperimentBare) => {
-    void router.push('/experiments/[id]', `/experiments/${rowData?.experimentId ?? ''}`)
+    if (!rowData?.experimentId) {
+      throw new Error('Missing experimentId')
+    }
+    history.push(`/experiments/${rowData.experimentId}`)
   }
 
   return (

--- a/src/components/Layout.stories.tsx
+++ b/src/components/Layout.stories.tsx
@@ -1,19 +1,22 @@
 import { withRouter } from 'next/router'
 import React from 'react'
+import { StaticRouter } from 'react-router-dom'
 
 import Layout from './Layout'
 
 export default { title: 'Layout' }
 
 export const withChildren = withRouter(() => (
-  <Layout title='Storybook'>
-    <div>
-      <p>I represent the children.</p>
-      <p>
-        Because Layout contains Next.js Links, you will find an error in the console due to the rest of Next.js being
-        rendered higher in the tree. I do not think it is important enough to find a workaround at this point. So,
-        remove this Layout story once real stories for isolated components have been created.
-      </p>
-    </div>
-  </Layout>
+  <StaticRouter>
+    <Layout title='Storybook'>
+      <div>
+        <p>I represent the children.</p>
+        <p>
+          Because Layout contains Next.js Links, you will find an error in the console due to the rest of Next.js being
+          rendered higher in the tree. I do not think it is important enough to find a workaround at this point. So,
+          remove this Layout story once real stories for isolated components have been created.
+        </p>
+      </div>
+    </Layout>
+  </StaticRouter>
 ))

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,9 +1,8 @@
 import { AppBar, Container, Theme, Typography } from '@material-ui/core'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
 import Head from 'next/head'
-import Link from 'next/link'
-import { useRouter } from 'next/router'
 import React, { ReactNode } from 'react'
+import { Link } from 'react-router-dom'
 
 import { isTestingProductionConfigInDevelopment } from 'src/config'
 import { isDebugMode, toggleDebugMode } from 'src/utils/general'
@@ -96,13 +95,12 @@ const Layout = ({
   children?: ReactNode
 }): JSX.Element => {
   const classes = useStyles()
-  const router = useRouter()
 
   // istanbul ignore next; debug mode only
   const onToggleDebugMode = (e: React.MouseEvent<HTMLSpanElement, MouseEvent>) => {
     if (e.shiftKey) {
       toggleDebugMode()
-      router.reload()
+      window.location.reload()
     }
   }
 
@@ -139,15 +137,9 @@ const Layout = ({
         <div className={classes.appBarBottom}>
           <Container>
             <nav className={classes.appNav}>
-              <Link href='/experiments'>
-                <a>Experiments</a>
-              </Link>
-              <Link href='/experiments/new'>
-                <a>Create Experiment</a>
-              </Link>
-              <Link href='/metrics'>
-                <a>Metrics</a>
-              </Link>
+              <Link to='/experiments'>Experiments</Link>
+              <Link to='/experiments/new'>Create Experiment</Link>
+              <Link to='/metrics'>Metrics</Link>
             </nav>
           </Container>
         </div>

--- a/src/pages-real/AuthCallback.tsx
+++ b/src/pages-real/AuthCallback.tsx
@@ -1,10 +1,10 @@
 import { CircularProgress, Container, createStyles, makeStyles, Theme, Typography } from '@material-ui/core'
 import debugFactory from 'debug'
-import { toInt } from 'qc-to_int'
 import qs from 'querystring'
 import React, { useEffect, useState } from 'react'
+import * as yup from 'yup'
 
-import { saveExperimentsAuthInfo } from 'src/utils/auth'
+import { ExperimentsAuthInfo, saveExperimentsAuthInfo } from 'src/utils/auth'
 
 const debug = debugFactory('abacus:pages/auth.tsx')
 
@@ -88,13 +88,18 @@ const AuthPage = function AuthPage(): JSX.Element {
       return
     }
 
-    const expiresInSeconds = toInt(authInfo.expires_in, 0) as unknown
-    const experimentsAuthInfo = {
+    const experimentsAuthInfo: ExperimentsAuthInfo = {
       accessToken: authInfo.access_token as string,
-      expiresAt: typeof expiresInSeconds === 'number' ? Date.now() + expiresInSeconds * 1000 : null,
+      expiresAt: null,
       scope: 'global',
       type: 'bearer',
     }
+
+    if (authInfo.expires_in) {
+      const expiresInSeconds = yup.number().integer().defined().validateSync(authInfo.expires_in)
+      experimentsAuthInfo.expiresAt = Date.now() + expiresInSeconds * 1000
+    }
+
     saveExperimentsAuthInfo(experimentsAuthInfo)
 
     window.location.replace(window.location.origin)

--- a/src/pages-real/experiments/Experiment.tsx
+++ b/src/pages-real/experiments/Experiment.tsx
@@ -1,22 +1,23 @@
 import debugFactory from 'debug'
-import { useRouter } from 'next/router'
-import { toIntOrNull } from 'qc-to_int'
 import React from 'react'
+import { useParams } from 'react-router-dom'
+import * as yup from 'yup'
 
 import ExperimentPageView, { ExperimentView } from 'src/components/ExperimentPageView'
 import { isDebugMode } from 'src/utils/general'
 
-const debug = debugFactory('abacus:pages/experiments/[id].tsx')
+const debug = debugFactory('abacus:pages/experiments/Experiment.tsx')
 
-export default function ExperimentPage(): JSX.Element | null {
-  const router = useRouter()
-  const experimentId = toIntOrNull(router.query.id) as number | null
+export default function Experiment(): JSX.Element | null {
+  const { experimentId: experimentIdRaw, view: viewRaw = ExperimentView.Overview } = useParams<{
+    experimentId: string
+    view: string
+  }>()
+  const experimentId = yup.number().integer().defined().validateSync(experimentIdRaw)
+  const view = yup.string().defined().oneOf(Object.values(ExperimentView)).validateSync(viewRaw)
   const debugMode = isDebugMode()
-  debug(`ExperimentPage#render ${experimentId ?? 'null'}`)
 
-  if (!experimentId) {
-    return null
-  }
+  debug(`ExperimentPage#render experimentId:%o view:%o debugMode:%o`, experimentId, view, debugMode)
 
-  return <ExperimentPageView {...{ experimentId, debugMode }} view={ExperimentView.Overview} />
+  return <ExperimentPageView {...{ experimentId, debugMode, view }} />
 }

--- a/src/pages-real/experiments/ExperimentNew.tsx
+++ b/src/pages-real/experiments/ExperimentNew.tsx
@@ -1,8 +1,8 @@
 import { createStyles, LinearProgress, makeStyles, Theme, Typography } from '@material-ui/core'
 import debugFactory from 'debug'
-import { useRouter } from 'next/router'
 import { useSnackbar } from 'notistack'
 import React from 'react'
+import { useHistory } from 'react-router-dom'
 
 import { getEventNameCompletions, getUserCompletions } from 'src/api/AutocompleteApi'
 import ExperimentsApi from 'src/api/ExperimentsApi'
@@ -49,17 +49,14 @@ const ExperimentsNewPage = function (): JSX.Element {
 
   const isLoading = or(metricsIsLoading, segmentsIsLoading)
 
-  const router = useRouter()
+  const history = useHistory()
   const { enqueueSnackbar } = useSnackbar()
   const onSubmit = async (formData: unknown) => {
     try {
       const { experiment } = formData as { experiment: ExperimentFullNew }
       const receivedExperiment = await ExperimentsApi.create(experiment)
       enqueueSnackbar('Experiment Created!', { variant: 'success' })
-      await router.push(
-        '/experiments/[id]/code-setup?freshly_created',
-        `/experiments/${receivedExperiment.experimentId}/code-setup?freshly_created`,
-      )
+      history.push(`/experiments/${receivedExperiment.experimentId}/code-setup?freshly_created`)
     } catch (error) {
       enqueueSnackbar('Failed to create experiment 😨 (Form data logged to console.)', { variant: 'error' })
       console.error(error)

--- a/src/pages-real/experiments/ExperimentWizardEdit.tsx
+++ b/src/pages-real/experiments/ExperimentWizardEdit.tsx
@@ -1,10 +1,9 @@
 import { LinearProgress } from '@material-ui/core'
 import debugFactory from 'debug'
 import _ from 'lodash'
-import { useRouter } from 'next/router'
 import { useSnackbar } from 'notistack'
 import React from 'react'
-import { useParams } from 'react-router-dom'
+import { useHistory, useParams } from 'react-router-dom'
 import * as yup from 'yup'
 
 import { getEventNameCompletions, getUserCompletions } from 'src/api/AutocompleteApi'
@@ -22,8 +21,8 @@ import { createUnresolvingPromise, or } from 'src/utils/general'
 const debug = debugFactory('abacus:pages/experiments/[id]/results.tsx')
 
 export default function WizardEditPage(): JSX.Element {
+  const history = useHistory()
   const { experimentId: experimentIdRaw } = useParams<{ experimentId: string }>()
-  const router = useRouter()
   const experimentId = yup.number().integer().defined().validateSync(experimentIdRaw)
   debug(`ExperimentWizardEdit#render ${experimentId}`)
 
@@ -56,7 +55,7 @@ export default function WizardEditPage(): JSX.Element {
       const { experiment } = formData as { experiment: ExperimentFullNew }
       await ExperimentsApi.put(experimentId, experiment)
       enqueueSnackbar('Experiment Updated!', { variant: 'success' })
-      await router.push('/experiments/[id]?freshly_wizard_edited', `/experiments/${experimentId}?freshly_wizard_edited`)
+      history.push(`/experiments/${experimentId}?freshly_wizard_edited`)
     } catch (error) {
       enqueueSnackbar('Failed to update experiment 😨 (Form data logged to console.)', { variant: 'error' })
       console.error(error)

--- a/src/pages-real/experiments/ExperimentWizardEdit.tsx
+++ b/src/pages-real/experiments/ExperimentWizardEdit.tsx
@@ -3,8 +3,9 @@ import debugFactory from 'debug'
 import _ from 'lodash'
 import { useRouter } from 'next/router'
 import { useSnackbar } from 'notistack'
-import { toIntOrNull } from 'qc-to_int'
 import React from 'react'
+import { useParams } from 'react-router-dom'
+import * as yup from 'yup'
 
 import { getEventNameCompletions, getUserCompletions } from 'src/api/AutocompleteApi'
 import ExperimentsApi from 'src/api/ExperimentsApi'
@@ -21,9 +22,10 @@ import { createUnresolvingPromise, or } from 'src/utils/general'
 const debug = debugFactory('abacus:pages/experiments/[id]/results.tsx')
 
 export default function WizardEditPage(): JSX.Element {
+  const { experimentId: experimentIdRaw } = useParams<{ experimentId: string }>()
   const router = useRouter()
-  const experimentId = toIntOrNull(router.query.id) as number | null
-  debug(`ExperimentWizardEdit#render ${experimentId ?? 'null'}`)
+  const experimentId = yup.number().integer().defined().validateSync(experimentIdRaw)
+  debug(`ExperimentWizardEdit#render ${experimentId}`)
 
   const { isLoading: experimentIsLoading, data: experiment, error: experimentError } = useDataSource(
     () => (experimentId ? ExperimentsApi.findById(experimentId) : createUnresolvingPromise<ExperimentFull>()),

--- a/src/pages-real/experiments/Experiments.tsx
+++ b/src/pages-real/experiments/Experiments.tsx
@@ -7,10 +7,10 @@ import ExperimentsTable from 'src/components/ExperimentsTable'
 import Layout from 'src/components/Layout'
 import { useDataLoadingError, useDataSource } from 'src/utils/data-loading'
 
-const debug = debugFactory('abacus:pages/experiments/index.tsx')
+const debug = debugFactory('abacus:pages/experiments/Experiments.tsx')
 
-const ExperimentsIndexPage = function (): JSX.Element {
-  debug('ExperimentsIndexPage#render')
+const Experiments = function (): JSX.Element {
+  debug('ExperimentsPage#render')
 
   const { isLoading, data: experiments, error } = useDataSource(() => ExperimentsApi.findAll(), [])
 
@@ -23,4 +23,4 @@ const ExperimentsIndexPage = function (): JSX.Element {
   )
 }
 
-export default ExperimentsIndexPage
+export default Experiments

--- a/src/test-helpers/test-utils.tsx
+++ b/src/test-helpers/test-utils.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, Queries, render as actualRender, RenderOptions, screen 
 import mediaQuery from 'css-mediaquery'
 import { Formik, FormikValues } from 'formik'
 import React from 'react'
+import { StaticRouter } from 'react-router-dom'
 import { ValidationError } from 'yup'
 
 import ThemeProvider from 'src/styles/ThemeProvider'
@@ -11,7 +12,14 @@ import ThemeProvider from 'src/styles/ThemeProvider'
  * A wrapped unit-test react-renderer, useful for adding React Contexts globally.
  */
 export const render: typeof actualRender = <Q extends Queries>(ui: React.ReactElement, options?: RenderOptions<Q>) =>
-  actualRender((<ThemeProvider>{ui}</ThemeProvider>) as React.ReactElement, options) as ReturnType<typeof actualRender>
+  actualRender(
+    (
+      <StaticRouter>
+        <ThemeProvider>{ui}</ThemeProvider>
+      </StaticRouter>
+    ) as React.ReactElement,
+    options,
+  ) as ReturnType<typeof actualRender>
 
 /**
  * Create a `matchMedia` function that will match a query based on the specified

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -2,7 +2,7 @@
  * Experiments authorization info, as returned from OAuth call. See
  * https://developer.wordpress.com/docs/oauth2/.
  */
-interface ExperimentsAuthInfo {
+export interface ExperimentsAuthInfo {
   accessToken: string
   expiresAt: number | null
   scope: string


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR alters pages to use react-router's page params system instead of NextJS.**

- Also clean up the parameter validation code by using yup.
- Remove the no longer needed `qc-to_int` and `qc-to_bool` libs
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Part of a series on #212 

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
- Manual testing with mock data (locally or on Vercel)
