### PR TITLE
Add wpandroid and wpios as new platforms

### DIFF
--- a/src/lib/experiments.ts
+++ b/src/lib/experiments.ts
@@ -42,5 +42,7 @@ export const PlatformToHuman: Record<Platform, string> = {
   [Platform.Calypso]: 'Calypso front-end',
   [Platform.Email]: 'Guides and other email systems',
   [Platform.Pipe]: 'Machine learning pipeline',
+  [Platform.Wpandroid]: 'WordPress Android app',
   [Platform.Wpcom]: 'WordPress.com back-end',
+  [Platform.Wpios]: 'WordPress iOS app',
 }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -243,7 +243,9 @@ export enum Platform {
   Calypso = 'calypso',
   Email = 'email',
   Pipe = 'pipe',
+  Wpandroid = 'wpandroid',
   Wpcom = 'wpcom',
+  Wpios = 'wpios',
 }
 
 export enum Status {


### PR DESCRIPTION
Adds the platforms `wpandroid` and `wpios` to Abacus! I'll merge this after the backend adjustments have been merged.

## How has this been tested?

- Automated tests that cover added/changed functionality
- Manual testing with mock data (locally or on Vercel)

![Screen Shot 2021-02-18 at 1 44 53 PM](https://user-images.githubusercontent.com/4505888/108425915-fcf57800-71ef-11eb-9fa2-21a06a5321ce.png)

