### PR TITLE
Add inline info links

### DIFF
--- a/src/components/experiments/wizard/Metrics.tsx
+++ b/src/components/experiments/wizard/Metrics.tsx
@@ -3,6 +3,7 @@ import {
   FormControl,
   IconButton,
   InputAdornment,
+  Link,
   MenuItem,
   Select as MuiSelect,
   Table,
@@ -17,7 +18,7 @@ import {
 } from '@material-ui/core'
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import { Add, Clear } from '@material-ui/icons'
-import { AutocompleteRenderInputParams } from '@material-ui/lab'
+import { Alert, AutocompleteRenderInputParams } from '@material-ui/lab'
 import { Field, FieldArray, useField } from 'formik'
 import { Select, Switch, TextField } from 'formik-material-ui'
 import React, { useState } from 'react'
@@ -58,9 +59,15 @@ const useStyles = makeStyles((theme: Theme) =>
     changeExpected: {
       textAlign: 'center',
     },
+    metricsInfo: {
+      marginTop: theme.spacing(4),
+    },
     exposureEventsTitle: {
       marginTop: theme.spacing(6),
       marginBottom: theme.spacing(4),
+    },
+    exposureEventsInfo: {
+      marginTop: theme.spacing(4),
     },
     tooltipped: {
       borderBottomWidth: 1,
@@ -480,7 +487,37 @@ const Metrics = ({
         }}
       />
 
-      <Typography variant='h4' gutterBottom className={classes.exposureEventsTitle}>
+      <Alert severity='info' className={classes.metricsInfo}>
+        <Link
+          underline='always'
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-primary-metric"
+        >
+          How do I choose a Primary Metric?
+        </Link>
+        &nbsp;
+        <Link
+          underline='always'
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-minimum-difference-practically-equivalent-value-for-my-metrics"
+        >
+          How do I choose a Minimum Difference?
+        </Link>
+        <br />
+        <Link
+          underline='always'
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-does-change-expected-mean-for-a-metric"
+        >
+          What is Change Expected?
+        </Link>
+        &nbsp;
+        <Link
+          underline='always'
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-attribution-window-for-a-metric"
+        >
+          What is an Attribution Window?
+        </Link>
+      </Alert>
+
+      <Typography variant='h4' className={classes.exposureEventsTitle}>
         Exposure Events (Optional)
       </Typography>
 
@@ -533,6 +570,15 @@ const Metrics = ({
           )
         }}
       />
+
+      <Alert severity='info' className={classes.exposureEventsInfo}>
+        <Link
+          underline='always'
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-exposure-event-and-when-do-i-need-it"
+        >
+          What is an Exposure Event? And when do I need it?
+        </Link>
+      </Alert>
     </div>
   )
 }

--- a/src/components/experiments/wizard/Metrics.tsx
+++ b/src/components/experiments/wizard/Metrics.tsx
@@ -491,6 +491,7 @@ const Metrics = ({
         <Link
           underline='always'
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-primary-metric"
+          target='_blank'
         >
           How do I choose a Primary Metric?
         </Link>
@@ -498,6 +499,7 @@ const Metrics = ({
         <Link
           underline='always'
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-minimum-difference-practically-equivalent-value-for-my-metrics"
+          target='_blank'
         >
           How do I choose a Minimum Difference?
         </Link>
@@ -505,6 +507,7 @@ const Metrics = ({
         <Link
           underline='always'
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-does-change-expected-mean-for-a-metric"
+          target='_blank'
         >
           What is Change Expected?
         </Link>
@@ -512,6 +515,7 @@ const Metrics = ({
         <Link
           underline='always'
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-attribution-window-for-a-metric"
+          target='_blank'
         >
           What is an Attribution Window?
         </Link>
@@ -575,6 +579,7 @@ const Metrics = ({
         <Link
           underline='always'
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-exposure-event-and-when-do-i-need-it"
+          target='_blank'
         >
           What is an Exposure Event? And when do I need it?
         </Link>

--- a/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
@@ -393,10 +393,10 @@ exports[`renders as expected 1`] = `
 exports[`sections should be browsable by the section buttons 1`] = `
 <div>
   <div
-    class="makeStyles-root-113"
+    class="makeStyles-root-117"
   >
     <div
-      class="makeStyles-navigation-114"
+      class="makeStyles-navigation-118"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -683,17 +683,17 @@ exports[`sections should be browsable by the section buttons 1`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-115"
+        class="makeStyles-form-119"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-116"
+          class="makeStyles-formPart-120"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-118 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-122 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-119"
+              class="makeStyles-root-123"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -717,7 +717,7 @@ exports[`sections should be browsable by the section buttons 1`] = `
                 </strong>
               </p>
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-p2EntryField-120"
+                class="MuiFormControl-root MuiTextField-root makeStyles-p2EntryField-124"
               >
                 <label
                   class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
@@ -741,10 +741,10 @@ exports[`sections should be browsable by the section buttons 1`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-122 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-126 MuiOutlinedInput-notchedOutline"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legendLabelled-124 PrivateNotchedOutline-legendNotched-125"
+                      class="PrivateNotchedOutline-legendLabelled-128 PrivateNotchedOutline-legendNotched-129"
                     >
                       <span>
                         Your Post's URL
@@ -756,7 +756,7 @@ exports[`sections should be browsable by the section buttons 1`] = `
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-117"
+            class="makeStyles-formPartActions-121"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -783,10 +783,10 @@ exports[`sections should be browsable by the section buttons 1`] = `
 exports[`sections should be browsable by the section buttons 2`] = `
 <div>
   <div
-    class="makeStyles-root-113"
+    class="makeStyles-root-117"
   >
     <div
-      class="makeStyles-navigation-114"
+      class="makeStyles-navigation-118"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -1063,17 +1063,17 @@ exports[`sections should be browsable by the section buttons 2`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-115"
+        class="makeStyles-form-119"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-116"
+          class="makeStyles-formPart-120"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-118 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-122 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-126"
+              class="makeStyles-root-130"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1081,7 +1081,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
                 Basic Info
               </h4>
               <div
-                class="makeStyles-row-127"
+                class="makeStyles-row-131"
               >
                 <div
                   class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -1117,10 +1117,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-122 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-126 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-124 PrivateNotchedOutline-legendNotched-125"
+                        class="PrivateNotchedOutline-legendLabelled-128 PrivateNotchedOutline-legendNotched-129"
                       >
                         <span>
                           Experiment name
@@ -1138,7 +1138,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-row-127"
+                class="makeStyles-row-131"
               >
                 <div
                   class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -1173,10 +1173,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-122 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-126 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-124 PrivateNotchedOutline-legendNotched-125"
+                        class="PrivateNotchedOutline-legendLabelled-128 PrivateNotchedOutline-legendNotched-129"
                       >
                         <span>
                           Experiment description
@@ -1194,10 +1194,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-row-127"
+                class="makeStyles-row-131"
               >
                 <div
-                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-129"
+                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-133"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
@@ -1231,10 +1231,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-122 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-126 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-124 PrivateNotchedOutline-legendNotched-125"
+                        class="PrivateNotchedOutline-legendLabelled-128 PrivateNotchedOutline-legendNotched-129"
                       >
                         <span>
                           Start date
@@ -1251,12 +1251,12 @@ exports[`sections should be browsable by the section buttons 2`] = `
                   </p>
                 </div>
                 <span
-                  class="makeStyles-through-128"
+                  class="makeStyles-through-132"
                 >
                    through 
                 </span>
                 <div
-                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-129"
+                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-133"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
@@ -1288,10 +1288,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-122 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-126 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-124 PrivateNotchedOutline-legendNotched-125"
+                        class="PrivateNotchedOutline-legendLabelled-128 PrivateNotchedOutline-legendNotched-129"
                       >
                         <span>
                           End date
@@ -1309,7 +1309,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-row-127"
+                class="makeStyles-row-131"
               >
                 <div
                   aria-expanded="false"
@@ -1417,10 +1417,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                       </div>
                       <fieldset
                         aria-hidden="true"
-                        class="PrivateNotchedOutline-root-122 MuiOutlinedInput-notchedOutline"
+                        class="PrivateNotchedOutline-root-126 MuiOutlinedInput-notchedOutline"
                       >
                         <legend
-                          class="PrivateNotchedOutline-legendLabelled-124 PrivateNotchedOutline-legendNotched-125"
+                          class="PrivateNotchedOutline-legendLabelled-128 PrivateNotchedOutline-legendNotched-129"
                         >
                           <span>
                             Owner
@@ -1441,7 +1441,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-117"
+            class="makeStyles-formPartActions-121"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -1482,10 +1482,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
 exports[`sections should be browsable by the section buttons 3`] = `
 <div>
   <div
-    class="makeStyles-root-113"
+    class="makeStyles-root-117"
   >
     <div
-      class="makeStyles-navigation-114"
+      class="makeStyles-navigation-118"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -1732,14 +1732,14 @@ exports[`sections should be browsable by the section buttons 3`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-115"
+        class="makeStyles-form-119"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-116"
+          class="makeStyles-formPart-120"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-118 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-122 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <h4
               class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1774,7 +1774,7 @@ exports[`sections should be browsable by the section buttons 3`] = `
             </p>
           </div>
           <div
-            class="makeStyles-formPartActions-117"
+            class="makeStyles-formPartActions-121"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -1791,7 +1791,7 @@ exports[`sections should be browsable by the section buttons 3`] = `
               />
             </button>
             <div
-              class="makeStyles-root-130"
+              class="makeStyles-root-134"
             >
               <button
                 class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary Mui-disabled Mui-disabled"
@@ -1817,10 +1817,10 @@ exports[`sections should be browsable by the section buttons 3`] = `
 exports[`sections should be browsable by the section buttons 4`] = `
 <div>
   <div
-    class="makeStyles-root-113"
+    class="makeStyles-root-117"
   >
     <div
-      class="makeStyles-navigation-114"
+      class="makeStyles-navigation-118"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -2077,17 +2077,17 @@ exports[`sections should be browsable by the section buttons 4`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-115"
+        class="makeStyles-form-119"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-116"
+          class="makeStyles-formPart-120"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-118 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-122 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-132"
+              class="makeStyles-root-136"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -2157,11 +2157,11 @@ exports[`sections should be browsable by the section buttons 4`] = `
                 </table>
               </div>
               <div
-                class="makeStyles-addMetric-143"
+                class="makeStyles-addMetric-149"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-144"
+                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-150"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -2170,7 +2170,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
                   />
                 </svg>
                 <div
-                  class="MuiFormControl-root makeStyles-addMetricSelect-134"
+                  class="MuiFormControl-root makeStyles-addMetricSelect-138"
                 >
                   <div
                     class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -2184,7 +2184,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
                       tabindex="0"
                     >
                       <span
-                        class="makeStyles-addMetricPlaceholder-133"
+                        class="makeStyles-addMetricPlaceholder-137"
                       >
                         Select a Metric
                       </span>
@@ -2221,8 +2221,58 @@ exports[`sections should be browsable by the section buttons 4`] = `
                   />
                 </button>
               </div>
+              <div
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-144 MuiPaper-elevation0"
+                role="alert"
+              >
+                <div
+                  class="MuiAlert-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiAlert-message"
+                >
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+                    href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-primary-metric"
+                  >
+                    How do I choose a Primary Metric?
+                  </a>
+                   
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+                    href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-minimum-difference-practically-equivalent-value-for-my-metrics"
+                  >
+                    How do I choose a Minimum Difference?
+                  </a>
+                  <br />
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+                    href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-does-change-expected-mean-for-a-metric"
+                  >
+                    What is Change Expected?
+                  </a>
+                   
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+                    href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-attribution-window-for-a-metric"
+                  >
+                    What is an Attribution Window?
+                  </a>
+                </div>
+              </div>
               <h4
-                class="MuiTypography-root makeStyles-exposureEventsTitle-140 MuiTypography-h4 MuiTypography-gutterBottom"
+                class="MuiTypography-root makeStyles-exposureEventsTitle-145 MuiTypography-h4"
               >
                 Exposure Events (Optional)
               </h4>
@@ -2253,11 +2303,11 @@ exports[`sections should be browsable by the section buttons 4`] = `
                 </table>
               </div>
               <div
-                class="makeStyles-addMetric-143"
+                class="makeStyles-addMetric-149"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-144"
+                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-150"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -2281,10 +2331,39 @@ exports[`sections should be browsable by the section buttons 4`] = `
                   />
                 </button>
               </div>
+              <div
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-146 MuiPaper-elevation0"
+                role="alert"
+              >
+                <div
+                  class="MuiAlert-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiAlert-message"
+                >
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+                    href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-exposure-event-and-when-do-i-need-it"
+                  >
+                    What is an Exposure Event? And when do I need it?
+                  </a>
+                </div>
+              </div>
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-117"
+            class="makeStyles-formPartActions-121"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -2325,10 +2404,10 @@ exports[`sections should be browsable by the section buttons 4`] = `
 exports[`skipping to submit should check all sections 1`] = `
 <div>
   <div
-    class="makeStyles-root-169"
+    class="makeStyles-root-175"
   >
     <div
-      class="makeStyles-navigation-170"
+      class="makeStyles-navigation-176"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -2575,14 +2654,14 @@ exports[`skipping to submit should check all sections 1`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-171"
+        class="makeStyles-form-177"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-172"
+          class="makeStyles-formPart-178"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-174 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-180 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <h4
               class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -2617,7 +2696,7 @@ exports[`skipping to submit should check all sections 1`] = `
             </p>
           </div>
           <div
-            class="makeStyles-formPartActions-173"
+            class="makeStyles-formPartActions-179"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -2634,7 +2713,7 @@ exports[`skipping to submit should check all sections 1`] = `
               />
             </button>
             <div
-              class="makeStyles-root-182"
+              class="makeStyles-root-188"
             >
               <button
                 class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary Mui-disabled Mui-disabled"

--- a/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
@@ -2245,6 +2245,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
                   <a
                     class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
                     href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-primary-metric"
+                    target="_blank"
                   >
                     How do I choose a Primary Metric?
                   </a>
@@ -2252,6 +2253,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
                   <a
                     class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
                     href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-minimum-difference-practically-equivalent-value-for-my-metrics"
+                    target="_blank"
                   >
                     How do I choose a Minimum Difference?
                   </a>
@@ -2259,6 +2261,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
                   <a
                     class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
                     href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-does-change-expected-mean-for-a-metric"
+                    target="_blank"
                   >
                     What is Change Expected?
                   </a>
@@ -2266,6 +2269,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
                   <a
                     class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
                     href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-attribution-window-for-a-metric"
+                    target="_blank"
                   >
                     What is an Attribution Window?
                   </a>
@@ -2355,6 +2359,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
                   <a
                     class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
                     href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-exposure-event-and-when-do-i-need-it"
+                    target="_blank"
                   >
                     What is an Exposure Event? And when do I need it?
                   </a>

--- a/src/components/experiments/wizard/__snapshots__/Metrics.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/Metrics.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`allows adding, editing and removing a Metric Assignment 1`] = `
 <div>
   <div
-    class="makeStyles-root-14"
+    class="makeStyles-root-16"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -73,11 +73,11 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-25"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -86,7 +86,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-16"
+        class="MuiFormControl-root makeStyles-addMetricSelect-18"
       >
         <div
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -100,7 +100,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
             tabindex="0"
           >
             <span
-              class="makeStyles-addMetricPlaceholder-15"
+              class="makeStyles-addMetricPlaceholder-17"
             >
               Select a Metric
             </span>
@@ -137,8 +137,58 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
         />
       </button>
     </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-24 MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-primary-metric"
+        >
+          How do I choose a Primary Metric?
+        </a>
+         
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-minimum-difference-practically-equivalent-value-for-my-metrics"
+        >
+          How do I choose a Minimum Difference?
+        </a>
+        <br />
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-does-change-expected-mean-for-a-metric"
+        >
+          What is Change Expected?
+        </a>
+         
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-attribution-window-for-a-metric"
+        >
+          What is an Attribution Window?
+        </a>
+      </div>
+    </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-22 MuiTypography-h4 MuiTypography-gutterBottom"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-25 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -169,11 +219,11 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-25"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -196,6 +246,35 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
           class="MuiTouchRipple-root"
         />
       </button>
+    </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-26 MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-exposure-event-and-when-do-i-need-it"
+        >
+          What is an Exposure Event? And when do I need it?
+        </a>
+      </div>
     </div>
   </div>
 </div>
@@ -204,7 +283,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
 exports[`allows adding, editing and removing a Metric Assignment 2`] = `
 <div>
   <div
-    class="makeStyles-root-14"
+    class="makeStyles-root-16"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -274,11 +353,11 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-25"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -287,7 +366,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-16"
+        class="MuiFormControl-root makeStyles-addMetricSelect-18"
       >
         <div
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -301,7 +380,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
             tabindex="0"
           >
             <span
-              class="makeStyles-addMetricPlaceholder-15"
+              class="makeStyles-addMetricPlaceholder-17"
             >
               Select a Metric
             </span>
@@ -338,8 +417,58 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
         />
       </button>
     </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-24 MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-primary-metric"
+        >
+          How do I choose a Primary Metric?
+        </a>
+         
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-minimum-difference-practically-equivalent-value-for-my-metrics"
+        >
+          How do I choose a Minimum Difference?
+        </a>
+        <br />
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-does-change-expected-mean-for-a-metric"
+        >
+          What is Change Expected?
+        </a>
+         
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-attribution-window-for-a-metric"
+        >
+          What is an Attribution Window?
+        </a>
+      </div>
+    </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-22 MuiTypography-h4 MuiTypography-gutterBottom"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-25 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -370,11 +499,11 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-25"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -398,6 +527,35 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
         />
       </button>
     </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-26 MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-exposure-event-and-when-do-i-need-it"
+        >
+          What is an Exposure Event? And when do I need it?
+        </a>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -405,7 +563,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
 exports[`allows adding, editing and removing a Metric Assignment 3`] = `
 <div>
   <div
-    class="makeStyles-root-14"
+    class="makeStyles-root-16"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -464,14 +622,14 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                class="makeStyles-metricName-18"
+                class="makeStyles-metricName-20"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-primary-19"
+                class="makeStyles-primary-21"
               >
                 Primary
               </span>
@@ -480,7 +638,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-17"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-19"
               >
                 <div
                   aria-haspopup="listbox"
@@ -510,11 +668,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-27 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-31 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-28"
+                    class="PrivateNotchedOutline-legend-32"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -525,7 +683,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-21"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-23"
             >
               <span
                 class="MuiSwitch-root"
@@ -533,14 +691,14 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-31 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-35 MuiSwitch-switchBase MuiSwitch-colorSecondary"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-34 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-38 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -563,7 +721,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-20"
+                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-22"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
@@ -590,11 +748,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-27 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-31 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-28"
+                      class="PrivateNotchedOutline-legend-32"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -642,11 +800,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-25"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -655,7 +813,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-16"
+        class="MuiFormControl-root makeStyles-addMetricSelect-18"
       >
         <div
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -669,7 +827,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
             tabindex="0"
           >
             <span
-              class="makeStyles-addMetricPlaceholder-15"
+              class="makeStyles-addMetricPlaceholder-17"
             >
               Select a Metric
             </span>
@@ -706,8 +864,58 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
         />
       </button>
     </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-24 MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-primary-metric"
+        >
+          How do I choose a Primary Metric?
+        </a>
+         
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-minimum-difference-practically-equivalent-value-for-my-metrics"
+        >
+          How do I choose a Minimum Difference?
+        </a>
+        <br />
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-does-change-expected-mean-for-a-metric"
+        >
+          What is Change Expected?
+        </a>
+         
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-attribution-window-for-a-metric"
+        >
+          What is an Attribution Window?
+        </a>
+      </div>
+    </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-22 MuiTypography-h4 MuiTypography-gutterBottom"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-25 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -738,11 +946,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-25"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -765,6 +973,35 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
           class="MuiTouchRipple-root"
         />
       </button>
+    </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-26 MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-exposure-event-and-when-do-i-need-it"
+        >
+          What is an Exposure Event? And when do I need it?
+        </a>
+      </div>
     </div>
   </div>
 </div>
@@ -775,7 +1012,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
   aria-hidden="true"
 >
   <div
-    class="makeStyles-root-14"
+    class="makeStyles-root-16"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -834,14 +1071,14 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                class="makeStyles-metricName-18"
+                class="makeStyles-metricName-20"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-primary-19"
+                class="makeStyles-primary-21"
               >
                 Primary
               </span>
@@ -850,7 +1087,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-17"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-19"
               >
                 <div
                   aria-haspopup="listbox"
@@ -880,11 +1117,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-27 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-31 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-28"
+                    class="PrivateNotchedOutline-legend-32"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -895,7 +1132,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-21"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-23"
             >
               <span
                 class="MuiSwitch-root"
@@ -903,14 +1140,14 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-31 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-35 MuiSwitch-switchBase MuiSwitch-colorSecondary"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-34 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-38 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -933,7 +1170,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-20"
+                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-22"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
@@ -960,11 +1197,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-27 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-31 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-28"
+                      class="PrivateNotchedOutline-legend-32"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -1012,11 +1249,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-25"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1025,7 +1262,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-16"
+        class="MuiFormControl-root makeStyles-addMetricSelect-18"
       >
         <div
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -1039,7 +1276,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
             tabindex="0"
           >
             <span
-              class="makeStyles-addMetricPlaceholder-15"
+              class="makeStyles-addMetricPlaceholder-17"
             >
               Select a Metric
             </span>
@@ -1076,8 +1313,58 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
         />
       </button>
     </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-24 MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-primary-metric"
+        >
+          How do I choose a Primary Metric?
+        </a>
+         
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-minimum-difference-practically-equivalent-value-for-my-metrics"
+        >
+          How do I choose a Minimum Difference?
+        </a>
+        <br />
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-does-change-expected-mean-for-a-metric"
+        >
+          What is Change Expected?
+        </a>
+         
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-attribution-window-for-a-metric"
+        >
+          What is an Attribution Window?
+        </a>
+      </div>
+    </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-22 MuiTypography-h4 MuiTypography-gutterBottom"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-25 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -1108,11 +1395,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-25"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1135,6 +1422,35 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
           class="MuiTouchRipple-root"
         />
       </button>
+    </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-26 MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-exposure-event-and-when-do-i-need-it"
+        >
+          What is an Exposure Event? And when do I need it?
+        </a>
+      </div>
     </div>
   </div>
 </div>
@@ -1143,7 +1459,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
 exports[`allows adding, editing and removing a Metric Assignment 5`] = `
 <div>
   <div
-    class="makeStyles-root-14"
+    class="makeStyles-root-16"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1202,14 +1518,14 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                class="makeStyles-metricName-18"
+                class="makeStyles-metricName-20"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-primary-19"
+                class="makeStyles-primary-21"
               >
                 Primary
               </span>
@@ -1218,7 +1534,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-17"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-19"
               >
                 <div
                   aria-haspopup="listbox"
@@ -1248,11 +1564,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-27 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-31 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-28"
+                    class="PrivateNotchedOutline-legend-32"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -1263,7 +1579,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-21"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-23"
             >
               <span
                 class="MuiSwitch-root"
@@ -1271,14 +1587,14 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-31 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-35 MuiSwitch-switchBase MuiSwitch-colorSecondary"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-34 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-38 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -1301,7 +1617,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-20"
+                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-22"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
@@ -1328,11 +1644,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-27 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-31 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-28"
+                      class="PrivateNotchedOutline-legend-32"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -1380,11 +1696,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-25"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1393,7 +1709,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-16"
+        class="MuiFormControl-root makeStyles-addMetricSelect-18"
       >
         <div
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -1407,7 +1723,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
             tabindex="0"
           >
             <span
-              class="makeStyles-addMetricPlaceholder-15"
+              class="makeStyles-addMetricPlaceholder-17"
             >
               Select a Metric
             </span>
@@ -1444,8 +1760,58 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
         />
       </button>
     </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-24 MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-primary-metric"
+        >
+          How do I choose a Primary Metric?
+        </a>
+         
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-minimum-difference-practically-equivalent-value-for-my-metrics"
+        >
+          How do I choose a Minimum Difference?
+        </a>
+        <br />
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-does-change-expected-mean-for-a-metric"
+        >
+          What is Change Expected?
+        </a>
+         
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-attribution-window-for-a-metric"
+        >
+          What is an Attribution Window?
+        </a>
+      </div>
+    </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-22 MuiTypography-h4 MuiTypography-gutterBottom"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-25 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -1476,11 +1842,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-25"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1504,6 +1870,35 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
         />
       </button>
     </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-26 MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-exposure-event-and-when-do-i-need-it"
+        >
+          What is an Exposure Event? And when do I need it?
+        </a>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -1511,7 +1906,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
 exports[`allows adding, editing and removing a Metric Assignment 6`] = `
 <div>
   <div
-    class="makeStyles-root-14"
+    class="makeStyles-root-16"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1581,11 +1976,11 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-25"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1594,7 +1989,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-16"
+        class="MuiFormControl-root makeStyles-addMetricSelect-18"
       >
         <div
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -1608,7 +2003,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
             tabindex="0"
           >
             <span
-              class="makeStyles-addMetricPlaceholder-15"
+              class="makeStyles-addMetricPlaceholder-17"
             >
               Select a Metric
             </span>
@@ -1645,8 +2040,58 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
         />
       </button>
     </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-24 MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-primary-metric"
+        >
+          How do I choose a Primary Metric?
+        </a>
+         
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-minimum-difference-practically-equivalent-value-for-my-metrics"
+        >
+          How do I choose a Minimum Difference?
+        </a>
+        <br />
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-does-change-expected-mean-for-a-metric"
+        >
+          What is Change Expected?
+        </a>
+         
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-attribution-window-for-a-metric"
+        >
+          What is an Attribution Window?
+        </a>
+      </div>
+    </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-22 MuiTypography-h4 MuiTypography-gutterBottom"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-25 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -1677,11 +2122,11 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-25"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1705,6 +2150,35 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
         />
       </button>
     </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-26 MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-exposure-event-and-when-do-i-need-it"
+        >
+          What is an Exposure Event? And when do I need it?
+        </a>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -1712,7 +2186,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
 exports[`allows adding, editing and removing a Metric Assignment 7`] = `
 <div>
   <div
-    class="makeStyles-root-14"
+    class="makeStyles-root-16"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1771,14 +2245,14 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                class="makeStyles-metricName-18"
+                class="makeStyles-metricName-20"
                 title="string"
               >
                 registration_start
               </span>
               <br />
               <span
-                class="makeStyles-primary-19"
+                class="makeStyles-primary-21"
               >
                 Primary
               </span>
@@ -1787,7 +2261,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-17"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-19"
               >
                 <div
                   aria-haspopup="listbox"
@@ -1817,11 +2291,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-35 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-39 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-36"
+                    class="PrivateNotchedOutline-legend-40"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -1832,7 +2306,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-21"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-23"
             >
               <span
                 class="MuiSwitch-root"
@@ -1840,14 +2314,14 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-39 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-43 MuiSwitch-switchBase MuiSwitch-colorSecondary"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-42 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-46 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -1870,7 +2344,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-20"
+                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-22"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
@@ -1890,7 +2364,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                     class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
                   >
                     <p
-                      class="MuiTypography-root makeStyles-tooltipped-23 MuiTypography-body1 MuiTypography-colorTextSecondary"
+                      class="MuiTypography-root makeStyles-tooltipped-27 MuiTypography-body1 MuiTypography-colorTextSecondary"
                       title="Percentage Points"
                     >
                       pp
@@ -1898,11 +2372,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                   </div>
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-35 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-39 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-36"
+                      class="PrivateNotchedOutline-legend-40"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -1950,11 +2424,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-25"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1963,7 +2437,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-16"
+        class="MuiFormControl-root makeStyles-addMetricSelect-18"
       >
         <div
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -1977,7 +2451,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
             tabindex="0"
           >
             <span
-              class="makeStyles-addMetricPlaceholder-15"
+              class="makeStyles-addMetricPlaceholder-17"
             >
               Select a Metric
             </span>
@@ -2014,8 +2488,58 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
         />
       </button>
     </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-24 MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-primary-metric"
+        >
+          How do I choose a Primary Metric?
+        </a>
+         
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-minimum-difference-practically-equivalent-value-for-my-metrics"
+        >
+          How do I choose a Minimum Difference?
+        </a>
+        <br />
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-does-change-expected-mean-for-a-metric"
+        >
+          What is Change Expected?
+        </a>
+         
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-attribution-window-for-a-metric"
+        >
+          What is an Attribution Window?
+        </a>
+      </div>
+    </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-22 MuiTypography-h4 MuiTypography-gutterBottom"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-25 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -2046,11 +2570,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-25"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-26"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -2073,6 +2597,35 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
           class="MuiTouchRipple-root"
         />
       </button>
+    </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-26 MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-exposure-event-and-when-do-i-need-it"
+        >
+          What is an Exposure Event? And when do I need it?
+        </a>
+      </div>
     </div>
   </div>
 </div>
@@ -2151,11 +2704,11 @@ exports[`renders as expected 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-12"
+      class="makeStyles-addMetric-14"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-13"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-15"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -2215,8 +2768,58 @@ exports[`renders as expected 1`] = `
         />
       </button>
     </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-9 MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-primary-metric"
+        >
+          How do I choose a Primary Metric?
+        </a>
+         
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-minimum-difference-practically-equivalent-value-for-my-metrics"
+        >
+          How do I choose a Minimum Difference?
+        </a>
+        <br />
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-does-change-expected-mean-for-a-metric"
+        >
+          What is Change Expected?
+        </a>
+         
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-attribution-window-for-a-metric"
+        >
+          What is an Attribution Window?
+        </a>
+      </div>
+    </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-9 MuiTypography-h4 MuiTypography-gutterBottom"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-10 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -2247,11 +2850,11 @@ exports[`renders as expected 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-12"
+      class="makeStyles-addMetric-14"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-13"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-15"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -2274,6 +2877,35 @@ exports[`renders as expected 1`] = `
           class="MuiTouchRipple-root"
         />
       </button>
+    </div>
+    <div
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-11 MuiPaper-elevation0"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message"
+      >
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-exposure-event-and-when-do-i-need-it"
+        >
+          What is an Exposure Event? And when do I need it?
+        </a>
+      </div>
     </div>
   </div>
 </div>

--- a/src/components/experiments/wizard/__snapshots__/Metrics.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/Metrics.test.tsx.snap
@@ -161,6 +161,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-primary-metric"
+          target="_blank"
         >
           How do I choose a Primary Metric?
         </a>
@@ -168,6 +169,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-minimum-difference-practically-equivalent-value-for-my-metrics"
+          target="_blank"
         >
           How do I choose a Minimum Difference?
         </a>
@@ -175,6 +177,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-does-change-expected-mean-for-a-metric"
+          target="_blank"
         >
           What is Change Expected?
         </a>
@@ -182,6 +185,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-attribution-window-for-a-metric"
+          target="_blank"
         >
           What is an Attribution Window?
         </a>
@@ -271,6 +275,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-exposure-event-and-when-do-i-need-it"
+          target="_blank"
         >
           What is an Exposure Event? And when do I need it?
         </a>
@@ -441,6 +446,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-primary-metric"
+          target="_blank"
         >
           How do I choose a Primary Metric?
         </a>
@@ -448,6 +454,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-minimum-difference-practically-equivalent-value-for-my-metrics"
+          target="_blank"
         >
           How do I choose a Minimum Difference?
         </a>
@@ -455,6 +462,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-does-change-expected-mean-for-a-metric"
+          target="_blank"
         >
           What is Change Expected?
         </a>
@@ -462,6 +470,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-attribution-window-for-a-metric"
+          target="_blank"
         >
           What is an Attribution Window?
         </a>
@@ -551,6 +560,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-exposure-event-and-when-do-i-need-it"
+          target="_blank"
         >
           What is an Exposure Event? And when do I need it?
         </a>
@@ -888,6 +898,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-primary-metric"
+          target="_blank"
         >
           How do I choose a Primary Metric?
         </a>
@@ -895,6 +906,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-minimum-difference-practically-equivalent-value-for-my-metrics"
+          target="_blank"
         >
           How do I choose a Minimum Difference?
         </a>
@@ -902,6 +914,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-does-change-expected-mean-for-a-metric"
+          target="_blank"
         >
           What is Change Expected?
         </a>
@@ -909,6 +922,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-attribution-window-for-a-metric"
+          target="_blank"
         >
           What is an Attribution Window?
         </a>
@@ -998,6 +1012,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-exposure-event-and-when-do-i-need-it"
+          target="_blank"
         >
           What is an Exposure Event? And when do I need it?
         </a>
@@ -1337,6 +1352,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-primary-metric"
+          target="_blank"
         >
           How do I choose a Primary Metric?
         </a>
@@ -1344,6 +1360,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-minimum-difference-practically-equivalent-value-for-my-metrics"
+          target="_blank"
         >
           How do I choose a Minimum Difference?
         </a>
@@ -1351,6 +1368,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-does-change-expected-mean-for-a-metric"
+          target="_blank"
         >
           What is Change Expected?
         </a>
@@ -1358,6 +1376,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-attribution-window-for-a-metric"
+          target="_blank"
         >
           What is an Attribution Window?
         </a>
@@ -1447,6 +1466,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-exposure-event-and-when-do-i-need-it"
+          target="_blank"
         >
           What is an Exposure Event? And when do I need it?
         </a>
@@ -1784,6 +1804,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-primary-metric"
+          target="_blank"
         >
           How do I choose a Primary Metric?
         </a>
@@ -1791,6 +1812,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-minimum-difference-practically-equivalent-value-for-my-metrics"
+          target="_blank"
         >
           How do I choose a Minimum Difference?
         </a>
@@ -1798,6 +1820,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-does-change-expected-mean-for-a-metric"
+          target="_blank"
         >
           What is Change Expected?
         </a>
@@ -1805,6 +1828,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-attribution-window-for-a-metric"
+          target="_blank"
         >
           What is an Attribution Window?
         </a>
@@ -1894,6 +1918,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-exposure-event-and-when-do-i-need-it"
+          target="_blank"
         >
           What is an Exposure Event? And when do I need it?
         </a>
@@ -2064,6 +2089,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-primary-metric"
+          target="_blank"
         >
           How do I choose a Primary Metric?
         </a>
@@ -2071,6 +2097,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-minimum-difference-practically-equivalent-value-for-my-metrics"
+          target="_blank"
         >
           How do I choose a Minimum Difference?
         </a>
@@ -2078,6 +2105,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-does-change-expected-mean-for-a-metric"
+          target="_blank"
         >
           What is Change Expected?
         </a>
@@ -2085,6 +2113,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-attribution-window-for-a-metric"
+          target="_blank"
         >
           What is an Attribution Window?
         </a>
@@ -2174,6 +2203,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-exposure-event-and-when-do-i-need-it"
+          target="_blank"
         >
           What is an Exposure Event? And when do I need it?
         </a>
@@ -2512,6 +2542,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-primary-metric"
+          target="_blank"
         >
           How do I choose a Primary Metric?
         </a>
@@ -2519,6 +2550,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-minimum-difference-practically-equivalent-value-for-my-metrics"
+          target="_blank"
         >
           How do I choose a Minimum Difference?
         </a>
@@ -2526,6 +2558,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-does-change-expected-mean-for-a-metric"
+          target="_blank"
         >
           What is Change Expected?
         </a>
@@ -2533,6 +2566,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-attribution-window-for-a-metric"
+          target="_blank"
         >
           What is an Attribution Window?
         </a>
@@ -2622,6 +2656,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-exposure-event-and-when-do-i-need-it"
+          target="_blank"
         >
           What is an Exposure Event? And when do I need it?
         </a>
@@ -2792,6 +2827,7 @@ exports[`renders as expected 1`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-primary-metric"
+          target="_blank"
         >
           How do I choose a Primary Metric?
         </a>
@@ -2799,6 +2835,7 @@ exports[`renders as expected 1`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-minimum-difference-practically-equivalent-value-for-my-metrics"
+          target="_blank"
         >
           How do I choose a Minimum Difference?
         </a>
@@ -2806,6 +2843,7 @@ exports[`renders as expected 1`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-does-change-expected-mean-for-a-metric"
+          target="_blank"
         >
           What is Change Expected?
         </a>
@@ -2813,6 +2851,7 @@ exports[`renders as expected 1`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-attribution-window-for-a-metric"
+          target="_blank"
         >
           What is an Attribution Window?
         </a>
@@ -2902,6 +2941,7 @@ exports[`renders as expected 1`] = `
         <a
           class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-exposure-event-and-when-do-i-need-it"
+          target="_blank"
         >
           What is an Exposure Event? And when do I need it?
         </a>


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR adds info boxes with links to the Wiki for Metrics and Exposure Events:**

<img width="675" alt="Screen Shot 2020-12-15 at 3 28 53 pm" src="https://user-images.githubusercontent.com/971886/102184636-baab7400-3eea-11eb-9727-3d81d75b1044.png">

Fixes #426 

<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
