### PR TITLE
Fix ROPE scaling in plots

### DIFF
--- a/src/components/experiments/single-view/results/CondensedLatestAnalyses.tsx
+++ b/src/components/experiments/single-view/results/CondensedLatestAnalyses.tsx
@@ -352,7 +352,7 @@ function AnalysisDetailPanel({
     {
       name: 'ROPE: lower bound',
       x: dates,
-      y: analyses.map((_) => -metricAssignment.minDifference).map(estimateTransform),
+      y: analyses.map((_) => -metricAssignment.minDifference),
       line: {
         color: 'rgba(0,0,0,.4)',
         dash: 'dash',
@@ -363,7 +363,7 @@ function AnalysisDetailPanel({
     {
       name: 'ROPE: upper bound',
       x: dates,
-      y: analyses.map((_) => metricAssignment.minDifference).map(estimateTransform),
+      y: analyses.map((_) => metricAssignment.minDifference),
       line: {
         color: 'rgba(0,0,0,.4)',
         dash: 'dash',
@@ -447,7 +447,7 @@ function AnalysisDetailPanel({
         <Plot
           layout={{
             ...Visualizations.plotlyLayoutDefault,
-            title: isConversion ? `Conversion rate difference estimates (%)` : `Revenue difference estimates ($)`,
+            title: isConversion ? `Conversion rate difference estimates (Percentage Points)` : `Revenue difference estimates ($)`,
           }}
           data={plotlyDataDifferenceGraph}
           className={classes.metricEstimatePlot}

--- a/src/components/experiments/single-view/results/CondensedLatestAnalyses.tsx
+++ b/src/components/experiments/single-view/results/CondensedLatestAnalyses.tsx
@@ -447,7 +447,9 @@ function AnalysisDetailPanel({
         <Plot
           layout={{
             ...Visualizations.plotlyLayoutDefault,
-            title: isConversion ? `Conversion rate difference estimates (Percentage Points)` : `Revenue difference estimates ($)`,
+            title: isConversion
+              ? `Conversion rate difference estimates (Percentage Points)`
+              : `Revenue difference estimates ($)`,
           }}
           data={plotlyDataDifferenceGraph}
           className={classes.metricEstimatePlot}

--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -631,7 +631,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               "2020-05-10T00:00:00.000Z",
             ],
             "y": Array [
-              -1200,
+              -12,
             ],
           },
           Object {
@@ -646,7 +646,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               "2020-05-10T00:00:00.000Z",
             ],
             "y": Array [
-              1200,
+              12,
             ],
           },
         ],
@@ -663,7 +663,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             "t": 64,
           },
           "showlegend": false,
-          "title": "Conversion rate difference estimates (%)",
+          "title": "Conversion rate difference estimates (Percentage Points)",
         },
         "style": Object {
           "display": "inline-block",


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR fixes rope scaling in plots.**
- Also renames `%` to `Percentage Points` for the diff graph.

<img width="1137" alt="Screen Shot 2021-01-12 at 12 52 59 pm" src="https://user-images.githubusercontent.com/971886/104319574-04a06d80-551c-11eb-8f60-e46241ce71ef.png">

<!-- Remember to include context: Why is this change required? What problem does it solve? -->
Resolves #435 
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
