### PR TITLE
Add generic HttpResponseErrors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38253,6 +38253,11 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
+    "wretch": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/wretch/-/wretch-1.7.4.tgz",
+      "integrity": "sha512-gBET7PgqgJ89GPBHujw0+arM/8YtWPqG6od8dRMTumvr3xvSlONpp2ANYqbpSL+cSoe6g97quZTgwM0jNn6riA=="
+    },
     "write": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17547,6 +17547,47 @@
         "pend": "~1.2.0"
       }
     },
+    "fetch-mock": {
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
+      "integrity": "sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.0.0",
+        "@babel/runtime": "^7.0.0",
+        "core-js": "^3.0.0",
+        "debug": "^4.1.1",
+        "glob-to-regexp": "^0.4.0",
+        "is-subset": "^0.1.1",
+        "lodash.isequal": "^4.5.0",
+        "path-to-regexp": "^2.2.1",
+        "querystring": "^0.2.0",
+        "whatwg-url": "^6.5.0"
+      },
+      "dependencies": {
+        "glob-to-regexp": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+          "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+          "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+          "dev": true
+        }
+      }
+    },
+    "fetch-mock-jest": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/fetch-mock-jest/-/fetch-mock-jest-1.5.1.tgz",
+      "integrity": "sha512-+utwzP8C+Pax1GSka3nFXILWMY3Er2L+s090FOgqVNrNCPp0fDqgXnAHAJf12PLHi0z4PhcTaZNTz8e7K3fjqQ==",
+      "dev": true,
+      "requires": {
+        "fetch-mock": "^9.11.0"
+      }
+    },
     "figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -20235,6 +20276,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
       "integrity": "sha512-9H+ZBCVs3L9OYqv8nuUAzpcT9OTgMD1yAWrG7ihlnibdkbtB850heAmYWxHuXc4CHy4lKeK69tN+ny1K7gBIrw=="
+    },
+    "is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+      "dev": true
     },
     "is-svg": {
       "version": "3.0.0",
@@ -24991,6 +25038,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -36359,6 +36412,15 @@
         "punycode": "^2.1.1"
       }
     },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -37289,6 +37351,12 @@
         "get-canvas-context": "^1.0.1"
       }
     },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
     "webpack": {
       "version": "4.44.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.2.tgz",
@@ -37759,6 +37827,17 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
       "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
+    },
+    "whatwg-url": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
     },
     "which": {
       "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19487,6 +19487,11 @@
         "sshpk": "^1.7.0"
       }
     },
+    "http-status-codes": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.1.4.tgz",
+      "integrity": "sha512-MZVIsLKGVOVE1KEnldppe6Ij+vmemMuApDfjhVSLzyYP+td0bREEYyAoIw9yFePoBXManCuBqmiNP5FqJS5Xkg=="
+    },
     "https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19070,7 +19070,8 @@
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "optional": true
     },
     "gud": {
       "version": "1.0.0",
@@ -26213,6 +26214,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -26226,6 +26228,7 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
           "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+          "optional": true,
           "requires": {
             "is-docker": "^2.0.0"
           }
@@ -26234,6 +26237,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "optional": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -26242,6 +26246,7 @@
           "version": "7.3.4",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -26249,12 +26254,14 @@
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "optional": true
         },
         "which": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -26262,7 +26269,8 @@
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "optional": true
         }
       }
     },
@@ -34790,7 +34798,8 @@
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "optional": true
     },
     "side-channel": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "eslint-plugin-react": "^7.20.3",
     "eslint-plugin-react-hooks": "^4.0.8",
     "eslint-plugin-simple-import-sort": "^5.0.3",
+    "fetch-mock-jest": "^1.5.1",
     "full-icu": "^1.3.1",
     "husky": "^4.2.5",
     "isomorphic-fetch": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-plotly.js": "^2.5.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^4.0.0",
+    "wretch": "^1.7.4",
     "yup": "^0.29.1"
   },
   "@comment devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "formik": "^2.1.4",
     "formik-material-ui": "^3.0.0",
     "formik-material-ui-lab": "0.0.5",
+    "http-status-codes": "^2.1.4",
     "isomorphic-unfetch": "^3.0.0",
     "lodash": "^4.17.19",
     "material-table": "^1.59.0",

--- a/src/__tests__/api/AutocompleteApi.test.ts
+++ b/src/__tests__/api/AutocompleteApi.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/require-await */
 import { getEventNameCompletions, getPropNameCompletions, getUserCompletions } from 'src/api/AutocompleteApi'
-import NotFoundError from 'src/api/NotFoundError'
+import HttpResponseError from 'src/api/HttpResponseError'
 import * as Utils from 'src/api/utils'
 
 jest.mock('src/api/utils')
@@ -74,7 +74,7 @@ test('an empty event name returns a useful error message', async () => {
 
 test('a nonexistent event name returns a useful error message', async () => {
   mockedUtils.fetchApi.mockImplementation(async () => {
-    throw new NotFoundError()
+    throw new HttpResponseError(404)
   })
   expect(await getPropNameCompletions('no_exist')).toMatchInlineSnapshot(`null`)
 })

--- a/src/__tests__/api/AutocompleteApi.test.ts
+++ b/src/__tests__/api/AutocompleteApi.test.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/require-await */
+import { StatusCodes } from 'http-status-codes'
+
 import { getEventNameCompletions, getPropNameCompletions, getUserCompletions } from 'src/api/AutocompleteApi'
 import HttpResponseError from 'src/api/HttpResponseError'
 import * as Utils from 'src/api/utils'
@@ -74,7 +76,7 @@ test('an empty event name returns a useful error message', async () => {
 
 test('a nonexistent event name returns a useful error message', async () => {
   mockedUtils.fetchApi.mockImplementation(async () => {
-    throw new HttpResponseError(404)
+    throw new HttpResponseError(StatusCodes.NOT_FOUND)
   })
   expect(await getPropNameCompletions('no_exist')).toMatchInlineSnapshot(`null`)
 })

--- a/src/__tests__/api/HttpResponseError.test.ts
+++ b/src/__tests__/api/HttpResponseError.test.ts
@@ -1,0 +1,16 @@
+import { WretcherError } from "wretch"
+import HttpResponseError, { wretcherErrorToHttpResponseError } from "../../api/HttpResponseError"
+
+describe('HttpResponseError.ts module', () => {
+  describe('wretcherErrorToHttpResponseError', () => {
+      it('should return a correct HttpResponseError', () => {
+          const error : WretcherError = new Error() as WretcherError
+          error.status = 404
+          error.message = 'Not Found'
+          error.json = {foo: 'bar'}
+          const httpResponseError = wretcherErrorToHttpResponseError(error)
+          expect(httpResponseError).toBeInstanceOf(HttpResponseError)
+          expect(httpResponseError).toMatchInlineSnapshot()
+      })
+    })
+})

--- a/src/__tests__/api/HttpResponseError.test.ts
+++ b/src/__tests__/api/HttpResponseError.test.ts
@@ -1,3 +1,4 @@
+import { StatusCodes } from 'http-status-codes'
 import { WretcherError } from 'wretch'
 
 import HttpResponseError, { wretcherErrorToHttpResponseError } from '../../api/HttpResponseError'
@@ -6,7 +7,7 @@ describe('HttpResponseError.ts module', () => {
   describe('wretcherErrorToHttpResponseError', () => {
     it('should return a correct HttpResponseError', () => {
       const error: WretcherError = new Error() as WretcherError
-      error.status = 404
+      error.status = StatusCodes.NOT_FOUND
       ;(error.response as unknown) = { statusText: 'Not Found' }
       error.message = 'Not Found'
       error.json = { foo: 'bar' }

--- a/src/__tests__/api/HttpResponseError.test.ts
+++ b/src/__tests__/api/HttpResponseError.test.ts
@@ -1,16 +1,18 @@
-import { WretcherError } from "wretch"
-import HttpResponseError, { wretcherErrorToHttpResponseError } from "../../api/HttpResponseError"
+import { WretcherError } from 'wretch'
+
+import HttpResponseError, { wretcherErrorToHttpResponseError } from '../../api/HttpResponseError'
 
 describe('HttpResponseError.ts module', () => {
   describe('wretcherErrorToHttpResponseError', () => {
-      it('should return a correct HttpResponseError', () => {
-          const error : WretcherError = new Error() as WretcherError
-          error.status = 404
-          error.message = 'Not Found'
-          error.json = {foo: 'bar'}
-          const httpResponseError = wretcherErrorToHttpResponseError(error)
-          expect(httpResponseError).toBeInstanceOf(HttpResponseError)
-          expect(httpResponseError).toMatchInlineSnapshot()
-      })
+    it('should return a correct HttpResponseError', () => {
+      const error: WretcherError = new Error() as WretcherError
+      error.status = 404
+      ;(error.response as unknown) = { statusText: 'Not Found' }
+      error.message = 'Not Found'
+      error.json = { foo: 'bar' }
+      const httpResponseError = wretcherErrorToHttpResponseError(error)
+      expect(httpResponseError).toBeInstanceOf(HttpResponseError)
+      expect(httpResponseError).toMatchInlineSnapshot(`[HttpResponseError: 404 Not Found]`)
     })
+  })
 })

--- a/src/__tests__/api/MetricsApi.test.ts
+++ b/src/__tests__/api/MetricsApi.test.ts
@@ -80,7 +80,7 @@ describe('MetricsApi.ts module', () => {
         expect(false).toBe(true) // This should never be reached.
       } catch (err) {
         expect(err).toBeInstanceOf(HttpResponseError)
-        expect(err).toBe(StatusCodes.NOT_FOUND)
+        expect((err as HttpResponseError).status).toBe(StatusCodes.NOT_FOUND)
       }
     })
   })

--- a/src/__tests__/api/MetricsApi.test.ts
+++ b/src/__tests__/api/MetricsApi.test.ts
@@ -1,3 +1,5 @@
+import { StatusCodes } from 'http-status-codes'
+
 import HttpResponseError from 'src/api/HttpResponseError'
 import MetricsApi from 'src/api/MetricsApi'
 import { metricFullNewOutboundSchema, TransactionTypes } from 'src/lib/schemas'
@@ -78,7 +80,7 @@ describe('MetricsApi.ts module', () => {
         expect(false).toBe(true) // This should never be reached.
       } catch (err) {
         expect(err).toBeInstanceOf(HttpResponseError)
-        expect(err).toBe(404)
+        expect(err).toBe(StatusCodes.NOT_FOUND)
       }
     })
   })

--- a/src/__tests__/api/MetricsApi.test.ts
+++ b/src/__tests__/api/MetricsApi.test.ts
@@ -1,5 +1,5 @@
-import MetricsApi from 'src/api/MetricsApi'
 import HttpResponseError from 'src/api/HttpResponseError'
+import MetricsApi from 'src/api/MetricsApi'
 import { metricFullNewOutboundSchema, TransactionTypes } from 'src/lib/schemas'
 import Fixtures from 'src/test-helpers/fixtures'
 import { validationErrorDisplayer } from 'src/test-helpers/test-utils'

--- a/src/__tests__/api/MetricsApi.test.ts
+++ b/src/__tests__/api/MetricsApi.test.ts
@@ -1,5 +1,5 @@
 import MetricsApi from 'src/api/MetricsApi'
-import NotFoundError from 'src/api/NotFoundError'
+import HttpResponseError from 'src/api/HttpResponseError'
 import { metricFullNewOutboundSchema, TransactionTypes } from 'src/lib/schemas'
 import Fixtures from 'src/test-helpers/fixtures'
 import { validationErrorDisplayer } from 'src/test-helpers/test-utils'
@@ -77,7 +77,8 @@ describe('MetricsApi.ts module', () => {
         await MetricsApi.findById(0)
         expect(false).toBe(true) // This should never be reached.
       } catch (err) {
-        expect(err).toBeInstanceOf(NotFoundError)
+        expect(err).toBeInstanceOf(HttpResponseError)
+        expect(err).toBe(404)
       }
     })
   })

--- a/src/__tests__/api/TagsApi.test.ts
+++ b/src/__tests__/api/TagsApi.test.ts
@@ -59,7 +59,9 @@ describe('TagsApi.ts module', () => {
         expect(false).toBe(true) // This should never be reached.
       } catch (err) {
         expect(err).toBeInstanceOf(HttpResponseError)
-        expect(err.status).toBe(404)
+        if (err instanceof HttpResponseError) {
+          expect(err.status).toBe(404)
+        }
       }
     })
   })

--- a/src/__tests__/api/TagsApi.test.ts
+++ b/src/__tests__/api/TagsApi.test.ts
@@ -1,3 +1,4 @@
+import { StatusCodes } from 'http-status-codes'
 import HttpResponseError from 'src/api/HttpResponseError'
 import TagsApi from 'src/api/TagsApi'
 import { tagFullNewOutboundSchema } from 'src/lib/schemas'
@@ -59,9 +60,7 @@ describe('TagsApi.ts module', () => {
         expect(false).toBe(true) // This should never be reached.
       } catch (err) {
         expect(err).toBeInstanceOf(HttpResponseError)
-        if (err instanceof HttpResponseError) {
-          expect(err.status).toBe(404)
-        }
+        expect((err as HttpResponseError).status).toBe(StatusCodes.NOT_FOUND)
       }
     })
   })

--- a/src/__tests__/api/TagsApi.test.ts
+++ b/src/__tests__/api/TagsApi.test.ts
@@ -1,4 +1,5 @@
 import { StatusCodes } from 'http-status-codes'
+
 import HttpResponseError from 'src/api/HttpResponseError'
 import TagsApi from 'src/api/TagsApi'
 import { tagFullNewOutboundSchema } from 'src/lib/schemas'

--- a/src/__tests__/api/TagsApi.test.ts
+++ b/src/__tests__/api/TagsApi.test.ts
@@ -1,4 +1,4 @@
-import NotFoundError from 'src/api/NotFoundError'
+import HttpResponseError from 'src/api/HttpResponseError'
 import TagsApi from 'src/api/TagsApi'
 import { tagFullNewOutboundSchema } from 'src/lib/schemas'
 import Fixtures from 'src/test-helpers/fixtures'
@@ -58,7 +58,8 @@ describe('TagsApi.ts module', () => {
         await TagsApi.findById(0)
         expect(false).toBe(true) // This should never be reached.
       } catch (err) {
-        expect(err).toBeInstanceOf(NotFoundError)
+        expect(err).toBeInstanceOf(HttpResponseError)
+        expect(err.status).toBe(404)
       }
     })
   })

--- a/src/__tests__/api/utils.test.ts
+++ b/src/__tests__/api/utils.test.ts
@@ -36,7 +36,7 @@ describe('utils.ts module', () => {
     it('should return a correct HttpResponseError for a bad HTTP request', async () => {
       expect.assertions(3)
       fetchMock.once('*', {
-        status: 400,
+        status: StatusCodes.BAD_REQUEST,
         body: '{"code":"invalid_name","message":"The experiment name is already taken","data":{"status":400}}',
       })
 
@@ -45,11 +45,11 @@ describe('utils.ts module', () => {
       } catch (error) {
         expect(error).toBeInstanceOf(HttpResponseError)
         if (error instanceof HttpResponseError) {
-          expect(error.status).toBe(400)
+          expect(error.status).toBe(StatusCodes.BAD_REQUEST)
           expect(error.json).toEqual({
             code: 'invalid_name',
             data: {
-              status: 400,
+              status: StatusCodes.BAD_REQUEST,
             },
             message: 'The experiment name is already taken',
           })

--- a/src/__tests__/api/utils.test.ts
+++ b/src/__tests__/api/utils.test.ts
@@ -1,5 +1,6 @@
-import HttpResponseError from 'src/api/HttpResponseError'
 import fetchMock from 'fetch-mock-jest'
+
+import HttpResponseError from 'src/api/HttpResponseError'
 import { fetchApi } from 'src/api/utils'
 
 fetchMock.config.overwriteRoutes = true
@@ -39,17 +40,17 @@ describe('utils.ts module', () => {
       })
 
       try {
-        const resp = await fetchApi('GET', '/')
+        await fetchApi('GET', '/')
       } catch (error) {
         expect(error).toBeInstanceOf(HttpResponseError)
         if (error instanceof HttpResponseError) {
           expect(error.status).toBe(400)
           expect(error.json).toEqual({
-            "code": "invalid_name",
-            "data": {
-              "status": 400,
+            code: 'invalid_name',
+            data: {
+              status: 400,
             },
-            "message": "The experiment name is already taken",
+            message: 'The experiment name is already taken',
           })
         }
       }

--- a/src/__tests__/api/utils.test.ts
+++ b/src/__tests__/api/utils.test.ts
@@ -1,0 +1,58 @@
+import HttpResponseError from 'src/api/HttpResponseError'
+import fetchMock from 'fetch-mock-jest'
+import { fetchApi } from 'src/api/utils'
+
+fetchMock.config.overwriteRoutes = true
+
+describe('utils.ts module', () => {
+  describe('fetchApi errors correctly', () => {
+    it('should return no error for a good request', async () => {
+      fetchMock.once('*', {
+        status: 200,
+        body: '{ "foo": 123 }',
+      })
+
+      const res = await fetchApi('GET', '/')
+      expect(res).toEqual({ foo: 123 })
+    })
+
+    it('should return an error if thrown and not an HttpResponseError', async () => {
+      expect.assertions(3)
+      fetchMock.once('*', { throws: new Error('Error Message') })
+
+      try {
+        await fetchApi('GET', '/')
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error)
+        if (error instanceof Error) {
+          expect(error.name).toBe('Error')
+          expect(error.message).toBe('Error Message')
+        }
+      }
+    })
+
+    it('should return a correct HttpResponseError for a bad HTTP request', async () => {
+      expect.assertions(3)
+      fetchMock.once('*', {
+        status: 400,
+        body: '{"code":"invalid_name","message":"The experiment name is already taken","data":{"status":400}}',
+      })
+
+      try {
+        const resp = await fetchApi('GET', '/')
+      } catch (error) {
+        expect(error).toBeInstanceOf(HttpResponseError)
+        if (error instanceof HttpResponseError) {
+          expect(error.status).toBe(400)
+          expect(error.json).toEqual({
+            "code": "invalid_name",
+            "data": {
+              "status": 400,
+            },
+            "message": "The experiment name is already taken",
+          })
+        }
+      }
+    })
+  })
+})

--- a/src/__tests__/api/utils.test.ts
+++ b/src/__tests__/api/utils.test.ts
@@ -1,4 +1,5 @@
 import fetchMock from 'fetch-mock-jest'
+import { StatusCodes } from 'http-status-codes'
 
 import HttpResponseError from 'src/api/HttpResponseError'
 import { fetchApi } from 'src/api/utils'
@@ -9,7 +10,7 @@ describe('utils.ts module', () => {
   describe('fetchApi errors correctly', () => {
     it('should return no error for a good request', async () => {
       fetchMock.once('*', {
-        status: 200,
+        status: StatusCodes.OK,
         body: '{ "foo": 123 }',
       })
 

--- a/src/api/AutocompleteApi.ts
+++ b/src/api/AutocompleteApi.ts
@@ -1,5 +1,6 @@
 import { fetchApi } from 'src/api/utils'
 import { AutocompleteItem, autocompleteSchema, eventDetailsSchema } from 'src/lib/schemas'
+
 import HttpResponseError from './HttpResponseError'
 
 async function getCompletion(name: string) {

--- a/src/api/AutocompleteApi.ts
+++ b/src/api/AutocompleteApi.ts
@@ -1,7 +1,6 @@
 import { fetchApi } from 'src/api/utils'
 import { AutocompleteItem, autocompleteSchema, eventDetailsSchema } from 'src/lib/schemas'
-
-import NotFoundError from './NotFoundError'
+import HttpResponseError from './HttpResponseError'
 
 async function getCompletion(name: string) {
   return await autocompleteSchema.validate(await fetchApi('GET', `/autocomplete/${name}`), { abortEarly: false })
@@ -28,7 +27,7 @@ export async function getPropNameCompletions(eventName: string): Promise<Autocom
     }))
   } catch (error) {
     // istanbul ignore else; Forced to use the else here to prevent two istanbul ignores
-    if (error instanceof NotFoundError) {
+    if (error instanceof HttpResponseError && error.status === 404) {
       return null
     } else {
       throw error

--- a/src/api/AutocompleteApi.ts
+++ b/src/api/AutocompleteApi.ts
@@ -1,3 +1,5 @@
+import { StatusCodes } from 'http-status-codes'
+
 import { fetchApi } from 'src/api/utils'
 import { AutocompleteItem, autocompleteSchema, eventDetailsSchema } from 'src/lib/schemas'
 
@@ -28,7 +30,7 @@ export async function getPropNameCompletions(eventName: string): Promise<Autocom
     }))
   } catch (error) {
     // istanbul ignore else; Forced to use the else here to prevent two istanbul ignores
-    if (error instanceof HttpResponseError && error.status === 404) {
+    if (error instanceof HttpResponseError && error.status === StatusCodes.NOT_FOUND) {
       return null
     } else {
       throw error

--- a/src/api/HttpResponseError.ts
+++ b/src/api/HttpResponseError.ts
@@ -1,42 +1,43 @@
-import { WretcherError as WretcherError, WretcherResponse } from 'wretch'
+import { WretcherError, WretcherResponse } from 'wretch'
 
 /**
  * A HTTP Error we receive from the server.
- * 
+ *
  * WretcherError gets close but isn't friendly enough.
  */
 export default class HttpResponseError extends Error implements WretcherError {
-    public status: number
-    public response: WretcherResponse
-    public text?: string
-    public json?: Object
-    public name = 'HttpResponseError'
+  public status: number
+  public response: WretcherResponse
+  public text?: string
+  public json?: unknown
+  public name = 'HttpResponseError'
 
-    /**
-     * This constructor is only for mocking.
-     * @param status 
-     */
-    constructor(status: number, ...vendorSpecificParams: unknown[]) {
-        // @ts-ignore vendorSpecificParams
-        super(`${status}`, ...vendorSpecificParams)
-        this.status = status
-    }
+  /**
+   * This constructor is only for mocking.
+   * @param status
+   */
+  constructor(status: number, ...vendorSpecificParams: unknown[]) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore vendorSpecificParams
+    super(`${status}`, ...vendorSpecificParams)
+    this.status = status
+  }
 }
 
 /**
  * Transform a WretcherError to HttpResponseError
- * 
+ *
  * Only necessary as a WretcherError isn't a named error :/
- * 
- * @param wretcherError 
+ *
+ * @param wretcherError
  */
 export function wretcherErrorToHttpResponseError(wretcherError: WretcherError): HttpResponseError {
-    wretcherError.name = 'HttpResponseError'
-    wretcherError.message = `${wretcherError.status} ${wretcherError.response.statusText}`
-    Object.setPrototypeOf(wretcherError, HttpResponseError.prototype)
-    // istanbul ignore next; V8 engine only
-    if (Error.captureStackTrace) {
-        Error.captureStackTrace(wretcherError, HttpResponseError);
-    }
-    return wretcherError
+  wretcherError.name = 'HttpResponseError'
+  wretcherError.message = `${wretcherError.status} ${wretcherError.response.statusText}`
+  Object.setPrototypeOf(wretcherError, HttpResponseError.prototype)
+  // istanbul ignore next; V8 engine only
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(wretcherError, HttpResponseError)
+  }
+  return wretcherError
 }

--- a/src/api/HttpResponseError.ts
+++ b/src/api/HttpResponseError.ts
@@ -1,0 +1,42 @@
+import { WretcherError as WretcherError, WretcherResponse } from 'wretch'
+
+/**
+ * A HTTP Error we receive from the server.
+ * 
+ * WretcherError gets close but isn't friendly enough.
+ */
+export default class HttpResponseError extends Error implements WretcherError {
+    public status: number
+    public response: WretcherResponse
+    public text?: string
+    public json?: Object
+    public name = 'HttpResponseError'
+
+    /**
+     * This constructor is only for mocking.
+     * @param status 
+     */
+    constructor(status: number, ...vendorSpecificParams: unknown[]) {
+        // @ts-ignore vendorSpecificParams
+        super(`${status}`, ...vendorSpecificParams)
+        this.status = status
+    }
+}
+
+/**
+ * Transform a WretcherError to HttpResponseError
+ * 
+ * Only necessary as a WretcherError isn't a named error :/
+ * 
+ * @param wretcherError 
+ */
+export function wretcherErrorToHttpResponseError(wretcherError: WretcherError): HttpResponseError {
+    wretcherError.name = 'HttpResponseError'
+    wretcherError.message = `${wretcherError.status} ${wretcherError.response.statusText}`
+    Object.setPrototypeOf(wretcherError, HttpResponseError.prototype)
+    // istanbul ignore next; V8 engine only
+    if (Error.captureStackTrace) {
+        Error.captureStackTrace(wretcherError, HttpResponseError);
+    }
+    return wretcherError
+}

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,62 +1,66 @@
+import wretch from 'wretch'
+
 import { config } from 'src/config'
 import { getExperimentsAuthInfo } from 'src/utils/auth'
 
-import NotFoundError from './NotFoundError'
 import UnauthorizedError from './UnauthorizedError'
+import { wretcherErrorToHttpResponseError } from './HttpResponseError'
 
 /**
+ * ExPlat API Wretcher (Fetch Wrapper)
+ * See wretch docs for more info
+ * 
  * Makes a request to the Experiment Platform's API with any necessary
  * authorization information, parses the response as JSON, and returns the parsed
  * response.
  *
  * Note: Be sure to handle any errors that may be thrown.
  *
- * @throws UnauthorizedError
+ * @throws UnauthorizedError HttpResponseError
  */
-async function fetchApi(method: string, path: string, body: unknown | null = null): Promise<unknown> {
-  /* istanbul ignore next; code branch not reachable in integration tests -- we don't hit production */
-  const apiUrlRoot = config.experimentApi.rootUrl
-
-  const headers = new Headers()
-  /* istanbul ignore next; code branch not reachable in integration tests -- we don't hit production */
-  if (config.experimentApi.needsAuth) {
-    const accessToken = getExperimentsAuthInfo()?.accessToken
-    if (!accessToken) {
-      throw new UnauthorizedError()
+export const exPlatWretcher = wretch()
+  .url(config.experimentApi.rootUrl)
+  // Get access token at call time
+  .defer((wretcher) => {
+    /* istanbul ignore next; code branch not reachable in integration tests -- we don't hit production */
+    if (config.experimentApi.needsAuth) {
+      const accessToken = getExperimentsAuthInfo()?.accessToken
+      if (!accessToken) {
+        throw new UnauthorizedError()
+      }
+      return wretcher.auth(`Bearer ${accessToken}`)
     }
-    headers.append('Authorization', `Bearer ${accessToken}`)
-  }
-
-  if (body !== null) {
-    headers.append('Content-Type', 'application/json')
-  }
-
-  const response = await fetch(`${apiUrlRoot}${path}`, {
-    method,
-    headers,
-    body: body === null ? null : JSON.stringify(body),
+    return wretcher
+  })
+  // This would ideally be JSON but can't be due to the below reasons.
+  .errorType('text')
+  // This is messy as our responses are non-standard:
+  // Everything should ideally return JSON, and at least if it doesn't it should return 204 No-Content
+  .resolve(async (resolver) => {
+    try {
+      const textResponse = await (await resolver.res()).text()
+      if (textResponse === '') {
+        return undefined
+      } else {
+        return JSON.parse(textResponse) as unknown
+      }
+    } catch (error) {
+      // We wrap WretcherErrors here:
+      if (typeof error.status === 'number') {
+        error.json = error.text === '' ? undefined : JSON.parse(error.text)
+        throw wretcherErrorToHttpResponseError(error)
+      }
+      throw error
+    }
   })
 
-  // istanbul ignore next; branch can't be reached with the current tests.
-  if (response.status === 404) {
-    throw new NotFoundError()
+/**
+ * Wrapper for the ExPlat Wretcher
+ */
+export async function fetchApi(method: 'GET' | 'PUT' | 'POST' | 'PATCH' | 'DELETE', path: string, body: unknown | null = null): Promise<unknown> {
+  if (method === 'GET' || method === 'DELETE') {
+    return exPlatWretcher.url(path)[method.toLowerCase() as 'get' | 'delete']()
+  } else {
+    return exPlatWretcher.url(path)[method.toLowerCase() as 'put' | 'post' | 'patch'](body)
   }
-
-  // istanbul ignore next; branch can't be reached with the current tests.
-  if (response.status >= 300 || response.status < 200) {
-    throw new Error('Received a non-2XX response from server.')
-  }
-
-  // Sometimes we don't have a JSON response but this abstraction was built as if all returns were JSON.
-  // This is unfortunately the best way I can see to deal with it.
-  // We lose the streaming parsing of fetch, but it shouldn't be a performance problem for now.
-  //
-  // TODO: Should return the response object so the function calling can decide how to parse the result.
-  const responseText = await response.text()
-  if (responseText === '') {
-    return
-  }
-  return JSON.parse(responseText) as unknown
 }
-
-export { fetchApi }

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -53,9 +53,12 @@ export const exPlatWretcher = wretch()
         return JSON.parse(textResponse) as unknown
       }
     } catch (error) {
-      // We wrap WretcherErrors here:
       if (isWretcherError(error)) {
-        ;(error.json as unknown) = error.text === '' || error.text === undefined ? undefined : JSON.parse(error.text)
+        // Due to non-standard responses:
+        // istanbul ignore next; Main case is tested, edge cases shouldn't occur
+        const json = error.text === '' || error.text === undefined ? undefined : JSON.parse(error.text)
+        // Have to have this line separate as the semicolon interferes with istanbul:
+        ;(error.json as unknown) = json
         throw wretcherErrorToHttpResponseError(error)
       }
       throw error

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -56,7 +56,7 @@ export const exPlatWretcher = wretch()
       if (isWretcherError(error)) {
         // Due to non-standard responses:
         // istanbul ignore next; Main case is tested, edge cases shouldn't occur
-        const json = error.text === '' || error.text === undefined ? undefined : JSON.parse(error.text)
+        const json: unknown = error.text === '' || error.text === undefined ? undefined : JSON.parse(error.text)
         // Have to have this line separate as the semicolon interferes with istanbul:
         ;(error.json as unknown) = json
         throw wretcherErrorToHttpResponseError(error)

--- a/src/components/experiments/wizard/ExperimentForm.test.tsx
+++ b/src/components/experiments/wizard/ExperimentForm.test.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/require-await,@typescript-eslint/ban-ts-comment */
 
 import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import { StatusCodes } from 'http-status-codes'
 import _ from 'lodash'
 import noop from 'lodash/noop'
 import MockDate from 'mockdate'
@@ -354,7 +355,7 @@ test('form submits with valid fields', async () => {
   let submittedData: unknown = null
   const onSubmit = async (formData: unknown): Promise<undefined> => {
     // We need to add a timeout here so the loading indicator renders
-    await new Promise((resolve) => setTimeout(resolve, 200))
+    await new Promise((resolve) => setTimeout(resolve, StatusCodes.OK))
     submittedData = formData
     return
   }
@@ -565,7 +566,7 @@ test('form submits an edited experiment without any changes', async () => {
   let submittedData: unknown = null
   const onSubmit = async (formData: unknown): Promise<undefined> => {
     // We need to add a timeout here so the loading indicator renders
-    await new Promise((resolve) => setTimeout(resolve, 200))
+    await new Promise((resolve) => setTimeout(resolve, StatusCodes.OK))
     submittedData = formData
     return
   }


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
This PR adds generic `HttpResponseError`:
- Cleans up `fetchApi` by using a fetch library.
- Consolidates http errors into a single HttpResponseError.
- `fetchApi` is now tested and the underlying code is battle-tested
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Resolves #300 
Makes easy: #415 

## How has this been tested?

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
