### PR TITLE
Removes nav_unification hacks.

### DIFF
--- a/src/components/experiments/single-view/ExperimentDisableButton.tsx
+++ b/src/components/experiments/single-view/ExperimentDisableButton.tsx
@@ -33,8 +33,7 @@ const ExperimentDisableButton = ({
 
   const { enqueueSnackbar } = useSnackbar()
 
-  const canDisableExperiment =
-    experiment && experiment.status !== Status.Disabled && experiment.name !== 'nav_unification_v2'
+  const canDisableExperiment = experiment && experiment.status !== Status.Disabled
   const [isAskingToConfirmDisableExperiment, setIsAskingToConfirmDisableExperiment] = useState<boolean>(false)
   const onAskToConfirmDisableExperiment = () => setIsAskingToConfirmDisableExperiment(true)
   const onCancelDisableExperiment = () => setIsAskingToConfirmDisableExperiment(false)

--- a/src/components/experiments/single-view/ExperimentPageView.tsx
+++ b/src/components/experiments/single-view/ExperimentPageView.tsx
@@ -145,7 +145,7 @@ export default function ExperimentPageView({
 
   const isLoading = or(experimentIsLoading, metricsIsLoading, segmentsIsLoading, tagsIsLoading, analysesIsLoading)
 
-  const canEditInWizard = experiment && experiment.status === Status.Staging && experiment.name !== 'nav_unification_v2'
+  const canEditInWizard = experiment && experiment.status === Status.Staging
 
   const experimentIdSlug = createIdSlug(experimentId, experiment?.name || '')
 

--- a/src/components/experiments/single-view/ExperimentRunButton.tsx
+++ b/src/components/experiments/single-view/ExperimentRunButton.tsx
@@ -38,8 +38,7 @@ const ExperimentRunButton = ({
   const dangerClasses = useDangerStyles()
   const { enqueueSnackbar } = useSnackbar()
 
-  const canRunExperiment =
-    experiment && experiment.status === Status.Staging && experiment.name !== 'nav_unification_v2'
+  const canRunExperiment = experiment && experiment.status === Status.Staging
   const [isAskingToConfirmRunExperiment, setIsAskingToConfirmRunExperiment] = useState<boolean>(false)
   const onAskToConfirmRunExperiment = () => setIsAskingToConfirmRunExperiment(true)
   const onCancelRunExperiment = () => setIsAskingToConfirmRunExperiment(false)


### PR DESCRIPTION
This PR aims to reverse https://github.com/Automattic/abacus/pull/418. After the launch of nav-unification to all a12s this hacks are no longer needed (p7DVsv-ago-p2). I have also disabled the experiment which can now be safely deleted. There are no useful data about it.

<!-- Describe your changes in detail. -->
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

* Run `REACT_APP_PRODUCTION_CONFIG_IN_DEVELOPMENT=true npm run dev`
* Navigate to a `staging` experiment and make sure that buttons are still active
* 
![](https://cln.sh/HxdRgQ+)