### PR TITLE
Let experimenters know dates are automatic

### DIFF
--- a/src/components/experiments/wizard/BasicInfo.tsx
+++ b/src/components/experiments/wizard/BasicInfo.tsx
@@ -106,7 +106,13 @@ const BasicInfo = ({
           name='experiment.startDatetime'
           id='experiment.startDatetime'
           label='Start date'
-          helperText='Use the UTC timezone.'
+          helperText={
+            <>
+              Automatic start date.
+              <br />
+              Use the UTC timezone.
+            </>
+          }
           type='date'
           variant='outlined'
           required
@@ -125,7 +131,13 @@ const BasicInfo = ({
           name='experiment.endDatetime'
           id='experiment.endDatetime'
           label='End date'
-          helperText='Use the UTC timezone.'
+          helperText={
+            <>
+              Automatic end date.
+              <br />
+              Use the UTC timezone.
+            </>
+          }
           type='date'
           variant='outlined'
           required

--- a/src/components/experiments/wizard/BasicInfo.tsx
+++ b/src/components/experiments/wizard/BasicInfo.tsx
@@ -108,9 +108,7 @@ const BasicInfo = ({
           label='Start date'
           helperText={
             <>
-              Automatic start date.
-              <br />
-              Use the UTC timezone.
+              Automatic start date. <br /> Use the UTC timezone.
             </>
           }
           type='date'
@@ -133,9 +131,7 @@ const BasicInfo = ({
           label='End date'
           helperText={
             <>
-              Automatic end date.
-              <br />
-              Use the UTC timezone.
+              Automatic end date. <br /> Use the UTC timezone.
             </>
           }
           type='date'

--- a/src/components/experiments/wizard/BasicInfo.tsx
+++ b/src/components/experiments/wizard/BasicInfo.tsx
@@ -1,6 +1,6 @@
 import { InputAdornment, TextField as MuiTextField, Typography } from '@material-ui/core'
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
-import { AutocompleteRenderInputParams } from '@material-ui/lab'
+import { Alert, AutocompleteRenderInputParams } from '@material-ui/lab'
 import * as dateFns from 'date-fns'
 import { Field, useField } from 'formik'
 import { TextField } from 'formik-material-ui'
@@ -19,7 +19,7 @@ const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {},
     row: {
-      margin: theme.spacing(5, 0),
+      margin: theme.spacing(5, 0, 1, 0),
       display: 'flex',
       alignItems: 'center',
       '&:first-of-type': {
@@ -106,11 +106,7 @@ const BasicInfo = ({
           name='experiment.startDatetime'
           id='experiment.startDatetime'
           label='Start date'
-          helperText={
-            <>
-              Automatic start date. <br /> Use the UTC timezone.
-            </>
-          }
+          helperText='Use the UTC timezone.'
           type='date'
           variant='outlined'
           required
@@ -129,11 +125,7 @@ const BasicInfo = ({
           name='experiment.endDatetime'
           id='experiment.endDatetime'
           label='End date'
-          helperText={
-            <>
-              Automatic end date. <br /> Use the UTC timezone.
-            </>
-          }
+          helperText='Use the UTC timezone.'
           type='date'
           variant='outlined'
           required
@@ -146,6 +138,9 @@ const BasicInfo = ({
           }}
         />
       </div>
+      <Alert severity='info'>
+        The experiment will <strong>start and end automatically</strong> around midnight UTC on these dates.
+      </Alert>
 
       <div className={classes.row}>
         <Field

--- a/src/components/experiments/wizard/BasicInfo.tsx
+++ b/src/components/experiments/wizard/BasicInfo.tsx
@@ -105,8 +105,7 @@ const BasicInfo = ({
           className={classes.datePicker}
           name='experiment.startDatetime'
           id='experiment.startDatetime'
-          label='Start date'
-          helperText='Use the UTC timezone.'
+          label='Start date (UTC)'
           type='date'
           variant='outlined'
           required
@@ -124,8 +123,7 @@ const BasicInfo = ({
           className={classes.datePicker}
           name='experiment.endDatetime'
           id='experiment.endDatetime'
-          label='End date'
-          helperText='Use the UTC timezone.'
+          label='End date (UTC)'
           type='date'
           variant='outlined'
           required

--- a/src/components/experiments/wizard/BasicInfo.tsx
+++ b/src/components/experiments/wizard/BasicInfo.tsx
@@ -137,7 +137,7 @@ const BasicInfo = ({
         />
       </div>
       <Alert severity='info'>
-        The experiment will <strong>start and end automatically</strong> around midnight UTC on these dates.
+        The experiment will <strong>start and end automatically</strong> around 00:10 UTC on these dates.
       </Alert>
 
       <div className={classes.row}>

--- a/src/components/experiments/wizard/__snapshots__/BasicInfo.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/BasicInfo.test.tsx.snap
@@ -177,9 +177,9 @@ exports[`renders as expected 1`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
           id="experiment.startDatetime-helper-text"
         >
-          Automatic start date.
+          Automatic start date. 
           <br />
-          Use the UTC timezone.
+           Use the UTC timezone.
         </p>
       </div>
       <span
@@ -236,9 +236,9 @@ exports[`renders as expected 1`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
           id="experiment.endDatetime-helper-text"
         >
-          Automatic end date.
+          Automatic end date. 
           <br />
-          Use the UTC timezone.
+           Use the UTC timezone.
         </p>
       </div>
     </div>
@@ -553,9 +553,9 @@ exports[`renders date validation errors as expected 1`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.startDatetime-helper-text"
         >
-          Automatic start date.
+          Automatic start date. 
           <br />
-          Use the UTC timezone.
+           Use the UTC timezone.
         </p>
       </div>
       <span
@@ -614,9 +614,9 @@ exports[`renders date validation errors as expected 1`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
           id="experiment.endDatetime-helper-text"
         >
-          Automatic end date.
+          Automatic end date. 
           <br />
-          Use the UTC timezone.
+           Use the UTC timezone.
         </p>
       </div>
     </div>
@@ -931,9 +931,9 @@ exports[`renders date validation errors as expected 2`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.startDatetime-helper-text"
         >
-          Automatic start date.
+          Automatic start date. 
           <br />
-          Use the UTC timezone.
+           Use the UTC timezone.
         </p>
       </div>
       <span
@@ -992,9 +992,9 @@ exports[`renders date validation errors as expected 2`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
           id="experiment.endDatetime-helper-text"
         >
-          Automatic end date.
+          Automatic end date. 
           <br />
-          Use the UTC timezone.
+           Use the UTC timezone.
         </p>
       </div>
     </div>
@@ -1309,9 +1309,9 @@ exports[`renders date validation errors as expected 3`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.startDatetime-helper-text"
         >
-          Automatic start date.
+          Automatic start date. 
           <br />
-          Use the UTC timezone.
+           Use the UTC timezone.
         </p>
       </div>
       <span
@@ -1370,9 +1370,9 @@ exports[`renders date validation errors as expected 3`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.endDatetime-helper-text"
         >
-          Automatic end date.
+          Automatic end date. 
           <br />
-          Use the UTC timezone.
+           Use the UTC timezone.
         </p>
       </div>
     </div>
@@ -1687,9 +1687,9 @@ exports[`renders date validation errors as expected 4`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.startDatetime-helper-text"
         >
-          Automatic start date.
+          Automatic start date. 
           <br />
-          Use the UTC timezone.
+           Use the UTC timezone.
         </p>
       </div>
       <span
@@ -1748,9 +1748,9 @@ exports[`renders date validation errors as expected 4`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.endDatetime-helper-text"
         >
-          Automatic end date.
+          Automatic end date. 
           <br />
-          Use the UTC timezone.
+           Use the UTC timezone.
         </p>
       </div>
     </div>
@@ -2065,9 +2065,9 @@ exports[`renders sensible dates as expected 1`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.startDatetime-helper-text"
         >
-          Automatic start date.
+          Automatic start date. 
           <br />
-          Use the UTC timezone.
+           Use the UTC timezone.
         </p>
       </div>
       <span
@@ -2126,9 +2126,9 @@ exports[`renders sensible dates as expected 1`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.endDatetime-helper-text"
         >
-          Automatic end date.
+          Automatic end date. 
           <br />
-          Use the UTC timezone.
+           Use the UTC timezone.
         </p>
       </div>
     </div>

--- a/src/components/experiments/wizard/__snapshots__/BasicInfo.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/BasicInfo.test.tsx.snap
@@ -177,6 +177,8 @@ exports[`renders as expected 1`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
           id="experiment.startDatetime-helper-text"
         >
+          Automatic start date.
+          <br />
           Use the UTC timezone.
         </p>
       </div>
@@ -234,6 +236,8 @@ exports[`renders as expected 1`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
           id="experiment.endDatetime-helper-text"
         >
+          Automatic end date.
+          <br />
           Use the UTC timezone.
         </p>
       </div>
@@ -549,6 +553,8 @@ exports[`renders date validation errors as expected 1`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.startDatetime-helper-text"
         >
+          Automatic start date.
+          <br />
           Use the UTC timezone.
         </p>
       </div>
@@ -608,6 +614,8 @@ exports[`renders date validation errors as expected 1`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
           id="experiment.endDatetime-helper-text"
         >
+          Automatic end date.
+          <br />
           Use the UTC timezone.
         </p>
       </div>
@@ -923,6 +931,8 @@ exports[`renders date validation errors as expected 2`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.startDatetime-helper-text"
         >
+          Automatic start date.
+          <br />
           Use the UTC timezone.
         </p>
       </div>
@@ -982,6 +992,8 @@ exports[`renders date validation errors as expected 2`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
           id="experiment.endDatetime-helper-text"
         >
+          Automatic end date.
+          <br />
           Use the UTC timezone.
         </p>
       </div>
@@ -1297,6 +1309,8 @@ exports[`renders date validation errors as expected 3`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.startDatetime-helper-text"
         >
+          Automatic start date.
+          <br />
           Use the UTC timezone.
         </p>
       </div>
@@ -1356,6 +1370,8 @@ exports[`renders date validation errors as expected 3`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.endDatetime-helper-text"
         >
+          Automatic end date.
+          <br />
           Use the UTC timezone.
         </p>
       </div>
@@ -1671,6 +1687,8 @@ exports[`renders date validation errors as expected 4`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.startDatetime-helper-text"
         >
+          Automatic start date.
+          <br />
           Use the UTC timezone.
         </p>
       </div>
@@ -1730,6 +1748,8 @@ exports[`renders date validation errors as expected 4`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.endDatetime-helper-text"
         >
+          Automatic end date.
+          <br />
           Use the UTC timezone.
         </p>
       </div>
@@ -2045,6 +2065,8 @@ exports[`renders sensible dates as expected 1`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.startDatetime-helper-text"
         >
+          Automatic start date.
+          <br />
           Use the UTC timezone.
         </p>
       </div>
@@ -2104,6 +2126,8 @@ exports[`renders sensible dates as expected 1`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.endDatetime-helper-text"
         >
+          Automatic end date.
+          <br />
           Use the UTC timezone.
         </p>
       </div>

--- a/src/components/experiments/wizard/__snapshots__/BasicInfo.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/BasicInfo.test.tsx.snap
@@ -249,7 +249,7 @@ exports[`renders as expected 1`] = `
         <strong>
           start and end automatically
         </strong>
-         around midnight UTC on these dates.
+         around 00:10 UTC on these dates.
       </div>
     </div>
     <div
@@ -637,7 +637,7 @@ exports[`renders date validation errors as expected 1`] = `
         <strong>
           start and end automatically
         </strong>
-         around midnight UTC on these dates.
+         around 00:10 UTC on these dates.
       </div>
     </div>
     <div
@@ -1025,7 +1025,7 @@ exports[`renders date validation errors as expected 2`] = `
         <strong>
           start and end automatically
         </strong>
-         around midnight UTC on these dates.
+         around 00:10 UTC on these dates.
       </div>
     </div>
     <div
@@ -1413,7 +1413,7 @@ exports[`renders date validation errors as expected 3`] = `
         <strong>
           start and end automatically
         </strong>
-         around midnight UTC on these dates.
+         around 00:10 UTC on these dates.
       </div>
     </div>
     <div
@@ -1801,7 +1801,7 @@ exports[`renders date validation errors as expected 4`] = `
         <strong>
           start and end automatically
         </strong>
-         around midnight UTC on these dates.
+         around 00:10 UTC on these dates.
       </div>
     </div>
     <div
@@ -2189,7 +2189,7 @@ exports[`renders sensible dates as expected 1`] = `
         <strong>
           start and end automatically
         </strong>
-         around midnight UTC on these dates.
+         around 00:10 UTC on these dates.
       </div>
     </div>
     <div

--- a/src/components/experiments/wizard/__snapshots__/BasicInfo.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/BasicInfo.test.tsx.snap
@@ -177,9 +177,7 @@ exports[`renders as expected 1`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
           id="experiment.startDatetime-helper-text"
         >
-          Automatic start date. 
-          <br />
-           Use the UTC timezone.
+          Use the UTC timezone.
         </p>
       </div>
       <span
@@ -236,10 +234,36 @@ exports[`renders as expected 1`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
           id="experiment.endDatetime-helper-text"
         >
-          Automatic end date. 
-          <br />
-           Use the UTC timezone.
+          Use the UTC timezone.
         </p>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        The experiment will 
+        <strong>
+          start and end automatically
+        </strong>
+         around midnight UTC on these dates.
       </div>
     </div>
     <div
@@ -553,9 +577,7 @@ exports[`renders date validation errors as expected 1`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.startDatetime-helper-text"
         >
-          Automatic start date. 
-          <br />
-           Use the UTC timezone.
+          Use the UTC timezone.
         </p>
       </div>
       <span
@@ -614,10 +636,36 @@ exports[`renders date validation errors as expected 1`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
           id="experiment.endDatetime-helper-text"
         >
-          Automatic end date. 
-          <br />
-           Use the UTC timezone.
+          Use the UTC timezone.
         </p>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        The experiment will 
+        <strong>
+          start and end automatically
+        </strong>
+         around midnight UTC on these dates.
       </div>
     </div>
     <div
@@ -931,9 +979,7 @@ exports[`renders date validation errors as expected 2`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.startDatetime-helper-text"
         >
-          Automatic start date. 
-          <br />
-           Use the UTC timezone.
+          Use the UTC timezone.
         </p>
       </div>
       <span
@@ -992,10 +1038,36 @@ exports[`renders date validation errors as expected 2`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
           id="experiment.endDatetime-helper-text"
         >
-          Automatic end date. 
-          <br />
-           Use the UTC timezone.
+          Use the UTC timezone.
         </p>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        The experiment will 
+        <strong>
+          start and end automatically
+        </strong>
+         around midnight UTC on these dates.
       </div>
     </div>
     <div
@@ -1309,9 +1381,7 @@ exports[`renders date validation errors as expected 3`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.startDatetime-helper-text"
         >
-          Automatic start date. 
-          <br />
-           Use the UTC timezone.
+          Use the UTC timezone.
         </p>
       </div>
       <span
@@ -1370,10 +1440,36 @@ exports[`renders date validation errors as expected 3`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.endDatetime-helper-text"
         >
-          Automatic end date. 
-          <br />
-           Use the UTC timezone.
+          Use the UTC timezone.
         </p>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        The experiment will 
+        <strong>
+          start and end automatically
+        </strong>
+         around midnight UTC on these dates.
       </div>
     </div>
     <div
@@ -1687,9 +1783,7 @@ exports[`renders date validation errors as expected 4`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.startDatetime-helper-text"
         >
-          Automatic start date. 
-          <br />
-           Use the UTC timezone.
+          Use the UTC timezone.
         </p>
       </div>
       <span
@@ -1748,10 +1842,36 @@ exports[`renders date validation errors as expected 4`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.endDatetime-helper-text"
         >
-          Automatic end date. 
-          <br />
-           Use the UTC timezone.
+          Use the UTC timezone.
         </p>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        The experiment will 
+        <strong>
+          start and end automatically
+        </strong>
+         around midnight UTC on these dates.
       </div>
     </div>
     <div
@@ -2065,9 +2185,7 @@ exports[`renders sensible dates as expected 1`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.startDatetime-helper-text"
         >
-          Automatic start date. 
-          <br />
-           Use the UTC timezone.
+          Use the UTC timezone.
         </p>
       </div>
       <span
@@ -2126,10 +2244,36 @@ exports[`renders sensible dates as expected 1`] = `
           class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
           id="experiment.endDatetime-helper-text"
         >
-          Automatic end date. 
-          <br />
-           Use the UTC timezone.
+          Use the UTC timezone.
         </p>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        The experiment will 
+        <strong>
+          start and end automatically
+        </strong>
+         around midnight UTC on these dates.
       </div>
     </div>
     <div

--- a/src/components/experiments/wizard/__snapshots__/BasicInfo.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/BasicInfo.test.tsx.snap
@@ -135,7 +135,7 @@ exports[`renders as expected 1`] = `
           for="experiment.startDatetime"
           id="experiment.startDatetime-label"
         >
-          Start date
+          Start date (UTC)
           <span
             aria-hidden="true"
             class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
@@ -148,7 +148,6 @@ exports[`renders as expected 1`] = `
           class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
         >
           <input
-            aria-describedby="experiment.startDatetime-helper-text"
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input"
             id="experiment.startDatetime"
@@ -167,18 +166,12 @@ exports[`renders as expected 1`] = `
               class="PrivateNotchedOutline-legendLabelled-7 PrivateNotchedOutline-legendNotched-8"
             >
               <span>
-                Start date
+                Start date (UTC)
                  *
               </span>
             </legend>
           </fieldset>
         </div>
-        <p
-          class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
-          id="experiment.startDatetime-helper-text"
-        >
-          Use the UTC timezone.
-        </p>
       </div>
       <span
         class="makeStyles-through-3"
@@ -194,7 +187,7 @@ exports[`renders as expected 1`] = `
           for="experiment.endDatetime"
           id="experiment.endDatetime-label"
         >
-          End date
+          End date (UTC)
           <span
             aria-hidden="true"
             class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
@@ -207,7 +200,6 @@ exports[`renders as expected 1`] = `
           class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
         >
           <input
-            aria-describedby="experiment.endDatetime-helper-text"
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input"
             id="experiment.endDatetime"
@@ -224,18 +216,12 @@ exports[`renders as expected 1`] = `
               class="PrivateNotchedOutline-legendLabelled-7 PrivateNotchedOutline-legendNotched-8"
             >
               <span>
-                End date
+                End date (UTC)
                  *
               </span>
             </legend>
           </fieldset>
         </div>
-        <p
-          class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
-          id="experiment.endDatetime-helper-text"
-        >
-          Use the UTC timezone.
-        </p>
       </div>
     </div>
     <div
@@ -535,7 +521,7 @@ exports[`renders date validation errors as expected 1`] = `
           for="experiment.startDatetime"
           id="experiment.startDatetime-label"
         >
-          Start date
+          Start date (UTC)
           <span
             aria-hidden="true"
             class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
@@ -548,7 +534,6 @@ exports[`renders date validation errors as expected 1`] = `
           class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
         >
           <input
-            aria-describedby="experiment.startDatetime-helper-text"
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input"
             id="experiment.startDatetime"
@@ -567,18 +552,12 @@ exports[`renders date validation errors as expected 1`] = `
               class="PrivateNotchedOutline-legendLabelled-23 PrivateNotchedOutline-legendNotched-24"
             >
               <span>
-                Start date
+                Start date (UTC)
                  *
               </span>
             </legend>
           </fieldset>
         </div>
-        <p
-          class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
-          id="experiment.startDatetime-helper-text"
-        >
-          Use the UTC timezone.
-        </p>
       </div>
       <span
         class="makeStyles-through-19"
@@ -594,7 +573,7 @@ exports[`renders date validation errors as expected 1`] = `
           for="experiment.endDatetime"
           id="experiment.endDatetime-label"
         >
-          End date
+          End date (UTC)
           <span
             aria-hidden="true"
             class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
@@ -607,7 +586,6 @@ exports[`renders date validation errors as expected 1`] = `
           class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
         >
           <input
-            aria-describedby="experiment.endDatetime-helper-text"
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input"
             id="experiment.endDatetime"
@@ -626,18 +604,12 @@ exports[`renders date validation errors as expected 1`] = `
               class="PrivateNotchedOutline-legendLabelled-23 PrivateNotchedOutline-legendNotched-24"
             >
               <span>
-                End date
+                End date (UTC)
                  *
               </span>
             </legend>
           </fieldset>
         </div>
-        <p
-          class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
-          id="experiment.endDatetime-helper-text"
-        >
-          Use the UTC timezone.
-        </p>
       </div>
     </div>
     <div
@@ -937,7 +909,7 @@ exports[`renders date validation errors as expected 2`] = `
           for="experiment.startDatetime"
           id="experiment.startDatetime-label"
         >
-          Start date
+          Start date (UTC)
           <span
             aria-hidden="true"
             class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
@@ -950,7 +922,6 @@ exports[`renders date validation errors as expected 2`] = `
           class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
         >
           <input
-            aria-describedby="experiment.startDatetime-helper-text"
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input"
             id="experiment.startDatetime"
@@ -969,18 +940,12 @@ exports[`renders date validation errors as expected 2`] = `
               class="PrivateNotchedOutline-legendLabelled-23 PrivateNotchedOutline-legendNotched-24"
             >
               <span>
-                Start date
+                Start date (UTC)
                  *
               </span>
             </legend>
           </fieldset>
         </div>
-        <p
-          class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
-          id="experiment.startDatetime-helper-text"
-        >
-          Use the UTC timezone.
-        </p>
       </div>
       <span
         class="makeStyles-through-19"
@@ -996,7 +961,7 @@ exports[`renders date validation errors as expected 2`] = `
           for="experiment.endDatetime"
           id="experiment.endDatetime-label"
         >
-          End date
+          End date (UTC)
           <span
             aria-hidden="true"
             class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
@@ -1009,7 +974,6 @@ exports[`renders date validation errors as expected 2`] = `
           class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
         >
           <input
-            aria-describedby="experiment.endDatetime-helper-text"
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input"
             id="experiment.endDatetime"
@@ -1028,18 +992,12 @@ exports[`renders date validation errors as expected 2`] = `
               class="PrivateNotchedOutline-legendLabelled-23 PrivateNotchedOutline-legendNotched-24"
             >
               <span>
-                End date
+                End date (UTC)
                  *
               </span>
             </legend>
           </fieldset>
         </div>
-        <p
-          class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
-          id="experiment.endDatetime-helper-text"
-        >
-          Use the UTC timezone.
-        </p>
       </div>
     </div>
     <div
@@ -1339,7 +1297,7 @@ exports[`renders date validation errors as expected 3`] = `
           for="experiment.startDatetime"
           id="experiment.startDatetime-label"
         >
-          Start date
+          Start date (UTC)
           <span
             aria-hidden="true"
             class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
@@ -1352,7 +1310,6 @@ exports[`renders date validation errors as expected 3`] = `
           class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
         >
           <input
-            aria-describedby="experiment.startDatetime-helper-text"
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input"
             id="experiment.startDatetime"
@@ -1371,18 +1328,12 @@ exports[`renders date validation errors as expected 3`] = `
               class="PrivateNotchedOutline-legendLabelled-23 PrivateNotchedOutline-legendNotched-24"
             >
               <span>
-                Start date
+                Start date (UTC)
                  *
               </span>
             </legend>
           </fieldset>
         </div>
-        <p
-          class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
-          id="experiment.startDatetime-helper-text"
-        >
-          Use the UTC timezone.
-        </p>
       </div>
       <span
         class="makeStyles-through-19"
@@ -1398,7 +1349,7 @@ exports[`renders date validation errors as expected 3`] = `
           for="experiment.endDatetime"
           id="experiment.endDatetime-label"
         >
-          End date
+          End date (UTC)
           <span
             aria-hidden="true"
             class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
@@ -1411,7 +1362,6 @@ exports[`renders date validation errors as expected 3`] = `
           class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
         >
           <input
-            aria-describedby="experiment.endDatetime-helper-text"
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input"
             id="experiment.endDatetime"
@@ -1430,18 +1380,12 @@ exports[`renders date validation errors as expected 3`] = `
               class="PrivateNotchedOutline-legendLabelled-23 PrivateNotchedOutline-legendNotched-24"
             >
               <span>
-                End date
+                End date (UTC)
                  *
               </span>
             </legend>
           </fieldset>
         </div>
-        <p
-          class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
-          id="experiment.endDatetime-helper-text"
-        >
-          Use the UTC timezone.
-        </p>
       </div>
     </div>
     <div
@@ -1741,7 +1685,7 @@ exports[`renders date validation errors as expected 4`] = `
           for="experiment.startDatetime"
           id="experiment.startDatetime-label"
         >
-          Start date
+          Start date (UTC)
           <span
             aria-hidden="true"
             class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
@@ -1754,7 +1698,6 @@ exports[`renders date validation errors as expected 4`] = `
           class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
         >
           <input
-            aria-describedby="experiment.startDatetime-helper-text"
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input"
             id="experiment.startDatetime"
@@ -1773,18 +1716,12 @@ exports[`renders date validation errors as expected 4`] = `
               class="PrivateNotchedOutline-legendLabelled-23 PrivateNotchedOutline-legendNotched-24"
             >
               <span>
-                Start date
+                Start date (UTC)
                  *
               </span>
             </legend>
           </fieldset>
         </div>
-        <p
-          class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
-          id="experiment.startDatetime-helper-text"
-        >
-          Use the UTC timezone.
-        </p>
       </div>
       <span
         class="makeStyles-through-19"
@@ -1800,7 +1737,7 @@ exports[`renders date validation errors as expected 4`] = `
           for="experiment.endDatetime"
           id="experiment.endDatetime-label"
         >
-          End date
+          End date (UTC)
           <span
             aria-hidden="true"
             class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
@@ -1813,7 +1750,6 @@ exports[`renders date validation errors as expected 4`] = `
           class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
         >
           <input
-            aria-describedby="experiment.endDatetime-helper-text"
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input"
             id="experiment.endDatetime"
@@ -1832,18 +1768,12 @@ exports[`renders date validation errors as expected 4`] = `
               class="PrivateNotchedOutline-legendLabelled-23 PrivateNotchedOutline-legendNotched-24"
             >
               <span>
-                End date
+                End date (UTC)
                  *
               </span>
             </legend>
           </fieldset>
         </div>
-        <p
-          class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
-          id="experiment.endDatetime-helper-text"
-        >
-          Use the UTC timezone.
-        </p>
       </div>
     </div>
     <div
@@ -2143,7 +2073,7 @@ exports[`renders sensible dates as expected 1`] = `
           for="experiment.startDatetime"
           id="experiment.startDatetime-label"
         >
-          Start date
+          Start date (UTC)
           <span
             aria-hidden="true"
             class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
@@ -2156,7 +2086,6 @@ exports[`renders sensible dates as expected 1`] = `
           class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
         >
           <input
-            aria-describedby="experiment.startDatetime-helper-text"
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input"
             id="experiment.startDatetime"
@@ -2175,18 +2104,12 @@ exports[`renders sensible dates as expected 1`] = `
               class="PrivateNotchedOutline-legendLabelled-15 PrivateNotchedOutline-legendNotched-16"
             >
               <span>
-                Start date
+                Start date (UTC)
                  *
               </span>
             </legend>
           </fieldset>
         </div>
-        <p
-          class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
-          id="experiment.startDatetime-helper-text"
-        >
-          Use the UTC timezone.
-        </p>
       </div>
       <span
         class="makeStyles-through-11"
@@ -2202,7 +2125,7 @@ exports[`renders sensible dates as expected 1`] = `
           for="experiment.endDatetime"
           id="experiment.endDatetime-label"
         >
-          End date
+          End date (UTC)
           <span
             aria-hidden="true"
             class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
@@ -2215,7 +2138,6 @@ exports[`renders sensible dates as expected 1`] = `
           class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
         >
           <input
-            aria-describedby="experiment.endDatetime-helper-text"
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input"
             id="experiment.endDatetime"
@@ -2234,18 +2156,12 @@ exports[`renders sensible dates as expected 1`] = `
               class="PrivateNotchedOutline-legendLabelled-15 PrivateNotchedOutline-legendNotched-16"
             >
               <span>
-                End date
+                End date (UTC)
                  *
               </span>
             </legend>
           </fieldset>
         </div>
-        <p
-          class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled Mui-required"
-          id="experiment.endDatetime-helper-text"
-        >
-          Use the UTC timezone.
-        </p>
       </div>
     </div>
     <div

--- a/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
@@ -1247,6 +1247,8 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
                     id="experiment.startDatetime-helper-text"
                   >
+                    Automatic start date.
+                    <br />
                     Use the UTC timezone.
                   </p>
                 </div>
@@ -1304,6 +1306,8 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
                     id="experiment.endDatetime-helper-text"
                   >
+                    Automatic end date.
+                    <br />
                     Use the UTC timezone.
                   </p>
                 </div>

--- a/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
@@ -1205,7 +1205,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     for="experiment.startDatetime"
                     id="experiment.startDatetime-label"
                   >
-                    Start date
+                    Start date (UTC)
                     <span
                       aria-hidden="true"
                       class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
@@ -1218,7 +1218,6 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
                   >
                     <input
-                      aria-describedby="experiment.startDatetime-helper-text"
                       aria-invalid="false"
                       class="MuiInputBase-input MuiOutlinedInput-input"
                       id="experiment.startDatetime"
@@ -1237,18 +1236,12 @@ exports[`sections should be browsable by the section buttons 2`] = `
                         class="PrivateNotchedOutline-legendLabelled-124 PrivateNotchedOutline-legendNotched-125"
                       >
                         <span>
-                          Start date
+                          Start date (UTC)
                            *
                         </span>
                       </legend>
                     </fieldset>
                   </div>
-                  <p
-                    class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
-                    id="experiment.startDatetime-helper-text"
-                  >
-                    Use the UTC timezone.
-                  </p>
                 </div>
                 <span
                   class="makeStyles-through-128"
@@ -1264,7 +1257,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     for="experiment.endDatetime"
                     id="experiment.endDatetime-label"
                   >
-                    End date
+                    End date (UTC)
                     <span
                       aria-hidden="true"
                       class="MuiFormLabel-asterisk MuiInputLabel-asterisk"
@@ -1277,7 +1270,6 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
                   >
                     <input
-                      aria-describedby="experiment.endDatetime-helper-text"
                       aria-invalid="false"
                       class="MuiInputBase-input MuiOutlinedInput-input"
                       id="experiment.endDatetime"
@@ -1294,18 +1286,12 @@ exports[`sections should be browsable by the section buttons 2`] = `
                         class="PrivateNotchedOutline-legendLabelled-124 PrivateNotchedOutline-legendNotched-125"
                       >
                         <span>
-                          End date
+                          End date (UTC)
                            *
                         </span>
                       </legend>
                     </fieldset>
                   </div>
-                  <p
-                    class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
-                    id="experiment.endDatetime-helper-text"
-                  >
-                    Use the UTC timezone.
-                  </p>
                 </div>
               </div>
               <div

--- a/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
@@ -1319,7 +1319,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
                   <strong>
                     start and end automatically
                   </strong>
-                   around midnight UTC on these dates.
+                   around 00:10 UTC on these dates.
                 </div>
               </div>
               <div

--- a/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
@@ -1247,9 +1247,9 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
                     id="experiment.startDatetime-helper-text"
                   >
-                    Automatic start date.
+                    Automatic start date. 
                     <br />
-                    Use the UTC timezone.
+                     Use the UTC timezone.
                   </p>
                 </div>
                 <span
@@ -1306,9 +1306,9 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
                     id="experiment.endDatetime-helper-text"
                   >
-                    Automatic end date.
+                    Automatic end date. 
                     <br />
-                    Use the UTC timezone.
+                     Use the UTC timezone.
                   </p>
                 </div>
               </div>

--- a/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
@@ -1247,9 +1247,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
                     id="experiment.startDatetime-helper-text"
                   >
-                    Automatic start date. 
-                    <br />
-                     Use the UTC timezone.
+                    Use the UTC timezone.
                   </p>
                 </div>
                 <span
@@ -1306,10 +1304,36 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     class="MuiFormHelperText-root MuiFormHelperText-contained Mui-required"
                     id="experiment.endDatetime-helper-text"
                   >
-                    Automatic end date. 
-                    <br />
-                     Use the UTC timezone.
+                    Use the UTC timezone.
                   </p>
+                </div>
+              </div>
+              <div
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo MuiPaper-elevation0"
+                role="alert"
+              >
+                <div
+                  class="MuiAlert-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiAlert-message"
+                >
+                  The experiment will 
+                  <strong>
+                    start and end automatically
+                  </strong>
+                   around midnight UTC on these dates.
                 </div>
               </div>
               <div


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR adds text underneath the start-date and end-date fields in the wizard to let Experimenters know that they are used for automation:**

<img width="553" alt="Screen Shot 2020-12-11 at 2 15 25 am" src="https://user-images.githubusercontent.com/971886/101812774-c4ce1b00-3b56-11eb-9d9e-4f585408042f.png">

Created this after seeing several experimenters surprised about it.
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
