### PR TITLE
Add id-slugs in urls for experiments (permalinks with names in it)

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -35,17 +35,17 @@ export default function Routes(): JSX.Element {
           <ExperimentNew />
         </Route>
         <Route
-          path='/experiments/:experimentId'
+          path='/experiments/:experimentIdSlug'
           render={({ location, history }) => {
             history.replace(`${location.pathname}/overview`)
             return undefined
           }}
           exact
         />
-        <Route path='/experiments/:experimentId/wizard-edit' exact>
+        <Route path='/experiments/:experimentIdSlug/wizard-edit' exact>
           <ExperimentWizardEdit />
         </Route>
-        <Route path='/experiments/:experimentId/:view' exact>
+        <Route path='/experiments/:experimentIdSlug/:view' exact>
           <Experiment />
         </Route>
 

--- a/src/components/ExperimentsTable.tsx
+++ b/src/components/ExperimentsTable.tsx
@@ -6,6 +6,7 @@ import { useHistory } from 'react-router-dom'
 
 import DatetimeText from 'src/components/DatetimeText'
 import { ExperimentBare } from 'src/lib/schemas'
+import { createIdSlug } from 'src/utils/general'
 import { defaultTableOptions } from 'src/utils/material-table'
 
 import ExperimentStatus from './ExperimentStatus'
@@ -22,10 +23,10 @@ const ExperimentsTable = ({ experiments }: { experiments: ExperimentBare[] }): J
 
   /* istanbul ignore next; to be handled by an e2e test */
   const handleRowClick = (event?: React.MouseEvent, rowData?: ExperimentBare) => {
-    if (!rowData?.experimentId) {
+    if (!rowData) {
       throw new Error('Missing experimentId')
     }
-    history.push(`/experiments/${rowData.experimentId}`)
+    history.push(`/experiments/${createIdSlug(rowData.experimentId, rowData.name)}`)
   }
 
   return (

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -8,7 +8,7 @@ import _ from 'lodash'
 import * as yup from 'yup'
 import { ObjectSchema } from 'yup'
 
-const idSchema = yup.number().integer().positive()
+export const idSchema = yup.number().integer().positive()
 export const nameSchema = yup
   .string()
   .max(128)

--- a/src/pages/experiments/Experiment.tsx
+++ b/src/pages/experiments/Experiment.tsx
@@ -4,16 +4,16 @@ import { useParams } from 'react-router-dom'
 import * as yup from 'yup'
 
 import ExperimentPageView, { ExperimentView } from 'src/components/ExperimentPageView'
-import { isDebugMode } from 'src/utils/general'
+import { isDebugMode, parseIdSlug } from 'src/utils/general'
 
 const debug = debugFactory('abacus:pages/experiments/Experiment.tsx')
 
 export default function Experiment(): JSX.Element | null {
-  const { experimentId: experimentIdRaw, view: viewRaw = ExperimentView.Overview } = useParams<{
-    experimentId: string
+  const { experimentIdSlug, view: viewRaw = ExperimentView.Overview } = useParams<{
+    experimentIdSlug: string
     view: string
   }>()
-  const experimentId = yup.number().integer().defined().validateSync(experimentIdRaw)
+  const experimentId = parseIdSlug(experimentIdSlug)
   const view = yup.string().defined().oneOf(Object.values(ExperimentView)).validateSync(viewRaw)
   const debugMode = isDebugMode()
 

--- a/src/pages/experiments/ExperimentWizardEdit.tsx
+++ b/src/pages/experiments/ExperimentWizardEdit.tsx
@@ -4,7 +4,6 @@ import _ from 'lodash'
 import { useSnackbar } from 'notistack'
 import React from 'react'
 import { useHistory, useParams } from 'react-router-dom'
-import * as yup from 'yup'
 
 import { getEventNameCompletions, getUserCompletions } from 'src/api/AutocompleteApi'
 import ExperimentsApi from 'src/api/ExperimentsApi'
@@ -16,14 +15,14 @@ import { experimentToFormData } from 'src/lib/form-data'
 import * as Normalizers from 'src/lib/normalizers'
 import { ExperimentFull, ExperimentFullNew } from 'src/lib/schemas'
 import { useDataLoadingError, useDataSource } from 'src/utils/data-loading'
-import { createUnresolvingPromise, or } from 'src/utils/general'
+import { createUnresolvingPromise, or, parseIdSlug } from 'src/utils/general'
 
 const debug = debugFactory('abacus:pages/experiments/[id]/results.tsx')
 
 export default function WizardEditPage(): JSX.Element {
   const history = useHistory()
-  const { experimentId: experimentIdRaw } = useParams<{ experimentId: string }>()
-  const experimentId = yup.number().integer().defined().validateSync(experimentIdRaw)
+  const { experimentIdSlug } = useParams<{ experimentIdSlug: string }>()
+  const experimentId = parseIdSlug(experimentIdSlug)
   debug(`ExperimentWizardEdit#render ${experimentId}`)
 
   const { isLoading: experimentIsLoading, data: experiment, error: experimentError } = useDataSource(

--- a/src/utils/general.test.ts
+++ b/src/utils/general.test.ts
@@ -1,4 +1,4 @@
-import { createUnresolvingPromise, or } from './general'
+import { createIdSlug, createUnresolvingPromise, or, parseIdSlug } from './general'
 
 describe('utils/general.ts module', () => {
   describe('createUnresolvingPromise', () => {
@@ -15,6 +15,35 @@ describe('utils/general.ts module', () => {
       expect(or(false, true)).toBe(true)
       expect(or(true, true)).toBe(true)
       expect(or(false, false)).toBe(false)
+    })
+  })
+
+  describe('parseIdSlug', () => {
+    it('should work as expected', () => {
+      expect(parseIdSlug('123')).toBe(123)
+      expect(parseIdSlug('0123')).toBe(123)
+      expect(parseIdSlug('123-asdfasdf asdf09u23jn asdlkvjn,bmn ;p092u35')).toBe(123)
+      expect(parseIdSlug('123-100000-123')).toBe(123)
+      expect(parseIdSlug('1-100000-123')).toBe(1)
+      expect(parseIdSlug('1x123')).toBe(1)
+      expect(() => parseIdSlug('0')).toThrow(Error)
+      expect(() => parseIdSlug('00000')).toThrow(Error)
+      expect(() => parseIdSlug('0-100000-123')).toThrow(Error)
+      expect(() => parseIdSlug('')).toThrow(Error)
+      expect(() => parseIdSlug('sdfasdf')).toThrow(Error)
+      expect(() => parseIdSlug('.sdfasdf')).toThrow(Error)
+      expect(() => parseIdSlug('.123')).toThrow(Error)
+      expect(() => parseIdSlug('-123')).toThrow(Error)
+      expect(() => parseIdSlug('-123sdfasdf')).toThrow(Error)
+    })
+  })
+
+  describe('createIdSlug', () => {
+    it('should work as expected', () => {
+      expect(createIdSlug(123, 'explat_test_experiment')).toBe('123-explat-test-experiment')
+      expect(createIdSlug(123, '')).toBe('123-')
+      expect(createIdSlug(0, 'explat_test_experiment')).toBe('0-explat-test-experiment')
+      expect(createIdSlug(0, '')).toBe('0-')
     })
   })
 })

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -1,3 +1,5 @@
+import { idSchema } from 'src/lib/schemas'
+
 // TODO: Consider using a more extensive lib like Rambda that covers these
 /**
  * Coerces values to booleans and performs an `or` operation across them.
@@ -29,4 +31,36 @@ export function toggleDebugMode(): void {
   } else {
     localStorage.setItem(debugModeLocalStorageKey, 'true')
   }
+}
+
+/**
+ * Parses an "id slug", a slug used in urls that contain an ID and a name, e.g.:
+ * 46-explat-test-monthly-experiment
+ *
+ * The idea here is that we can use these for permalinks because even if the name changes
+ * all we care about is the ID.
+ *
+ * @param idSlug string The idSlug
+ * @returns integer The id from the id slug
+ */
+export function parseIdSlug(idSlug: string): number {
+  const results = /^\d+/.exec(idSlug)
+  const id = results && idSchema.defined().validateSync(results[0])
+  // istanbul ignore next; Should not occur
+  if (!id) {
+    throw new Error('Could not retrieve ID from idSlug.')
+  }
+  return id
+}
+
+/**
+ * Creates an idSlug.
+ *
+ * @param id integer
+ * @param name number
+ *
+ * @returns string The idSlug
+ */
+export function createIdSlug(id: number, name: string): string {
+  return `${id}-${name.replace(/_/g, '-')}`
 }

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -46,7 +46,6 @@ export function toggleDebugMode(): void {
 export function parseIdSlug(idSlug: string): number {
   const results = /^\d+/.exec(idSlug)
   const id = results && idSchema.defined().validateSync(results[0])
-  // istanbul ignore next; Should not occur
   if (!id) {
     throw new Error('Could not retrieve ID from idSlug.')
   }


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR adds id-slugs for experiments.**

Now we use urls like:  
`http://a8c-abacus-local:3000/experiments/20033-explat-test-aa-weekly-calypso-2020-week-46/overview`

This is a cinch with CRA 😄 

Resolves #365 

<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
