### PR TITLE
Relax manual analysis criteria to only check chosenVariationId

### DIFF
--- a/src/components/experiments/single-view/results/CondensedLatestAnalyses.tsx
+++ b/src/components/experiments/single-view/results/CondensedLatestAnalyses.tsx
@@ -85,7 +85,7 @@ export default function CondensedLatestAnalyses({
         .map(
           (analyses) =>
             //  istanbul ignore next; We don't need to test empty analyses as we filter out all undefined values
-            _.last(analyses)?.recommendation,
+            _.last(analyses)?.recommendation.chosenVariationId,
         )
         .filter((recommendation) => !!recommendation)
       const uniqueRecommendations = _.uniq(recommendations.map((recommendation) => JSON.stringify(recommendation)))

--- a/src/components/experiments/single-view/results/CondensedLatestAnalyses.tsx
+++ b/src/components/experiments/single-view/results/CondensedLatestAnalyses.tsx
@@ -85,10 +85,10 @@ export default function CondensedLatestAnalyses({
         .map(
           (analyses) =>
             //  istanbul ignore next; We don't need to test empty analyses as we filter out all undefined values
-            _.last(analyses)?.recommendation.chosenVariationId,
+            _.last(analyses)?.recommendation,
         )
         .filter((recommendation) => !!recommendation)
-      const uniqueRecommendations = _.uniq(recommendations.map((recommendation) => JSON.stringify(recommendation)))
+      const recommendationConflict = _.uniq(recommendations.map((recommendation) => recommendation.chosenVariationId)) > 1
 
       return {
         metricAssignment,

--- a/src/components/experiments/single-view/results/CondensedLatestAnalyses.tsx
+++ b/src/components/experiments/single-view/results/CondensedLatestAnalyses.tsx
@@ -29,6 +29,7 @@ import {
   MetricAssignment,
   MetricBare,
   MetricParameterType,
+  Recommendation,
 } from 'src/lib/schemas'
 import * as Variations from 'src/lib/variations'
 import * as Visualizations from 'src/lib/visualizations'
@@ -87,15 +88,8 @@ export default function CondensedLatestAnalyses({
             //  istanbul ignore next; We don't need to test empty analyses as we filter out all undefined values
             _.last(analyses)?.recommendation,
         )
-        .filter((recommendation) => !!recommendation)
-      const recommendedChosenVariationIds = recommendations.map((recommendation) => {
-        // istanbul ignore next; typeguard
-        if (!recommendation) {
-          throw new Error(`Missing Recommendation - this should never occur`)
-        }
-        return recommendation.chosenVariationId
-      })
-      const recommendationConflict = _.uniq(recommendedChosenVariationIds).length > 1
+        .filter((recommendation) => !!recommendation) as Array<Recommendation>
+      const recommendationConflict = _.uniq(_.map(recommendations, 'chosenVariationId')).length > 1
 
       return {
         metricAssignment,

--- a/src/components/experiments/single-view/results/CondensedLatestAnalyses.tsx
+++ b/src/components/experiments/single-view/results/CondensedLatestAnalyses.tsx
@@ -88,14 +88,21 @@ export default function CondensedLatestAnalyses({
             _.last(analyses)?.recommendation,
         )
         .filter((recommendation) => !!recommendation)
-      const recommendationConflict = _.uniq(recommendations.map((recommendation) => recommendation.chosenVariationId)) > 1
+      const recommendedChosenVariationIds = recommendations.map((recommendation) => {
+        // istanbul ignore next; typeguard
+        if (!recommendation) {
+          throw new Error(`Missing Recommendation - this should never occur`)
+        }
+        return recommendation.chosenVariationId
+      })
+      const recommendationConflict = _.uniq(recommendedChosenVariationIds).length > 1
 
       return {
         metricAssignment,
         metric,
         analysesByStrategyDateAsc,
         latestDefaultAnalysis: _.last(analysesByStrategyDateAsc[defaultAnalysisStrategy]),
-        recommendationConflict: uniqueRecommendations.length > 1,
+        recommendationConflict,
       }
     },
   )


### PR DESCRIPTION
While looking at some of our experiment results, I kept getting frustrated with the manual analysis required. In with hopefully a quick fix! :)

## How has this been tested?

- [x] Manual testing with production data (locally)
