### PR TITLE
Hack: Disable status change and editing buttons for nav_unification_v2

### DIFF
--- a/src/components/experiments/single-view/ExperimentDisableButton.tsx
+++ b/src/components/experiments/single-view/ExperimentDisableButton.tsx
@@ -28,7 +28,8 @@ const ExperimentDisableButton = ({
 
   const { enqueueSnackbar } = useSnackbar()
 
-  const canDisableExperiment = experiment && experiment.status !== Status.Disabled
+  const canDisableExperiment =
+    experiment && experiment.status !== Status.Disabled && experiment.name !== 'nav_unification_v2'
   const [isAskingToConfirmDisableExperiment, setIsAskingToConfirmDisableExperiment] = useState<boolean>(false)
   const onAskToConfirmDisableExperiment = () => setIsAskingToConfirmDisableExperiment(true)
   const onCancelDisableExperiment = () => setIsAskingToConfirmDisableExperiment(false)

--- a/src/components/experiments/single-view/ExperimentPageView.tsx
+++ b/src/components/experiments/single-view/ExperimentPageView.tsx
@@ -142,7 +142,7 @@ export default function ExperimentPageView({
 
   const isLoading = or(experimentIsLoading, metricsIsLoading, segmentsIsLoading, tagsIsLoading, analysesIsLoading)
 
-  const canEditInWizard = experiment && experiment.status === Status.Staging
+  const canEditInWizard = experiment && experiment.status === Status.Staging && experiment.name !== 'nav_unification_v2'
 
   const experimentIdSlug = createIdSlug(experimentId, experiment?.name || '')
 

--- a/src/components/experiments/single-view/ExperimentRunButton.tsx
+++ b/src/components/experiments/single-view/ExperimentRunButton.tsx
@@ -16,7 +16,8 @@ const ExperimentRunButton = ({
 }): JSX.Element => {
   const { enqueueSnackbar } = useSnackbar()
 
-  const canRunExperiment = experiment && experiment.status === Status.Staging
+  const canRunExperiment =
+    experiment && experiment.status === Status.Staging && experiment.name !== 'nav_unification_v2'
   const [isAskingToConfirmRunExperiment, setIsAskingToConfirmRunExperiment] = useState<boolean>(false)
   const onAskToConfirmRunExperiment = () => setIsAskingToConfirmRunExperiment(true)
   const onCancelRunExperiment = () => setIsAskingToConfirmRunExperiment(false)


### PR DESCRIPTION
Following the discussion in #413, this is a temporary hack to disable the buttons for the `nav_unification_v2` experiment.

## How has this been tested?

* Run `REACT_APP_PRODUCTION_CONFIG_IN_DEVELOPMENT=true npm run dev`
* Navigate to the `nav_unification_v2` overview page and verify that the buttons are disabled:

![image](https://user-images.githubusercontent.com/3952615/100946337-d6a83080-354e-11eb-962f-80f3b25a7eab.png)

* Navigate to a different `staging` experiment page and verify that the buttons are enabled