### PR TITLE
Add support for email and pipe platforms

### DIFF
--- a/src/components/experiments/wizard/Audience.tsx
+++ b/src/components/experiments/wizard/Audience.tsx
@@ -163,7 +163,7 @@ const Audience = ({
           <Field component={Select} name='experiment.platform'>
             {Object.values(Platform).map((platform) => (
               <MenuItem key={platform} value={platform}>
-                {PlatformToHuman[platform]}
+                {platform}: {PlatformToHuman[platform]}
               </MenuItem>
             ))}
           </Field>

--- a/src/components/experiments/wizard/__snapshots__/Audience.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/Audience.test.tsx.snap
@@ -39,7 +39,9 @@ exports[`renders as expected 1`] = `
             role="button"
             tabindex="0"
           >
-            WordPress.com Backend
+            wpcom
+            : 
+            WordPress.com back-end
           </div>
           <input
             name="experiment.platform"
@@ -736,7 +738,9 @@ exports[`renders as expected 2`] = `
             role="button"
             tabindex="0"
           >
-            WordPress.com Backend
+            wpcom
+            : 
+            WordPress.com back-end
           </div>
           <input
             name="experiment.platform"

--- a/src/lib/experiments.ts
+++ b/src/lib/experiments.ts
@@ -39,8 +39,8 @@ export function getDefaultAnalysisStrategy(experiment: ExperimentFull): Analysis
 }
 
 export const PlatformToHuman: Record<Platform, string> = {
-  [Platform.Calypso]: 'Calypso',
-  [Platform.Email]: 'Email (Guides)',
-  [Platform.Pipe]: 'pipe (machine learning pipeline)',
-  [Platform.Wpcom]: 'WordPress.com Backend',
+  [Platform.Calypso]: 'Calypso front-end',
+  [Platform.Email]: 'Guides and other email systems',
+  [Platform.Pipe]: 'Machine learning pipeline',
+  [Platform.Wpcom]: 'WordPress.com back-end',
 }

--- a/src/lib/experiments.ts
+++ b/src/lib/experiments.ts
@@ -39,6 +39,8 @@ export function getDefaultAnalysisStrategy(experiment: ExperimentFull): Analysis
 }
 
 export const PlatformToHuman: Record<Platform, string> = {
-  [Platform.Wpcom]: 'WordPress.com Backend',
   [Platform.Calypso]: 'Calypso',
+  [Platform.Email]: 'Email (Guides)',
+  [Platform.Pipe]: 'pipe (machine learning pipeline)',
+  [Platform.Wpcom]: 'WordPress.com Backend',
 }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -241,6 +241,8 @@ export interface Variation extends yup.InferType<typeof variationSchema> {}
 
 export enum Platform {
   Calypso = 'calypso',
+  Email = 'email',
+  Pipe = 'pipe',
   Wpcom = 'wpcom',
 }
 


### PR DESCRIPTION
Add `email` and `pipe` as platforms to the `Platform` enum and `PlatformToHuman` mapping.

**Note**: We can hold off on merging this until the backend supports the new platforms.

## How has this been tested?
- Automated tests that cover added/changed functionality
- Manual testing with mock data (locally or on Vercel): Checked that the new platforms appear in the wizard

![](https://user-images.githubusercontent.com/3952615/100684961-20fea580-33c7-11eb-81af-1f6754841097.gif)


