### PR TITLE
Remove default platform from wizard

### DIFF
--- a/src/components/experiments/wizard/Audience.tsx
+++ b/src/components/experiments/wizard/Audience.tsx
@@ -160,7 +160,10 @@ const Audience = ({
       <div className={classes.row}>
         <FormControl component='fieldset'>
           <FormLabel required>Platform</FormLabel>
-          <Field component={Select} name='experiment.platform'>
+          <Field component={Select} name='experiment.platform' displayEmpty>
+            <MenuItem value='' disabled>
+              Select a Platform
+            </MenuItem>
             {Object.values(Platform).map((platform) => (
               <MenuItem key={platform} value={platform}>
                 {platform}: {PlatformToHuman[platform]}

--- a/src/components/experiments/wizard/ExperimentForm.test.tsx
+++ b/src/components/experiments/wizard/ExperimentForm.test.tsx
@@ -338,13 +338,13 @@ test('skipping to submit should check all sections', async () => {
 
   expect(isSectionError(startSectionButton)).toBe(true)
   expect(isSectionError(basicInfoSectionButton)).toBe(true)
-  expect(isSectionError(audienceSectionButton)).toBe(false)
+  expect(isSectionError(audienceSectionButton)).toBe(true)
   expect(isSectionError(metricsSectionButton)).toBe(true)
   expect(isSectionError(submitSectionButton)).toBe(false)
 
   expect(isSectionComplete(startSectionButton)).toBe(false)
   expect(isSectionComplete(basicInfoSectionButton)).toBe(false)
-  expect(isSectionComplete(audienceSectionButton)).toBe(true)
+  expect(isSectionComplete(audienceSectionButton)).toBe(false)
   expect(isSectionComplete(metricsSectionButton)).toBe(false)
   expect(isSectionComplete(submitSectionButton)).toBe(false)
 })
@@ -406,6 +406,19 @@ test('form submits with valid fields', async () => {
 
   // ### Audience
   screen.getByText(/Define Your Audience/)
+
+  const platformField = screen.getByRole('button', { name: /Select a Platform/ })
+  await act(async () => {
+    fireEvent.focus(platformField)
+  })
+  await act(async () => {
+    fireEvent.keyDown(platformField, { key: 'Enter' })
+  })
+  const platformOption = await screen.findByRole('option', { name: /wpcom/ })
+  await act(async () => {
+    fireEvent.click(platformOption)
+  })
+
   const targetingField = screen.getByRole('textbox', { name: /Targeting/ })
   fireEvent.change(targetingField, { target: { value: 'segment_3' } })
   const targetingOption = await screen.findByRole('option', { name: /Locale: segment_3/ })

--- a/src/components/experiments/wizard/__snapshots__/Audience.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/Audience.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`renders as expected 1`] = `
         class="MuiFormControl-root"
       >
         <label
-          class="MuiFormLabel-root MuiFormLabel-filled Mui-required"
+          class="MuiFormLabel-root Mui-required"
         >
           Platform
           <span
@@ -39,14 +39,12 @@ exports[`renders as expected 1`] = `
             role="button"
             tabindex="0"
           >
-            wpcom
-            : 
-            WordPress.com back-end
+            Select a Platform
           </div>
           <input
             name="experiment.platform"
             type="hidden"
-            value="wpcom"
+            value=""
           />
           <svg
             aria-hidden="true"
@@ -716,7 +714,7 @@ exports[`renders as expected 2`] = `
         class="MuiFormControl-root"
       >
         <label
-          class="MuiFormLabel-root MuiFormLabel-filled Mui-required"
+          class="MuiFormLabel-root Mui-required"
         >
           Platform
           <span
@@ -738,14 +736,12 @@ exports[`renders as expected 2`] = `
             role="button"
             tabindex="0"
           >
-            wpcom
-            : 
-            WordPress.com back-end
+            Select a Platform
           </div>
           <input
             name="experiment.platform"
             type="hidden"
-            value="wpcom"
+            value=""
           />
           <svg
             aria-hidden="true"

--- a/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
@@ -1643,7 +1643,7 @@ exports[`sections should be browsable by the section buttons 3`] = `
           />
         </div>
         <div
-          class="MuiStep-root MuiStep-vertical MuiStep-completed"
+          class="MuiStep-root MuiStep-vertical"
         >
           <button
             class="MuiButtonBase-root MuiStepButton-root MuiStepButton-vertical"
@@ -1651,19 +1651,19 @@ exports[`sections should be browsable by the section buttons 3`] = `
             type="button"
           >
             <span
-              class="MuiStepLabel-root MuiStepLabel-vertical"
+              class="MuiStepLabel-root MuiStepLabel-vertical Mui-error"
             >
               <span
                 class="MuiStepLabel-iconContainer"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiStepIcon-root MuiStepIcon-completed"
+                  class="MuiSvgIcon-root MuiStepIcon-root Mui-error"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
                   <path
-                    d="M12 0a12 12 0 1 0 0 24 12 12 0 0 0 0-24zm-2 17l-5-5 1.4-1.4 3.6 3.6 7.6-7.6L19 8l-9 9z"
+                    d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
                   />
                 </svg>
               </span>
@@ -1671,7 +1671,7 @@ exports[`sections should be browsable by the section buttons 3`] = `
                 class="MuiStepLabel-labelContainer"
               >
                 <span
-                  class="MuiTypography-root MuiStepLabel-label MuiStepLabel-completed MuiTypography-body2 MuiTypography-displayBlock"
+                  class="MuiTypography-root MuiStepLabel-label Mui-error MuiTypography-body2 MuiTypography-displayBlock"
                 >
                   Audience
                 </span>
@@ -1979,7 +1979,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
           />
         </div>
         <div
-          class="MuiStep-root MuiStep-vertical MuiStep-completed"
+          class="MuiStep-root MuiStep-vertical"
         >
           <button
             class="MuiButtonBase-root MuiStepButton-root MuiStepButton-vertical"
@@ -1987,19 +1987,19 @@ exports[`sections should be browsable by the section buttons 4`] = `
             type="button"
           >
             <span
-              class="MuiStepLabel-root MuiStepLabel-vertical"
+              class="MuiStepLabel-root MuiStepLabel-vertical Mui-error"
             >
               <span
                 class="MuiStepLabel-iconContainer"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiStepIcon-root MuiStepIcon-completed"
+                  class="MuiSvgIcon-root MuiStepIcon-root Mui-error"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
                   <path
-                    d="M12 0a12 12 0 1 0 0 24 12 12 0 0 0 0-24zm-2 17l-5-5 1.4-1.4 3.6 3.6 7.6-7.6L19 8l-9 9z"
+                    d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
                   />
                 </svg>
               </span>
@@ -2007,7 +2007,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
                 class="MuiStepLabel-labelContainer"
               >
                 <span
-                  class="MuiTypography-root MuiStepLabel-label MuiStepLabel-completed MuiTypography-body2 MuiTypography-displayBlock"
+                  class="MuiTypography-root MuiStepLabel-label Mui-error MuiTypography-body2 MuiTypography-displayBlock"
                 >
                   Audience
                 </span>
@@ -2571,7 +2571,7 @@ exports[`skipping to submit should check all sections 1`] = `
           />
         </div>
         <div
-          class="MuiStep-root MuiStep-vertical MuiStep-completed"
+          class="MuiStep-root MuiStep-vertical"
         >
           <button
             class="MuiButtonBase-root MuiStepButton-root MuiStepButton-vertical"
@@ -2579,19 +2579,19 @@ exports[`skipping to submit should check all sections 1`] = `
             type="button"
           >
             <span
-              class="MuiStepLabel-root MuiStepLabel-vertical"
+              class="MuiStepLabel-root MuiStepLabel-vertical Mui-error"
             >
               <span
                 class="MuiStepLabel-iconContainer"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiStepIcon-root MuiStepIcon-completed"
+                  class="MuiSvgIcon-root MuiStepIcon-root Mui-error"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
                   <path
-                    d="M12 0a12 12 0 1 0 0 24 12 12 0 0 0 0-24zm-2 17l-5-5 1.4-1.4 3.6 3.6 7.6-7.6L19 8l-9 9z"
+                    d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
                   />
                 </svg>
               </span>
@@ -2599,7 +2599,7 @@ exports[`skipping to submit should check all sections 1`] = `
                 class="MuiStepLabel-labelContainer"
               >
                 <span
-                  class="MuiTypography-root MuiStepLabel-label MuiStepLabel-completed MuiTypography-body2 MuiTypography-displayBlock"
+                  class="MuiTypography-root MuiStepLabel-label Mui-error MuiTypography-body2 MuiTypography-displayBlock"
                 >
                   Audience
                 </span>

--- a/src/lib/form-data.test.ts
+++ b/src/lib/form-data.test.ts
@@ -20,7 +20,7 @@ describe('lib/form-data.test.ts module', () => {
           "name": "",
           "ownerLogin": "",
           "p2Url": "",
-          "platform": "wpcom",
+          "platform": "",
           "segmentAssignments": Array [],
           "startDatetime": "",
           "variations": Array [

--- a/src/lib/form-data.ts
+++ b/src/lib/form-data.ts
@@ -6,7 +6,6 @@ import {
   MetricAssignment,
   MetricFull,
   MetricParameterType,
-  Platform,
   SegmentAssignment,
   TagBare,
   Variation,

--- a/src/lib/form-data.ts
+++ b/src/lib/form-data.ts
@@ -99,7 +99,7 @@ export function experimentToFormData(
       experiment.existingUsersAllowed === undefined
         ? 'true'
         : (String(experiment.existingUsersAllowed) as 'true' | 'false'),
-    platform: experiment.platform ?? Platform.Wpcom,
+    platform: experiment.platform ?? '',
     metricAssignments: experiment.metricAssignments ? experiment.metricAssignments.map(metricAssignmentToFormData) : [],
     segmentAssignments: experiment.segmentAssignments
       ? experiment.segmentAssignments.map(segmentAssignmentToFormData)


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR removes the default platform from the Experiment Wizard.**

<img width="758" alt="Screen Shot 2021-02-02 at 4 13 28 pm" src="https://user-images.githubusercontent.com/971886/106577685-9f1f2a00-6579-11eb-8226-6df0036e4476.png">

Resolves #453 
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
