### PR TITLE
Make accidental Experiment control changes harder: Part 1 The buttons 

### DIFF
--- a/src/components/experiments/single-view/ExperimentDisableButton.tsx
+++ b/src/components/experiments/single-view/ExperimentDisableButton.tsx
@@ -18,9 +18,11 @@ const useStyles = makeStyles((theme: Theme) =>
 )
 
 const ExperimentDisableButton = ({
+  className,
   experiment,
   experimentReloadRef,
 }: {
+  className?: string
   experiment: ExperimentFull | null
   experimentReloadRef: React.MutableRefObject<() => void>
 }): JSX.Element => {
@@ -57,7 +59,7 @@ const ExperimentDisableButton = ({
   return (
     <>
       <Tooltip title={canDisableExperiment ? '' : 'This experiment is disabled.'}>
-        <span>
+        <span className={className}>
           <Button
             variant='outlined'
             classes={{ outlined: classes.buttonOutlined }}

--- a/src/components/experiments/single-view/ExperimentPageView.test.tsx
+++ b/src/components/experiments/single-view/ExperimentPageView.test.tsx
@@ -63,7 +63,7 @@ const renderExperimentPageView = async ({ experiment: experimentOverrides = {} }
  */
 const getButtonStates = () => {
   const editInWizard = screen.getByRole('button', { name: /Edit In Wizard/ })
-  const run = screen.getByRole('button', { name: /Run/ })
+  const run = screen.getByRole('button', { name: /Deploy/ })
   const disable = screen.getByRole('button', { name: /Disable/ })
   const generalPanelEdit = screen.getByRole('button', { name: /Edit Experiment General Data/ })
   const assignMetric = screen.getByRole('button', { name: /Assign Metric/ })

--- a/src/components/experiments/single-view/ExperimentPageView.tsx
+++ b/src/components/experiments/single-view/ExperimentPageView.tsx
@@ -62,6 +62,9 @@ const useStyles = makeStyles((theme: Theme) =>
         marginBottom: 7,
       },
     },
+    disableButton: {
+      marginRight: theme.spacing(1),
+    },
   }),
 )
 
@@ -193,9 +196,8 @@ export default function ExperimentPageView({
             />
           </Tabs>
           <div className={classes.topBarActions}>
-            <Button variant='outlined' color='primary' component={Link} to={`/experiments/${experimentIdSlug}/clone`}>
-              Clone
-            </Button>{' '}
+            <ExperimentRunButton {...{ experiment, experimentReloadRef }} />{' '}
+            <ExperimentDisableButton {...{ experiment, experimentReloadRef }} className={classes.disableButton} />
             <Tooltip title={canEditInWizard ? '' : 'Only available for staging experiments.'}>
               <span>
                 <Button
@@ -209,8 +211,9 @@ export default function ExperimentPageView({
                 </Button>
               </span>
             </Tooltip>{' '}
-            <ExperimentRunButton {...{ experiment, experimentReloadRef }} />{' '}
-            <ExperimentDisableButton {...{ experiment, experimentReloadRef }} />
+            <Button variant='outlined' color='primary' component={Link} to={`/experiments/${experimentIdSlug}/clone`}>
+              Clone
+            </Button>
           </div>
         </div>
         {isLoading && <LinearProgress />}

--- a/src/components/experiments/single-view/ExperimentRunButton.test.tsx
+++ b/src/components/experiments/single-view/ExperimentRunButton.test.tsx
@@ -30,7 +30,7 @@ test('runs an experiment', async () => {
   mockedExperimentsApi.changeStatus.mockReset()
   mockedExperimentsApi.changeStatus.mockImplementationOnce(async () => undefined)
 
-  const firstRunButton = screen.getByRole('button', { name: /Run/ })
+  const firstRunButton = screen.getByRole('button', { name: /Deploy/ })
 
   // First Opening - We cancel
   fireEvent.click(firstRunButton)
@@ -52,7 +52,7 @@ test('runs an experiment', async () => {
   await waitFor(() => screen.getByRole('button', { name: /Cancel/ }))
   const cancelButton2nd = screen.getByRole('button', { name: /Cancel/ })
 
-  const allRunButtons = screen.getAllByRole('button', { name: /Run/ })
+  const allRunButtons = screen.getAllByRole('button', { name: /Deploy/ })
   allRunButtons.forEach((button) => fireEvent.click(button))
 
   await waitForElementToBeRemoved(cancelButton2nd)

--- a/src/components/experiments/single-view/ExperimentRunButton.tsx
+++ b/src/components/experiments/single-view/ExperimentRunButton.tsx
@@ -1,4 +1,14 @@
-import { Button, Dialog, DialogActions, DialogContent, Tooltip, Typography } from '@material-ui/core'
+import {
+  Button,
+  createStyles,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  makeStyles,
+  Theme,
+  Tooltip,
+  Typography,
+} from '@material-ui/core'
 import { useSnackbar } from 'notistack'
 import React, { useState } from 'react'
 
@@ -7,6 +17,15 @@ import { ExperimentFull, Status } from 'src/lib/schemas'
 
 import LoadingButtonContainer from '../../general/LoadingButtonContainer'
 
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    buttonOutlined: {
+      borderColor: theme.palette.error.dark,
+      color: theme.palette.error.dark,
+    },
+  }),
+)
+
 const ExperimentRunButton = ({
   experiment,
   experimentReloadRef,
@@ -14,6 +33,7 @@ const ExperimentRunButton = ({
   experiment: ExperimentFull | null
   experimentReloadRef: React.MutableRefObject<() => void>
 }): JSX.Element => {
+  const classes = useStyles()
   const { enqueueSnackbar } = useSnackbar()
 
   const canRunExperiment =
@@ -48,17 +68,17 @@ const ExperimentRunButton = ({
         <span>
           <Button
             variant='outlined'
-            color='secondary'
+            classes={{ outlined: classes.buttonOutlined }}
             disabled={!canRunExperiment}
             onClick={onAskToConfirmRunExperiment}
           >
-            Run
+            Deploy
           </Button>
         </span>
       </Tooltip>
       <Dialog open={isAskingToConfirmRunExperiment} aria-labelledby='confirm-run-experiment-dialog-title'>
         <DialogContent>
-          <Typography variant='body1'>Are you sure you want to run this experiment?</Typography>
+          <Typography variant='body1'>Are you sure you want to deploy this experiment?</Typography>
         </DialogContent>
         <DialogActions>
           <Button onClick={onCancelRunExperiment}>Cancel</Button>
@@ -69,7 +89,7 @@ const ExperimentRunButton = ({
               disabled={isSubmittingRunExperiment}
               onClick={onConfirmRunExperiment}
             >
-              Run
+              Deploy
             </Button>
           </LoadingButtonContainer>
         </DialogActions>

--- a/src/components/experiments/single-view/__snapshots__/ExperimentRunButton.test.tsx.snap
+++ b/src/components/experiments/single-view/__snapshots__/ExperimentRunButton.test.tsx.snap
@@ -7,14 +7,14 @@ exports[`renders as expected 1`] = `
     title=""
   >
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedSecondary"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-buttonOutlined-1"
       tabindex="0"
       type="button"
     >
       <span
         class="MuiButton-label"
       >
-        Run
+        Deploy
       </span>
       <span
         class="MuiTouchRipple-root"
@@ -33,14 +33,14 @@ exports[`runs an experiment 1`] = `
     title=""
   >
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedSecondary"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-buttonOutlined-2"
       tabindex="0"
       type="button"
     >
       <span
         class="MuiButton-label"
       >
-        Run
+        Deploy
       </span>
       <span
         class="MuiTouchRipple-root"


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR makes the buttons less "clickable":**

<img width="1344" alt="Screen Shot 2020-12-03 at 3 25 29 pm" src="https://user-images.githubusercontent.com/971886/100977466-fc97fa00-357b-11eb-962a-4efe92fd2919.png">

- Separates them
- Makes them Red
- "Run" -> "Deploy"
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
