### PR TITLE
Fix edit exposure event with no props

### DIFF
--- a/src/components/experiments/single-view/overview/__snapshots__/AudiencePanel.test.tsx.snap
+++ b/src/components/experiments/single-view/overview/__snapshots__/AudiencePanel.test.tsx.snap
@@ -1225,6 +1225,15 @@ exports[`renders as expected with all segments resolvable 1`] = `
                   prop3Value
                 </span>
               </p>
+              <p
+                class="MuiTypography-root makeStyles-monospace-60 MuiTypography-body1"
+              >
+                <span
+                  class="makeStyles-eventName-58"
+                >
+                  event_without_props
+                </span>
+              </p>
             </div>
           </td>
         </tr>
@@ -1542,6 +1551,15 @@ exports[`renders as expected with existing users allowed 1`] = `
                   additionalProp3
                   : 
                   prop3Value
+                </span>
+              </p>
+              <p
+                class="MuiTypography-root makeStyles-monospace-45 MuiTypography-body1"
+              >
+                <span
+                  class="makeStyles-eventName-43"
+                >
+                  event_without_props
                 </span>
               </p>
             </div>
@@ -1863,6 +1881,15 @@ exports[`renders as expected with no exclusion groups 1`] = `
                   prop3Value
                 </span>
               </p>
+              <p
+                class="MuiTypography-root makeStyles-monospace-30 MuiTypography-body1"
+              >
+                <span
+                  class="makeStyles-eventName-28"
+                >
+                  event_without_props
+                </span>
+              </p>
             </div>
           </td>
         </tr>
@@ -2154,6 +2181,15 @@ exports[`renders as expected with no segment assignments 1`] = `
                   additionalProp3
                   : 
                   prop3Value
+                </span>
+              </p>
+              <p
+                class="MuiTypography-root makeStyles-monospace-15 MuiTypography-body1"
+              >
+                <span
+                  class="makeStyles-eventName-13"
+                >
+                  event_without_props
                 </span>
               </p>
             </div>

--- a/src/components/experiments/single-view/overview/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/src/components/experiments/single-view/overview/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -698,6 +698,15 @@ exports[`renders as expected at large width 1`] = `
                       prop3Value
                     </span>
                   </p>
+                  <p
+                    class="MuiTypography-root makeStyles-monospace-35 MuiTypography-body1"
+                  >
+                    <span
+                      class="makeStyles-eventName-33"
+                    >
+                      event_without_props
+                    </span>
+                  </p>
                 </div>
               </td>
             </tr>
@@ -1209,6 +1218,15 @@ exports[`renders as expected at small width 1`] = `
                           additionalProp3
                           : 
                           prop3Value
+                        </span>
+                      </p>
+                      <p
+                        class="MuiTypography-root makeStyles-monospace-70 MuiTypography-body1"
+                      >
+                        <span
+                          class="makeStyles-eventName-68"
+                        >
+                          event_without_props
                         </span>
                       </p>
                     </div>
@@ -1946,6 +1964,15 @@ exports[`renders as expected with conclusion data 1`] = `
                           additionalProp3
                           : 
                           prop3Value
+                        </span>
+                      </p>
+                      <p
+                        class="MuiTypography-root makeStyles-monospace-107 MuiTypography-body1"
+                      >
+                        <span
+                          class="makeStyles-eventName-105"
+                        >
+                          event_without_props
                         </span>
                       </p>
                     </div>
@@ -2787,6 +2814,15 @@ exports[`renders as expected without conclusion data 1`] = `
                           additionalProp3
                           : 
                           prop3Value
+                        </span>
+                      </p>
+                      <p
+                        class="MuiTypography-root makeStyles-monospace-142 MuiTypography-body1"
+                      >
+                        <span
+                          class="makeStyles-eventName-140"
+                        >
+                          event_without_props
                         </span>
                       </p>
                     </div>

--- a/src/components/experiments/wizard/ExperimentForm.test.tsx
+++ b/src/components/experiments/wizard/ExperimentForm.test.tsx
@@ -628,9 +628,7 @@ test('form submits an edited experiment without any changes', async () => {
   // @ts-ignore
   newShapedExperiment.variations.forEach((variation) => delete variation.variationId)
   newShapedExperiment.exposureEvents?.forEach((exposureEvent) => {
-    if (exposureEvent.props) {
-      exposureEvent.props = _.toPairs(exposureEvent.props).map(([key, value]) => ({ key, value }))
-    }
+    exposureEvent.props = _.toPairs(exposureEvent.props || {}).map(([key, value]) => ({ key, value }))
   })
 
   expect(validatedExperiment).toEqual(newShapedExperiment)

--- a/src/lib/form-data.test.ts
+++ b/src/lib/form-data.test.ts
@@ -67,6 +67,10 @@ describe('lib/form-data.test.ts module', () => {
                 },
               ],
             },
+            Object {
+              "event": "event_without_props",
+              "props": Array [],
+            },
           ],
           "metricAssignments": Array [
             Object {

--- a/src/lib/form-data.ts
+++ b/src/lib/form-data.ts
@@ -64,7 +64,7 @@ function variationToFormData(variation: Variation): VariationFormData {
 function exposureEventToFormData(exposureEvent: Event): ExposureEventFormData {
   return {
     event: exposureEvent.event,
-    props: Object.entries(exposureEvent.props as Record<string, unknown>).map(([key, value]) => ({ key, value })),
+    props: Object.entries(exposureEvent.props || {}).map(([key, value]) => ({ key, value })),
   }
 }
 

--- a/src/test-helpers/fixtures.ts
+++ b/src/test-helpers/fixtures.ts
@@ -414,6 +414,9 @@ function createExperimentFull(fieldOverrides: Partial<ExperimentFull> = {}): Exp
           additionalProp3: 'prop3Value',
         },
       },
+      {
+        event: 'event_without_props',
+      },
     ],
     exclusionGroupTagIds: [1],
     ...existingExperimentFieldOverrides,


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR fixes a new bug where editing an exposure event with no props crashes.**
- Also adds exposure event with no props to the fixtures.
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
- Additional manual testing instructions (please specify):
Visit: `/experiments/20073-explat-test-scjr-2021-01-14-21-55/wizard-edit`