### PR TITLE
Add and improve PP tooltips

### DIFF
--- a/src/components/MetricAssignmentsPanel.test.tsx
+++ b/src/components/MetricAssignmentsPanel.test.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/require-await, no-irregular-whitespace */
 import { act, fireEvent, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react'
 import { noop } from 'lodash'
 import * as notistack from 'notistack'
@@ -143,7 +143,14 @@ test('renders as expected with all metrics resolvable', () => {
                 class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-2"
               >
                 <span>
-                  0.1 pp
+                  0.1
+                   
+                  <span
+                    class="makeStyles-tooltipped-8"
+                    title="Percentage Points"
+                  >
+                    pp
+                  </span>
                 </span>
               </td>
             </tr>
@@ -224,7 +231,14 @@ test('renders as expected with all metrics resolvable', () => {
                 class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-2"
               >
                 <span>
-                  12 pp
+                  12
+                   
+                  <span
+                    class="makeStyles-tooltipped-8"
+                    title="Percentage Points"
+                  >
+                    pp
+                  </span>
                 </span>
               </td>
             </tr>

--- a/src/components/MetricAssignmentsPanel.tsx
+++ b/src/components/MetricAssignmentsPanel.tsx
@@ -100,6 +100,11 @@ const useStyles = makeStyles((theme: Theme) =>
     primaryChip: {
       marginTop: theme.spacing(1),
     },
+    tooltipped: {
+      borderBottomWidth: 1,
+      borderBottomStyle: 'dashed',
+      borderBottomColor: theme.palette.grey[500],
+    },
   }),
 )
 
@@ -208,9 +213,16 @@ function MetricAssignmentsPanel({
               </TableCell>
               <TableCell className={classes.monospace}>
                 <span>
-                  {resolvedMetricAssignment.metric.parameterType === MetricParameterType.Revenue
-                    ? formatUsCurrencyDollar(resolvedMetricAssignment.minDifference)
-                    : `${resolvedMetricAssignment.minDifference} pp`}
+                  {resolvedMetricAssignment.metric.parameterType === MetricParameterType.Revenue ? (
+                    formatUsCurrencyDollar(resolvedMetricAssignment.minDifference)
+                  ) : (
+                    <>
+                      {resolvedMetricAssignment.minDifference}&nbsp;
+                      <Tooltip title='Percentage Points'>
+                        <span className={classes.tooltipped}>pp</span>
+                      </Tooltip>
+                    </>
+                  )}
                 </span>
               </TableCell>
             </TableRow>
@@ -341,7 +353,7 @@ function MetricAssignmentsPanel({
                               endAdornment: (
                                 <InputAdornment position='end'>
                                   <Tooltip title='Percentage Points'>
-                                    <Typography variant='body1' color='textSecondary'>
+                                    <Typography variant='body1' color='textSecondary' className={classes.tooltipped}>
                                       pp
                                     </Typography>
                                   </Tooltip>

--- a/src/components/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/src/components/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -300,7 +300,14 @@ exports[`renders as expected at large width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-14"
                   >
                     <span>
-                      0.1 pp
+                      0.1
+                       
+                      <span
+                        class="makeStyles-tooltipped-20"
+                        title="Percentage Points"
+                      >
+                        pp
+                      </span>
                     </span>
                   </td>
                 </tr>
@@ -381,7 +388,14 @@ exports[`renders as expected at large width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-14"
                   >
                     <span>
-                      12 pp
+                      12
+                       
+                      <span
+                        class="makeStyles-tooltipped-20"
+                        title="Percentage Points"
+                      >
+                        pp
+                      </span>
                     </span>
                   </td>
                 </tr>
@@ -401,7 +415,7 @@ exports[`renders as expected at large width 1`] = `
           class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
         >
           <h3
-            class="MuiTypography-root makeStyles-title-20 MuiTypography-h3 MuiTypography-colorTextPrimary"
+            class="MuiTypography-root makeStyles-title-21 MuiTypography-h3 MuiTypography-colorTextPrimary"
           >
             Audience
           </h3>
@@ -426,7 +440,7 @@ exports[`renders as expected at large width 1`] = `
                 class="MuiTableCell-root MuiTableCell-body"
               >
                 <span
-                  class="makeStyles-monospace-21"
+                  class="makeStyles-monospace-22"
                 >
                   calypso
                 </span>
@@ -446,7 +460,7 @@ exports[`renders as expected at large width 1`] = `
                 class="MuiTableCell-root MuiTableCell-body"
               >
                 <span
-                  class="makeStyles-monospace-21"
+                  class="makeStyles-monospace-22"
                 >
                   New users only
                 </span>
@@ -466,7 +480,7 @@ exports[`renders as expected at large width 1`] = `
                 class="MuiTableCell-root MuiTableCell-body"
               >
                 <table
-                  class="MuiTable-root makeStyles-root-22"
+                  class="MuiTable-root makeStyles-root-23"
                 >
                   <thead
                     class="MuiTableHead-root"
@@ -497,10 +511,10 @@ exports[`renders as expected at large width 1`] = `
                       class="MuiTableRow-root"
                     >
                       <td
-                        class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-27"
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-28"
                       >
                         <span
-                          class="makeStyles-variation-25"
+                          class="makeStyles-variation-26"
                         >
                           control
                         </span>
@@ -517,7 +531,7 @@ exports[`renders as expected at large width 1`] = `
                         </div>
                       </td>
                       <td
-                        class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-27"
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-28"
                       >
                         60
                         %
@@ -527,17 +541,17 @@ exports[`renders as expected at large width 1`] = `
                       class="MuiTableRow-root"
                     >
                       <td
-                        class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-27"
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-28"
                       >
                         <span
-                          class="makeStyles-variation-25"
+                          class="makeStyles-variation-26"
                         >
                           test
                         </span>
                          
                       </td>
                       <td
-                        class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-27"
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-28"
                       >
                         40
                         %
@@ -561,7 +575,7 @@ exports[`renders as expected at large width 1`] = `
                 class="MuiTableCell-root MuiTableCell-body"
               >
                 <table
-                  class="MuiTable-root makeStyles-root-28"
+                  class="MuiTable-root makeStyles-root-29"
                 >
                   <thead
                     class="MuiTableHead-root"
@@ -585,7 +599,7 @@ exports[`renders as expected at large width 1`] = `
                       class="MuiTableRow-root"
                     >
                       <td
-                        class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-31"
                       >
                         segment_1
                          
@@ -594,7 +608,7 @@ exports[`renders as expected at large width 1`] = `
                   </tbody>
                 </table>
                 <table
-                  class="MuiTable-root makeStyles-root-28"
+                  class="MuiTable-root makeStyles-root-29"
                 >
                   <thead
                     class="MuiTableHead-root"
@@ -618,7 +632,7 @@ exports[`renders as expected at large width 1`] = `
                       class="MuiTableRow-root"
                     >
                       <td
-                        class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-31"
                       >
                         segment_2
                          
@@ -652,32 +666,32 @@ exports[`renders as expected at large width 1`] = `
                 class="MuiTableCell-root MuiTableCell-body"
               >
                 <div
-                  class="makeStyles-eventList-33"
+                  class="makeStyles-eventList-34"
                 >
                   <p
-                    class="MuiTypography-root makeStyles-monospace-34 MuiTypography-body1"
+                    class="MuiTypography-root makeStyles-monospace-35 MuiTypography-body1"
                   >
                     <span
-                      class="makeStyles-eventName-32"
+                      class="makeStyles-eventName-33"
                     >
                       event_name
                     </span>
                     <span
-                      class="makeStyles-entry-31"
+                      class="makeStyles-entry-32"
                     >
                       additionalProp1
                       : 
                       prop1Value
                     </span>
                     <span
-                      class="makeStyles-entry-31"
+                      class="makeStyles-entry-32"
                     >
                       additionalProp2
                       : 
                       prop2Value
                     </span>
                     <span
-                      class="makeStyles-entry-31"
+                      class="makeStyles-entry-32"
                     >
                       additionalProp3
                       : 
@@ -742,7 +756,7 @@ exports[`renders as expected at small width 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-36 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-37 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 General
               </h3>
@@ -795,10 +809,10 @@ exports[`renders as expected at small width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-40"
+                      class="makeStyles-root-41"
                     >
                       <span
-                        class="makeStyles-statusDot-45 makeStyles-staging-43"
+                        class="makeStyles-statusDot-46 makeStyles-staging-44"
                       />
                        
                       staging
@@ -819,18 +833,18 @@ exports[`renders as expected at small width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-46"
+                      class="makeStyles-root-47"
                       title="20/09/2020, 20:00:00"
                     >
                       2020-09-21
                     </span>
                     <span
-                      class="makeStyles-to-35"
+                      class="makeStyles-to-36"
                     >
                       to
                     </span>
                     <span
-                      class="makeStyles-root-46"
+                      class="makeStyles-root-47"
                       title="20/11/2020, 19:00:00"
                     >
                       2020-11-21
@@ -851,7 +865,7 @@ exports[`renders as expected at small width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-monospace-39"
+                      class="makeStyles-monospace-40"
                     >
                       Experiment with things. Change stuff. Profit.
                     </span>
@@ -871,7 +885,7 @@ exports[`renders as expected at small width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-monospace-39"
+                      class="makeStyles-monospace-40"
                     >
                       owner-nickname
                     </span>
@@ -891,7 +905,7 @@ exports[`renders as expected at small width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <a
-                      class="MuiTypography-root MuiLink-root MuiLink-underlineHover makeStyles-monospace-39 MuiTypography-colorPrimary"
+                      class="MuiTypography-root MuiLink-root MuiLink-underlineHover makeStyles-monospace-40 MuiTypography-colorPrimary"
                       href="https://wordpress.com/experiment_1"
                       rel="noopener noreferrer"
                       target="_blank"
@@ -914,7 +928,7 @@ exports[`renders as expected at small width 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-54 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-56 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Audience
               </h3>
@@ -939,7 +953,7 @@ exports[`renders as expected at small width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-monospace-55"
+                      class="makeStyles-monospace-57"
                     >
                       calypso
                     </span>
@@ -959,7 +973,7 @@ exports[`renders as expected at small width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-monospace-55"
+                      class="makeStyles-monospace-57"
                     >
                       New users only
                     </span>
@@ -979,7 +993,7 @@ exports[`renders as expected at small width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <table
-                      class="MuiTable-root makeStyles-root-56"
+                      class="MuiTable-root makeStyles-root-58"
                     >
                       <thead
                         class="MuiTableHead-root"
@@ -1010,10 +1024,10 @@ exports[`renders as expected at small width 1`] = `
                           class="MuiTableRow-root"
                         >
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-61"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-63"
                           >
                             <span
-                              class="makeStyles-variation-59"
+                              class="makeStyles-variation-61"
                             >
                               control
                             </span>
@@ -1030,7 +1044,7 @@ exports[`renders as expected at small width 1`] = `
                             </div>
                           </td>
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-61"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-63"
                           >
                             60
                             %
@@ -1040,17 +1054,17 @@ exports[`renders as expected at small width 1`] = `
                           class="MuiTableRow-root"
                         >
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-61"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-63"
                           >
                             <span
-                              class="makeStyles-variation-59"
+                              class="makeStyles-variation-61"
                             >
                               test
                             </span>
                              
                           </td>
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-61"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-63"
                           >
                             40
                             %
@@ -1074,7 +1088,7 @@ exports[`renders as expected at small width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <table
-                      class="MuiTable-root makeStyles-root-62"
+                      class="MuiTable-root makeStyles-root-64"
                     >
                       <thead
                         class="MuiTableHead-root"
@@ -1098,7 +1112,7 @@ exports[`renders as expected at small width 1`] = `
                           class="MuiTableRow-root"
                         >
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-64"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
                           >
                             segment_1
                              
@@ -1107,7 +1121,7 @@ exports[`renders as expected at small width 1`] = `
                       </tbody>
                     </table>
                     <table
-                      class="MuiTable-root makeStyles-root-62"
+                      class="MuiTable-root makeStyles-root-64"
                     >
                       <thead
                         class="MuiTableHead-root"
@@ -1131,7 +1145,7 @@ exports[`renders as expected at small width 1`] = `
                           class="MuiTableRow-root"
                         >
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-64"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
                           >
                             segment_2
                              
@@ -1165,32 +1179,32 @@ exports[`renders as expected at small width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <div
-                      class="makeStyles-eventList-67"
+                      class="makeStyles-eventList-69"
                     >
                       <p
-                        class="MuiTypography-root makeStyles-monospace-68 MuiTypography-body1"
+                        class="MuiTypography-root makeStyles-monospace-70 MuiTypography-body1"
                       >
                         <span
-                          class="makeStyles-eventName-66"
+                          class="makeStyles-eventName-68"
                         >
                           event_name
                         </span>
                         <span
-                          class="makeStyles-entry-65"
+                          class="makeStyles-entry-67"
                         >
                           additionalProp1
                           : 
                           prop1Value
                         </span>
                         <span
-                          class="makeStyles-entry-65"
+                          class="makeStyles-entry-67"
                         >
                           additionalProp2
                           : 
                           prop2Value
                         </span>
                         <span
-                          class="makeStyles-entry-65"
+                          class="makeStyles-entry-67"
                         >
                           additionalProp3
                           : 
@@ -1240,7 +1254,7 @@ exports[`renders as expected at small width 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-49 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-50 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Metrics
               </h3>
@@ -1318,13 +1332,13 @@ exports[`renders as expected at small width 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49"
                   >
                     metric_1
                     <br />
                     <div
                       aria-disabled="true"
-                      class="MuiChip-root makeStyles-primaryChip-53 MuiChip-outlined Mui-disabled"
+                      class="MuiChip-root makeStyles-primaryChip-54 MuiChip-outlined Mui-disabled"
                     >
                       <span
                         class="MuiChip-label"
@@ -1334,20 +1348,27 @@ exports[`renders as expected at small width 1`] = `
                     </div>
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49"
                   >
                     1 week
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49"
                   >
                     Yes
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49"
                   >
                     <span>
-                      0.1 pp
+                      0.1
+                       
+                      <span
+                        class="makeStyles-tooltipped-55"
+                        title="Percentage Points"
+                      >
+                        pp
+                      </span>
                     </span>
                   </td>
                 </tr>
@@ -1355,23 +1376,23 @@ exports[`renders as expected at small width 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49"
                   >
                     metric_2
                     <br />
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49"
                   >
                     1 hour
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49"
                   >
                     Yes
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49"
                   >
                     <span>
                       $0.50
@@ -1382,23 +1403,23 @@ exports[`renders as expected at small width 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49"
                   >
                     metric_2
                     <br />
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49"
                   >
                     4 weeks
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49"
                   >
                     No
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49"
                   >
                     <span>
                       $10.50
@@ -1409,26 +1430,33 @@ exports[`renders as expected at small width 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49"
                   >
                     metric_3
                     <br />
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49"
                   >
                     6 hours
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49"
                   >
                     Yes
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-48"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49"
                   >
                     <span>
-                      12 pp
+                      12
+                       
+                      <span
+                        class="makeStyles-tooltipped-55"
+                        title="Percentage Points"
+                      >
+                        pp
+                      </span>
                     </span>
                   </td>
                 </tr>
@@ -1463,7 +1491,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-70 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-72 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 General
               </h3>
@@ -1518,10 +1546,10 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-74"
+                      class="makeStyles-root-76"
                     >
                       <span
-                        class="makeStyles-statusDot-79 makeStyles-disabled-78"
+                        class="makeStyles-statusDot-81 makeStyles-disabled-80"
                       />
                        
                       disabled
@@ -1542,18 +1570,18 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-80"
+                      class="makeStyles-root-82"
                       title="20/09/2020, 20:00:00"
                     >
                       2020-09-21
                     </span>
                     <span
-                      class="makeStyles-to-69"
+                      class="makeStyles-to-71"
                     >
                       to
                     </span>
                     <span
-                      class="makeStyles-root-80"
+                      class="makeStyles-root-82"
                       title="20/11/2020, 19:00:00"
                     >
                       2020-11-21
@@ -1574,7 +1602,7 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-monospace-73"
+                      class="makeStyles-monospace-75"
                     >
                       Experiment with things. Change stuff. Profit.
                     </span>
@@ -1594,7 +1622,7 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-monospace-73"
+                      class="makeStyles-monospace-75"
                     >
                       owner-nickname
                     </span>
@@ -1614,7 +1642,7 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <a
-                      class="MuiTypography-root MuiLink-root MuiLink-underlineHover makeStyles-monospace-73 MuiTypography-colorPrimary"
+                      class="MuiTypography-root MuiLink-root MuiLink-underlineHover makeStyles-monospace-75 MuiTypography-colorPrimary"
                       href="https://wordpress.com/experiment_1"
                       rel="noopener noreferrer"
                       target="_blank"
@@ -1637,7 +1665,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-90 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-93 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Audience
               </h3>
@@ -1662,7 +1690,7 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-monospace-91"
+                      class="makeStyles-monospace-94"
                     >
                       calypso
                     </span>
@@ -1682,7 +1710,7 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-monospace-91"
+                      class="makeStyles-monospace-94"
                     >
                       New users only
                     </span>
@@ -1702,7 +1730,7 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <table
-                      class="MuiTable-root makeStyles-root-92"
+                      class="MuiTable-root makeStyles-root-95"
                     >
                       <thead
                         class="MuiTableHead-root"
@@ -1733,10 +1761,10 @@ exports[`renders as expected with conclusion data 1`] = `
                           class="MuiTableRow-root"
                         >
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-97"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-100"
                           >
                             <span
-                              class="makeStyles-variation-95"
+                              class="makeStyles-variation-98"
                             >
                               control
                             </span>
@@ -1753,7 +1781,7 @@ exports[`renders as expected with conclusion data 1`] = `
                             </div>
                           </td>
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-97"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-100"
                           >
                             60
                             %
@@ -1763,17 +1791,17 @@ exports[`renders as expected with conclusion data 1`] = `
                           class="MuiTableRow-root"
                         >
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-97"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-100"
                           >
                             <span
-                              class="makeStyles-variation-95"
+                              class="makeStyles-variation-98"
                             >
                               test
                             </span>
                              
                           </td>
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-97"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-100"
                           >
                             40
                             %
@@ -1797,7 +1825,7 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <table
-                      class="MuiTable-root makeStyles-root-98"
+                      class="MuiTable-root makeStyles-root-101"
                     >
                       <thead
                         class="MuiTableHead-root"
@@ -1821,7 +1849,7 @@ exports[`renders as expected with conclusion data 1`] = `
                           class="MuiTableRow-root"
                         >
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-100"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-103"
                           >
                             segment_1
                              
@@ -1830,7 +1858,7 @@ exports[`renders as expected with conclusion data 1`] = `
                       </tbody>
                     </table>
                     <table
-                      class="MuiTable-root makeStyles-root-98"
+                      class="MuiTable-root makeStyles-root-101"
                     >
                       <thead
                         class="MuiTableHead-root"
@@ -1854,7 +1882,7 @@ exports[`renders as expected with conclusion data 1`] = `
                           class="MuiTableRow-root"
                         >
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-100"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-103"
                           >
                             segment_2
                              
@@ -1888,32 +1916,32 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <div
-                      class="makeStyles-eventList-103"
+                      class="makeStyles-eventList-106"
                     >
                       <p
-                        class="MuiTypography-root makeStyles-monospace-104 MuiTypography-body1"
+                        class="MuiTypography-root makeStyles-monospace-107 MuiTypography-body1"
                       >
                         <span
-                          class="makeStyles-eventName-102"
+                          class="makeStyles-eventName-105"
                         >
                           event_name
                         </span>
                         <span
-                          class="makeStyles-entry-101"
+                          class="makeStyles-entry-104"
                         >
                           additionalProp1
                           : 
                           prop1Value
                         </span>
                         <span
-                          class="makeStyles-entry-101"
+                          class="makeStyles-entry-104"
                         >
                           additionalProp2
                           : 
                           prop2Value
                         </span>
                         <span
-                          class="makeStyles-entry-101"
+                          class="makeStyles-entry-104"
                         >
                           additionalProp3
                           : 
@@ -1963,7 +1991,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-83 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-85 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Metrics
               </h3>
@@ -2043,13 +2071,13 @@ exports[`renders as expected with conclusion data 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-84"
                   >
                     metric_1
                     <br />
                     <div
                       aria-disabled="true"
-                      class="MuiChip-root makeStyles-primaryChip-87 MuiChip-outlined Mui-disabled"
+                      class="MuiChip-root makeStyles-primaryChip-89 MuiChip-outlined Mui-disabled"
                     >
                       <span
                         class="MuiChip-label"
@@ -2059,20 +2087,27 @@ exports[`renders as expected with conclusion data 1`] = `
                     </div>
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-84"
                   >
                     1 week
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-84"
                   >
                     Yes
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-84"
                   >
                     <span>
-                      0.1 pp
+                      0.1
+                       
+                      <span
+                        class="makeStyles-tooltipped-90"
+                        title="Percentage Points"
+                      >
+                        pp
+                      </span>
                     </span>
                   </td>
                 </tr>
@@ -2080,23 +2115,23 @@ exports[`renders as expected with conclusion data 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-84"
                   >
                     metric_2
                     <br />
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-84"
                   >
                     1 hour
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-84"
                   >
                     Yes
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-84"
                   >
                     <span>
                       $0.50
@@ -2107,23 +2142,23 @@ exports[`renders as expected with conclusion data 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-84"
                   >
                     metric_2
                     <br />
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-84"
                   >
                     4 weeks
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-84"
                   >
                     No
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-84"
                   >
                     <span>
                       $10.50
@@ -2134,26 +2169,33 @@ exports[`renders as expected with conclusion data 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-84"
                   >
                     metric_3
                     <br />
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-84"
                   >
                     6 hours
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-84"
                   >
                     Yes
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-82"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-84"
                   >
                     <span>
-                      12 pp
+                      12
+                       
+                      <span
+                        class="makeStyles-tooltipped-90"
+                        title="Percentage Points"
+                      >
+                        pp
+                      </span>
                     </span>
                   </td>
                 </tr>
@@ -2171,7 +2213,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-88 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-91 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Conclusions
               </h3>
@@ -2292,7 +2334,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-106 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-109 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 General
               </h3>
@@ -2345,10 +2387,10 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-110"
+                      class="makeStyles-root-113"
                     >
                       <span
-                        class="makeStyles-statusDot-115 makeStyles-staging-113"
+                        class="makeStyles-statusDot-118 makeStyles-staging-116"
                       />
                        
                       staging
@@ -2369,18 +2411,18 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-root-116"
+                      class="makeStyles-root-119"
                       title="20/09/2020, 20:00:00"
                     >
                       2020-09-21
                     </span>
                     <span
-                      class="makeStyles-to-105"
+                      class="makeStyles-to-108"
                     >
                       to
                     </span>
                     <span
-                      class="makeStyles-root-116"
+                      class="makeStyles-root-119"
                       title="20/11/2020, 19:00:00"
                     >
                       2020-11-21
@@ -2401,7 +2443,7 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-monospace-109"
+                      class="makeStyles-monospace-112"
                     >
                       Experiment with things. Change stuff. Profit.
                     </span>
@@ -2421,7 +2463,7 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-monospace-109"
+                      class="makeStyles-monospace-112"
                     >
                       owner-nickname
                     </span>
@@ -2441,7 +2483,7 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <a
-                      class="MuiTypography-root MuiLink-root MuiLink-underlineHover makeStyles-monospace-109 MuiTypography-colorPrimary"
+                      class="MuiTypography-root MuiLink-root MuiLink-underlineHover makeStyles-monospace-112 MuiTypography-colorPrimary"
                       href="https://wordpress.com/experiment_1"
                       rel="noopener noreferrer"
                       target="_blank"
@@ -2464,7 +2506,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-124 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-128 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Audience
               </h3>
@@ -2489,7 +2531,7 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-monospace-125"
+                      class="makeStyles-monospace-129"
                     >
                       calypso
                     </span>
@@ -2509,7 +2551,7 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <span
-                      class="makeStyles-monospace-125"
+                      class="makeStyles-monospace-129"
                     >
                       New users only
                     </span>
@@ -2529,7 +2571,7 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <table
-                      class="MuiTable-root makeStyles-root-126"
+                      class="MuiTable-root makeStyles-root-130"
                     >
                       <thead
                         class="MuiTableHead-root"
@@ -2560,10 +2602,10 @@ exports[`renders as expected without conclusion data 1`] = `
                           class="MuiTableRow-root"
                         >
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-131"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-135"
                           >
                             <span
-                              class="makeStyles-variation-129"
+                              class="makeStyles-variation-133"
                             >
                               control
                             </span>
@@ -2580,7 +2622,7 @@ exports[`renders as expected without conclusion data 1`] = `
                             </div>
                           </td>
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-131"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-135"
                           >
                             60
                             %
@@ -2590,17 +2632,17 @@ exports[`renders as expected without conclusion data 1`] = `
                           class="MuiTableRow-root"
                         >
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-131"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-135"
                           >
                             <span
-                              class="makeStyles-variation-129"
+                              class="makeStyles-variation-133"
                             >
                               test
                             </span>
                              
                           </td>
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-131"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-135"
                           >
                             40
                             %
@@ -2624,7 +2666,7 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <table
-                      class="MuiTable-root makeStyles-root-132"
+                      class="MuiTable-root makeStyles-root-136"
                     >
                       <thead
                         class="MuiTableHead-root"
@@ -2648,7 +2690,7 @@ exports[`renders as expected without conclusion data 1`] = `
                           class="MuiTableRow-root"
                         >
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-134"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-138"
                           >
                             segment_1
                              
@@ -2657,7 +2699,7 @@ exports[`renders as expected without conclusion data 1`] = `
                       </tbody>
                     </table>
                     <table
-                      class="MuiTable-root makeStyles-root-132"
+                      class="MuiTable-root makeStyles-root-136"
                     >
                       <thead
                         class="MuiTableHead-root"
@@ -2681,7 +2723,7 @@ exports[`renders as expected without conclusion data 1`] = `
                           class="MuiTableRow-root"
                         >
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-134"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-138"
                           >
                             segment_2
                              
@@ -2715,32 +2757,32 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <div
-                      class="makeStyles-eventList-137"
+                      class="makeStyles-eventList-141"
                     >
                       <p
-                        class="MuiTypography-root makeStyles-monospace-138 MuiTypography-body1"
+                        class="MuiTypography-root makeStyles-monospace-142 MuiTypography-body1"
                       >
                         <span
-                          class="makeStyles-eventName-136"
+                          class="makeStyles-eventName-140"
                         >
                           event_name
                         </span>
                         <span
-                          class="makeStyles-entry-135"
+                          class="makeStyles-entry-139"
                         >
                           additionalProp1
                           : 
                           prop1Value
                         </span>
                         <span
-                          class="makeStyles-entry-135"
+                          class="makeStyles-entry-139"
                         >
                           additionalProp2
                           : 
                           prop2Value
                         </span>
                         <span
-                          class="makeStyles-entry-135"
+                          class="makeStyles-entry-139"
                         >
                           additionalProp3
                           : 
@@ -2790,7 +2832,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
             >
               <h3
-                class="MuiTypography-root makeStyles-title-119 MuiTypography-h3 MuiTypography-colorTextPrimary"
+                class="MuiTypography-root makeStyles-title-122 MuiTypography-h3 MuiTypography-colorTextPrimary"
               >
                 Metrics
               </h3>
@@ -2868,13 +2910,13 @@ exports[`renders as expected without conclusion data 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
                   >
                     metric_1
                     <br />
                     <div
                       aria-disabled="true"
-                      class="MuiChip-root makeStyles-primaryChip-123 MuiChip-outlined Mui-disabled"
+                      class="MuiChip-root makeStyles-primaryChip-126 MuiChip-outlined Mui-disabled"
                     >
                       <span
                         class="MuiChip-label"
@@ -2884,20 +2926,27 @@ exports[`renders as expected without conclusion data 1`] = `
                     </div>
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
                   >
                     1 week
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
                   >
                     Yes
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
                   >
                     <span>
-                      0.1 pp
+                      0.1
+                       
+                      <span
+                        class="makeStyles-tooltipped-127"
+                        title="Percentage Points"
+                      >
+                        pp
+                      </span>
                     </span>
                   </td>
                 </tr>
@@ -2905,23 +2954,23 @@ exports[`renders as expected without conclusion data 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
                   >
                     metric_2
                     <br />
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
                   >
                     1 hour
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
                   >
                     Yes
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
                   >
                     <span>
                       $0.50
@@ -2932,23 +2981,23 @@ exports[`renders as expected without conclusion data 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
                   >
                     metric_2
                     <br />
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
                   >
                     4 weeks
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
                   >
                     No
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
                   >
                     <span>
                       $10.50
@@ -2959,26 +3008,33 @@ exports[`renders as expected without conclusion data 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
                   >
                     metric_3
                     <br />
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
                   >
                     6 hours
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
                   >
                     Yes
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-118"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
                   >
                     <span>
-                      12 pp
+                      12
+                       
+                      <span
+                        class="makeStyles-tooltipped-127"
+                        title="Percentage Points"
+                      >
+                        pp
+                      </span>
                     </span>
                   </td>
                 </tr>

--- a/src/components/experiment-creation/Metrics.tsx
+++ b/src/components/experiment-creation/Metrics.tsx
@@ -60,6 +60,11 @@ const useStyles = makeStyles((theme: Theme) =>
       marginTop: theme.spacing(6),
       marginBottom: theme.spacing(4),
     },
+    tooltipped: {
+      borderBottomWidth: 1,
+      borderBottomStyle: 'dashed',
+      borderBottomColor: theme.palette.grey[500],
+    },
   }),
 )
 
@@ -406,7 +411,11 @@ const Metrics = ({
                                       endAdornment: (
                                         <InputAdornment position='end'>
                                           <Tooltip title='Percentage Points'>
-                                            <Typography variant='body1' color='textSecondary'>
+                                            <Typography
+                                              variant='body1'
+                                              color='textSecondary'
+                                              className={classes.tooltipped}
+                                            >
                                               pp
                                             </Typography>
                                           </Tooltip>

--- a/src/components/experiment-creation/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/src/components/experiment-creation/__snapshots__/ExperimentForm.test.tsx.snap
@@ -393,10 +393,10 @@ exports[`renders as expected 1`] = `
 exports[`sections should be browsable by the section buttons 1`] = `
 <div>
   <div
-    class="makeStyles-root-111"
+    class="makeStyles-root-113"
   >
     <div
-      class="makeStyles-navigation-112"
+      class="makeStyles-navigation-114"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -683,17 +683,17 @@ exports[`sections should be browsable by the section buttons 1`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-113"
+        class="makeStyles-form-115"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-114"
+          class="makeStyles-formPart-116"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-116 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-118 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-117"
+              class="makeStyles-root-119"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -717,7 +717,7 @@ exports[`sections should be browsable by the section buttons 1`] = `
                 </strong>
               </p>
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-p2EntryField-118"
+                class="MuiFormControl-root MuiTextField-root makeStyles-p2EntryField-120"
               >
                 <label
                   class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
@@ -741,10 +741,10 @@ exports[`sections should be browsable by the section buttons 1`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-120 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-122 MuiOutlinedInput-notchedOutline"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legendLabelled-122 PrivateNotchedOutline-legendNotched-123"
+                      class="PrivateNotchedOutline-legendLabelled-124 PrivateNotchedOutline-legendNotched-125"
                     >
                       <span>
                         Your Post's URL
@@ -756,7 +756,7 @@ exports[`sections should be browsable by the section buttons 1`] = `
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-115"
+            class="makeStyles-formPartActions-117"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -783,10 +783,10 @@ exports[`sections should be browsable by the section buttons 1`] = `
 exports[`sections should be browsable by the section buttons 2`] = `
 <div>
   <div
-    class="makeStyles-root-111"
+    class="makeStyles-root-113"
   >
     <div
-      class="makeStyles-navigation-112"
+      class="makeStyles-navigation-114"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -1063,17 +1063,17 @@ exports[`sections should be browsable by the section buttons 2`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-113"
+        class="makeStyles-form-115"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-114"
+          class="makeStyles-formPart-116"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-116 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-118 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-124"
+              class="makeStyles-root-126"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1081,7 +1081,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
                 Basic Info
               </h4>
               <div
-                class="makeStyles-row-125"
+                class="makeStyles-row-127"
               >
                 <div
                   class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -1117,10 +1117,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-120 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-122 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-122 PrivateNotchedOutline-legendNotched-123"
+                        class="PrivateNotchedOutline-legendLabelled-124 PrivateNotchedOutline-legendNotched-125"
                       >
                         <span>
                           Experiment name
@@ -1138,7 +1138,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-row-125"
+                class="makeStyles-row-127"
               >
                 <div
                   class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -1173,10 +1173,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-120 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-122 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-122 PrivateNotchedOutline-legendNotched-123"
+                        class="PrivateNotchedOutline-legendLabelled-124 PrivateNotchedOutline-legendNotched-125"
                       >
                         <span>
                           Experiment description
@@ -1194,10 +1194,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-row-125"
+                class="makeStyles-row-127"
               >
                 <div
-                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-127"
+                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-129"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
@@ -1231,10 +1231,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-120 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-122 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-122 PrivateNotchedOutline-legendNotched-123"
+                        class="PrivateNotchedOutline-legendLabelled-124 PrivateNotchedOutline-legendNotched-125"
                       >
                         <span>
                           Start date
@@ -1251,12 +1251,12 @@ exports[`sections should be browsable by the section buttons 2`] = `
                   </p>
                 </div>
                 <span
-                  class="makeStyles-through-126"
+                  class="makeStyles-through-128"
                 >
                    through 
                 </span>
                 <div
-                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-127"
+                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-129"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
@@ -1288,10 +1288,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-120 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-122 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-122 PrivateNotchedOutline-legendNotched-123"
+                        class="PrivateNotchedOutline-legendLabelled-124 PrivateNotchedOutline-legendNotched-125"
                       >
                         <span>
                           End date
@@ -1309,7 +1309,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-row-125"
+                class="makeStyles-row-127"
               >
                 <div
                   aria-expanded="false"
@@ -1417,10 +1417,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                       </div>
                       <fieldset
                         aria-hidden="true"
-                        class="PrivateNotchedOutline-root-120 MuiOutlinedInput-notchedOutline"
+                        class="PrivateNotchedOutline-root-122 MuiOutlinedInput-notchedOutline"
                       >
                         <legend
-                          class="PrivateNotchedOutline-legendLabelled-122 PrivateNotchedOutline-legendNotched-123"
+                          class="PrivateNotchedOutline-legendLabelled-124 PrivateNotchedOutline-legendNotched-125"
                         >
                           <span>
                             Owner
@@ -1441,7 +1441,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-115"
+            class="makeStyles-formPartActions-117"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -1482,10 +1482,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
 exports[`sections should be browsable by the section buttons 3`] = `
 <div>
   <div
-    class="makeStyles-root-111"
+    class="makeStyles-root-113"
   >
     <div
-      class="makeStyles-navigation-112"
+      class="makeStyles-navigation-114"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -1732,14 +1732,14 @@ exports[`sections should be browsable by the section buttons 3`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-113"
+        class="makeStyles-form-115"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-114"
+          class="makeStyles-formPart-116"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-116 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-118 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <h4
               class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1774,7 +1774,7 @@ exports[`sections should be browsable by the section buttons 3`] = `
             </p>
           </div>
           <div
-            class="makeStyles-formPartActions-115"
+            class="makeStyles-formPartActions-117"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -1791,7 +1791,7 @@ exports[`sections should be browsable by the section buttons 3`] = `
               />
             </button>
             <div
-              class="makeStyles-root-128"
+              class="makeStyles-root-130"
             >
               <button
                 class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary Mui-disabled Mui-disabled"
@@ -1817,10 +1817,10 @@ exports[`sections should be browsable by the section buttons 3`] = `
 exports[`sections should be browsable by the section buttons 4`] = `
 <div>
   <div
-    class="makeStyles-root-111"
+    class="makeStyles-root-113"
   >
     <div
-      class="makeStyles-navigation-112"
+      class="makeStyles-navigation-114"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -2077,17 +2077,17 @@ exports[`sections should be browsable by the section buttons 4`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-113"
+        class="makeStyles-form-115"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-114"
+          class="makeStyles-formPart-116"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-116 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-118 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-130"
+              class="makeStyles-root-132"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -2157,11 +2157,11 @@ exports[`sections should be browsable by the section buttons 4`] = `
                 </table>
               </div>
               <div
-                class="makeStyles-addMetric-140"
+                class="makeStyles-addMetric-143"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-141"
+                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-144"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -2170,7 +2170,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
                   />
                 </svg>
                 <div
-                  class="MuiFormControl-root makeStyles-addMetricSelect-132"
+                  class="MuiFormControl-root makeStyles-addMetricSelect-134"
                 >
                   <div
                     class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -2184,7 +2184,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
                       tabindex="0"
                     >
                       <span
-                        class="makeStyles-addMetricPlaceholder-131"
+                        class="makeStyles-addMetricPlaceholder-133"
                       >
                         Select a Metric
                       </span>
@@ -2222,7 +2222,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
                 </button>
               </div>
               <h4
-                class="MuiTypography-root makeStyles-exposureEventsTitle-138 MuiTypography-h4 MuiTypography-gutterBottom"
+                class="MuiTypography-root makeStyles-exposureEventsTitle-140 MuiTypography-h4 MuiTypography-gutterBottom"
               >
                 Exposure Events (Optional)
               </h4>
@@ -2253,11 +2253,11 @@ exports[`sections should be browsable by the section buttons 4`] = `
                 </table>
               </div>
               <div
-                class="makeStyles-addMetric-140"
+                class="makeStyles-addMetric-143"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-141"
+                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-144"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -2284,7 +2284,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-115"
+            class="makeStyles-formPartActions-117"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -2325,10 +2325,10 @@ exports[`sections should be browsable by the section buttons 4`] = `
 exports[`skipping to submit should check all sections 1`] = `
 <div>
   <div
-    class="makeStyles-root-166"
+    class="makeStyles-root-169"
   >
     <div
-      class="makeStyles-navigation-167"
+      class="makeStyles-navigation-170"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -2575,14 +2575,14 @@ exports[`skipping to submit should check all sections 1`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-168"
+        class="makeStyles-form-171"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-169"
+          class="makeStyles-formPart-172"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-171 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-174 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <h4
               class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -2617,7 +2617,7 @@ exports[`skipping to submit should check all sections 1`] = `
             </p>
           </div>
           <div
-            class="makeStyles-formPartActions-170"
+            class="makeStyles-formPartActions-173"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -2634,7 +2634,7 @@ exports[`skipping to submit should check all sections 1`] = `
               />
             </button>
             <div
-              class="makeStyles-root-179"
+              class="makeStyles-root-182"
             >
               <button
                 class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary Mui-disabled Mui-disabled"

--- a/src/components/experiment-creation/__snapshots__/Metrics.test.tsx.snap
+++ b/src/components/experiment-creation/__snapshots__/Metrics.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`allows adding, editing and removing a Metric Assignment 1`] = `
 <div>
   <div
-    class="makeStyles-root-13"
+    class="makeStyles-root-14"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -73,11 +73,11 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-23"
+      class="makeStyles-addMetric-25"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-24"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -86,7 +86,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-15"
+        class="MuiFormControl-root makeStyles-addMetricSelect-16"
       >
         <div
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -100,7 +100,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
             tabindex="0"
           >
             <span
-              class="makeStyles-addMetricPlaceholder-14"
+              class="makeStyles-addMetricPlaceholder-15"
             >
               Select a Metric
             </span>
@@ -138,7 +138,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </button>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-21 MuiTypography-h4 MuiTypography-gutterBottom"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-22 MuiTypography-h4 MuiTypography-gutterBottom"
     >
       Exposure Events (Optional)
     </h4>
@@ -169,11 +169,11 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-23"
+      class="makeStyles-addMetric-25"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-24"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -204,7 +204,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
 exports[`allows adding, editing and removing a Metric Assignment 2`] = `
 <div>
   <div
-    class="makeStyles-root-13"
+    class="makeStyles-root-14"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -274,11 +274,11 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-23"
+      class="makeStyles-addMetric-25"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-24"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -287,7 +287,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-15"
+        class="MuiFormControl-root makeStyles-addMetricSelect-16"
       >
         <div
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -301,7 +301,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
             tabindex="0"
           >
             <span
-              class="makeStyles-addMetricPlaceholder-14"
+              class="makeStyles-addMetricPlaceholder-15"
             >
               Select a Metric
             </span>
@@ -339,7 +339,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </button>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-21 MuiTypography-h4 MuiTypography-gutterBottom"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-22 MuiTypography-h4 MuiTypography-gutterBottom"
     >
       Exposure Events (Optional)
     </h4>
@@ -370,11 +370,11 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-23"
+      class="makeStyles-addMetric-25"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-24"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -405,7 +405,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
 exports[`allows adding, editing and removing a Metric Assignment 3`] = `
 <div>
   <div
-    class="makeStyles-root-13"
+    class="makeStyles-root-14"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -464,14 +464,14 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                class="makeStyles-metricName-17"
+                class="makeStyles-metricName-18"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-primary-18"
+                class="makeStyles-primary-19"
               >
                 Primary
               </span>
@@ -480,7 +480,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-16"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-17"
               >
                 <div
                   aria-haspopup="listbox"
@@ -510,11 +510,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-25 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-27 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-26"
+                    class="PrivateNotchedOutline-legend-28"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -525,7 +525,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-20"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-21"
             >
               <span
                 class="MuiSwitch-root"
@@ -533,14 +533,14 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-29 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-31 MuiSwitch-switchBase MuiSwitch-colorSecondary"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-32 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-34 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -563,7 +563,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-19"
+                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-20"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
@@ -590,11 +590,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-25 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-27 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-26"
+                      class="PrivateNotchedOutline-legend-28"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -642,11 +642,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-23"
+      class="makeStyles-addMetric-25"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-24"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -655,7 +655,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-15"
+        class="MuiFormControl-root makeStyles-addMetricSelect-16"
       >
         <div
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -669,7 +669,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
             tabindex="0"
           >
             <span
-              class="makeStyles-addMetricPlaceholder-14"
+              class="makeStyles-addMetricPlaceholder-15"
             >
               Select a Metric
             </span>
@@ -707,7 +707,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </button>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-21 MuiTypography-h4 MuiTypography-gutterBottom"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-22 MuiTypography-h4 MuiTypography-gutterBottom"
     >
       Exposure Events (Optional)
     </h4>
@@ -738,11 +738,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-23"
+      class="makeStyles-addMetric-25"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-24"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -775,7 +775,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
   aria-hidden="true"
 >
   <div
-    class="makeStyles-root-13"
+    class="makeStyles-root-14"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -834,14 +834,14 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                class="makeStyles-metricName-17"
+                class="makeStyles-metricName-18"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-primary-18"
+                class="makeStyles-primary-19"
               >
                 Primary
               </span>
@@ -850,7 +850,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-16"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-17"
               >
                 <div
                   aria-haspopup="listbox"
@@ -880,11 +880,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-25 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-27 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-26"
+                    class="PrivateNotchedOutline-legend-28"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -895,7 +895,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-20"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-21"
             >
               <span
                 class="MuiSwitch-root"
@@ -903,14 +903,14 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-29 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-31 MuiSwitch-switchBase MuiSwitch-colorSecondary"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-32 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-34 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -933,7 +933,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-19"
+                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-20"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
@@ -960,11 +960,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-25 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-27 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-26"
+                      class="PrivateNotchedOutline-legend-28"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -1012,11 +1012,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-23"
+      class="makeStyles-addMetric-25"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-24"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1025,7 +1025,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-15"
+        class="MuiFormControl-root makeStyles-addMetricSelect-16"
       >
         <div
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -1039,7 +1039,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
             tabindex="0"
           >
             <span
-              class="makeStyles-addMetricPlaceholder-14"
+              class="makeStyles-addMetricPlaceholder-15"
             >
               Select a Metric
             </span>
@@ -1077,7 +1077,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </button>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-21 MuiTypography-h4 MuiTypography-gutterBottom"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-22 MuiTypography-h4 MuiTypography-gutterBottom"
     >
       Exposure Events (Optional)
     </h4>
@@ -1108,11 +1108,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-23"
+      class="makeStyles-addMetric-25"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-24"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1143,7 +1143,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
 exports[`allows adding, editing and removing a Metric Assignment 5`] = `
 <div>
   <div
-    class="makeStyles-root-13"
+    class="makeStyles-root-14"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1202,14 +1202,14 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                class="makeStyles-metricName-17"
+                class="makeStyles-metricName-18"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-primary-18"
+                class="makeStyles-primary-19"
               >
                 Primary
               </span>
@@ -1218,7 +1218,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-16"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-17"
               >
                 <div
                   aria-haspopup="listbox"
@@ -1248,11 +1248,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-25 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-27 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-26"
+                    class="PrivateNotchedOutline-legend-28"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -1263,7 +1263,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-20"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-21"
             >
               <span
                 class="MuiSwitch-root"
@@ -1271,14 +1271,14 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-29 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-31 MuiSwitch-switchBase MuiSwitch-colorSecondary"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-32 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-34 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -1301,7 +1301,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-19"
+                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-20"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
@@ -1328,11 +1328,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-25 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-27 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-26"
+                      class="PrivateNotchedOutline-legend-28"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -1380,11 +1380,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-23"
+      class="makeStyles-addMetric-25"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-24"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1393,7 +1393,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-15"
+        class="MuiFormControl-root makeStyles-addMetricSelect-16"
       >
         <div
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -1407,7 +1407,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
             tabindex="0"
           >
             <span
-              class="makeStyles-addMetricPlaceholder-14"
+              class="makeStyles-addMetricPlaceholder-15"
             >
               Select a Metric
             </span>
@@ -1445,7 +1445,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </button>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-21 MuiTypography-h4 MuiTypography-gutterBottom"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-22 MuiTypography-h4 MuiTypography-gutterBottom"
     >
       Exposure Events (Optional)
     </h4>
@@ -1476,11 +1476,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-23"
+      class="makeStyles-addMetric-25"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-24"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1511,7 +1511,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
 exports[`allows adding, editing and removing a Metric Assignment 6`] = `
 <div>
   <div
-    class="makeStyles-root-13"
+    class="makeStyles-root-14"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1581,11 +1581,11 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-23"
+      class="makeStyles-addMetric-25"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-24"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1594,7 +1594,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-15"
+        class="MuiFormControl-root makeStyles-addMetricSelect-16"
       >
         <div
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -1608,7 +1608,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
             tabindex="0"
           >
             <span
-              class="makeStyles-addMetricPlaceholder-14"
+              class="makeStyles-addMetricPlaceholder-15"
             >
               Select a Metric
             </span>
@@ -1646,7 +1646,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </button>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-21 MuiTypography-h4 MuiTypography-gutterBottom"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-22 MuiTypography-h4 MuiTypography-gutterBottom"
     >
       Exposure Events (Optional)
     </h4>
@@ -1677,11 +1677,11 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-23"
+      class="makeStyles-addMetric-25"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-24"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1712,7 +1712,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
 exports[`allows adding, editing and removing a Metric Assignment 7`] = `
 <div>
   <div
-    class="makeStyles-root-13"
+    class="makeStyles-root-14"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1771,14 +1771,14 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                class="makeStyles-metricName-17"
+                class="makeStyles-metricName-18"
                 title="string"
               >
                 registration_start
               </span>
               <br />
               <span
-                class="makeStyles-primary-18"
+                class="makeStyles-primary-19"
               >
                 Primary
               </span>
@@ -1787,7 +1787,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-16"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-17"
               >
                 <div
                   aria-haspopup="listbox"
@@ -1817,11 +1817,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-33 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-35 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-34"
+                    class="PrivateNotchedOutline-legend-36"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -1832,7 +1832,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-20"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-21"
             >
               <span
                 class="MuiSwitch-root"
@@ -1840,14 +1840,14 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-37 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-39 MuiSwitch-switchBase MuiSwitch-colorSecondary"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-40 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-42 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -1870,7 +1870,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-19"
+                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-20"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
@@ -1890,7 +1890,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                     class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
                   >
                     <p
-                      class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
+                      class="MuiTypography-root makeStyles-tooltipped-23 MuiTypography-body1 MuiTypography-colorTextSecondary"
                       title="Percentage Points"
                     >
                       pp
@@ -1898,11 +1898,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                   </div>
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-33 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-35 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-34"
+                      class="PrivateNotchedOutline-legend-36"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -1950,11 +1950,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-23"
+      class="makeStyles-addMetric-25"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-24"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1963,7 +1963,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-15"
+        class="MuiFormControl-root makeStyles-addMetricSelect-16"
       >
         <div
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -1977,7 +1977,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
             tabindex="0"
           >
             <span
-              class="makeStyles-addMetricPlaceholder-14"
+              class="makeStyles-addMetricPlaceholder-15"
             >
               Select a Metric
             </span>
@@ -2015,7 +2015,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </button>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-21 MuiTypography-h4 MuiTypography-gutterBottom"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-22 MuiTypography-h4 MuiTypography-gutterBottom"
     >
       Exposure Events (Optional)
     </h4>
@@ -2046,11 +2046,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-23"
+      class="makeStyles-addMetric-25"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-24"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -2151,11 +2151,11 @@ exports[`renders as expected 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-11"
+      class="makeStyles-addMetric-12"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-12"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-13"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -2247,11 +2247,11 @@ exports[`renders as expected 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-11"
+      class="makeStyles-addMetric-12"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-12"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-13"
         focusable="false"
         viewBox="0 0 24 24"
       >


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR adds tooltips for PP (percentage points) and ensures existing tooltips are more obvious.** 
- Also fixes the line break in experiment overview

<img width="267" alt="Screen Shot 2020-11-12 at 9 28 55 pm" src="https://user-images.githubusercontent.com/971886/98947684-7d8d4400-2530-11eb-83b7-d763701cd0c7.png">
<img width="164" alt="Screen Shot 2020-11-12 at 9 32 29 pm" src="https://user-images.githubusercontent.com/971886/98947689-7f570780-2530-11eb-8ee9-5eb4e9ddb5b1.png">
<img width="167" alt="Screen Shot 2020-11-12 at 9 34 36 pm" src="https://user-images.githubusercontent.com/971886/98947694-8120cb00-2530-11eb-98ea-a84f9de431b7.png">


Fixes part of https://github.com/Automattic/abacus/issues/377
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
