### PR TITLE
Prompt on Experiment Creation form navigate-away

### DIFF
--- a/src/components/experiments/wizard/ExperimentForm.tsx
+++ b/src/components/experiments/wizard/ExperimentForm.tsx
@@ -190,7 +190,7 @@ const ExperimentForm = ({
 
         return (
           <div className={classes.root}>
-            <Prompt when={formikProps.dirty} message='You have unsaved data, are you sure you want to leave?' />
+            <Prompt when={formikProps.dirty && !formikProps.isSubmitting} message='You have unsaved data, are you sure you want to leave?' />
             <div className={classes.navigation}>
               <Stepper nonLinear activeStep={currentStageId} orientation='vertical'>
                 {stages.map((stage) => (

--- a/src/components/experiments/wizard/ExperimentForm.tsx
+++ b/src/components/experiments/wizard/ExperimentForm.tsx
@@ -275,7 +275,7 @@ const ExperimentForm = ({
                       </Typography>
                       <Typography variant='body2' gutterBottom>
                         Now is a good time to{' '}
-                        <Link href='https://github.com/Automattic/experimentation-platform/wiki'>
+                        <Link href='https://github.com/Automattic/experimentation-platform/wiki' target='_blank'>
                           check our wiki&apos;s experiment creation checklist
                         </Link>{' '}
                         and confirm everything is in place.

--- a/src/components/experiments/wizard/ExperimentForm.tsx
+++ b/src/components/experiments/wizard/ExperimentForm.tsx
@@ -190,7 +190,10 @@ const ExperimentForm = ({
 
         return (
           <div className={classes.root}>
-            <Prompt when={formikProps.dirty && !formikProps.isSubmitting} message='You have unsaved data, are you sure you want to leave?' />
+            <Prompt
+              when={formikProps.dirty && !formikProps.isSubmitting}
+              message='You have unsaved data, are you sure you want to leave?'
+            />
             <div className={classes.navigation}>
               <Stepper nonLinear activeStep={currentStageId} orientation='vertical'>
                 {stages.map((stage) => (

--- a/src/components/experiments/wizard/ExperimentForm.tsx
+++ b/src/components/experiments/wizard/ExperimentForm.tsx
@@ -3,6 +3,7 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import { Formik } from 'formik'
 import _ from 'lodash'
 import React, { useEffect, useRef, useState } from 'react'
+import { Prompt } from 'react-router-dom'
 import * as yup from 'yup'
 
 import GeneralErrorAlert from 'src/components/general/GeneralErrorAlert'
@@ -189,6 +190,7 @@ const ExperimentForm = ({
 
         return (
           <div className={classes.root}>
+            <Prompt when={formikProps.dirty} message='You have unsaved data, are you sure you want to leave?' />
             <div className={classes.navigation}>
               <Stepper nonLinear activeStep={currentStageId} orientation='vertical'>
                 {stages.map((stage) => (

--- a/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
@@ -1812,6 +1812,7 @@ exports[`sections should be browsable by the section buttons 3`] = `
               <a
                 class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
                 href="https://github.com/Automattic/experimentation-platform/wiki"
+                target="_blank"
               >
                 check our wiki's experiment creation checklist
               </a>
@@ -2739,6 +2740,7 @@ exports[`skipping to submit should check all sections 1`] = `
               <a
                 class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
                 href="https://github.com/Automattic/experimentation-platform/wiki"
+                target="_blank"
               >
                 check our wiki's experiment creation checklist
               </a>


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR adds a prompt on navigate-away of the Experiment Creation form to prevent data loss.**
- Also makes the checklist linked in the submit form-part open in a new window.
<img width="1051" alt="Screen Shot 2021-01-19 at 9 41 09 pm" src="https://user-images.githubusercontent.com/971886/105042748-93266900-5a9f-11eb-8b7d-c0c6862e448e.png">

Fixes #450 

<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
   - Check that form warns on navigate away
   - Check that submission happens successfully
