### PR TITLE
Add an assignment cache indicator to the experiment overview

### DIFF
--- a/src/components/experiments/single-view/overview/GeneralPanel.test.tsx
+++ b/src/components/experiments/single-view/overview/GeneralPanel.test.tsx
@@ -189,6 +189,26 @@ test('renders as expected', () => {
                 </a>
               </td>
             </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <th
+                class="MuiTableCell-root MuiTableCell-head"
+                role="cell"
+                scope="row"
+              >
+                Assignment Cache Entry
+              </th>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+              >
+                <span
+                  class="makeStyles-monospace-5"
+                >
+                  Fresh: The cache matches the database for this experiment
+                </span>
+              </td>
+            </tr>
           </tbody>
         </table>
       </div>

--- a/src/components/experiments/single-view/overview/GeneralPanel.test.tsx
+++ b/src/components/experiments/single-view/overview/GeneralPanel.test.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/require-await, no-irregular-whitespace */
 import { fireEvent, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react'
 import { noop } from 'lodash'
 import MockDate from 'mockdate'
@@ -206,6 +206,16 @@ test('renders as expected', () => {
                   class="makeStyles-monospace-5"
                 >
                   Fresh: The cache matches the database for this experiment
+                   (
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+                    href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#the-file-system-cache"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    learn more
+                  </a>
+                  )
                 </span>
               </td>
             </tr>

--- a/src/components/experiments/single-view/overview/GeneralPanel.test.tsx
+++ b/src/components/experiments/single-view/overview/GeneralPanel.test.tsx
@@ -205,7 +205,7 @@ test('renders as expected', () => {
                 <span
                   class="makeStyles-monospace-5"
                 >
-                  ✅ Fresh: The cache matches the database for this experiment
+                  ✅ Fresh: Production cache is up to date, but manual sandbox updates may be needed
                    (
                   <a
                     class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"

--- a/src/components/experiments/single-view/overview/GeneralPanel.test.tsx
+++ b/src/components/experiments/single-view/overview/GeneralPanel.test.tsx
@@ -205,7 +205,7 @@ test('renders as expected', () => {
                 <span
                   class="makeStyles-monospace-5"
                 >
-                  Fresh: The cache matches the database for this experiment
+                  ✅ Fresh: The cache matches the database for this experiment
                    (
                   <a
                     class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"

--- a/src/components/experiments/single-view/overview/GeneralPanel.tsx
+++ b/src/components/experiments/single-view/overview/GeneralPanel.tsx
@@ -105,7 +105,18 @@ function GeneralPanel({
     {
       label: 'Assignment Cache Entry',
       value: (
-        <span className={classes.monospace}>{AssignmentCacheStatusToHuman[experiment.assignmentCacheStatus]}</span>
+        <span className={classes.monospace}>
+          {AssignmentCacheStatusToHuman[experiment.assignmentCacheStatus]}&nbsp;(
+          <Link
+            href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#the-file-system-cache"
+            rel='noopener noreferrer'
+            target='_blank'
+            underline='always'
+          >
+            learn more
+          </Link>
+          )
+        </span>
       ),
     },
   ]

--- a/src/components/experiments/single-view/overview/GeneralPanel.tsx
+++ b/src/components/experiments/single-view/overview/GeneralPanel.tsx
@@ -29,6 +29,7 @@ import LabelValueTable from 'src/components/general/LabelValueTable'
 import { ExperimentFull, experimentFullSchema, Status, yupPick } from 'src/lib/schemas'
 import { formatIsoDate } from 'src/utils/time'
 
+import { AssignmentCacheStatusToHuman } from '../../../../lib/experiments'
 import LoadingButtonContainer from '../../../general/LoadingButtonContainer'
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -99,6 +100,12 @@ function GeneralPanel({
         <Link href={experiment.p2Url} rel='noopener noreferrer' target='_blank' className={classes.monospace}>
           {experiment.p2Url}
         </Link>
+      ),
+    },
+    {
+      label: 'Assignment Cache Entry',
+      value: (
+        <span className={classes.monospace}>{AssignmentCacheStatusToHuman[experiment.assignmentCacheStatus]}</span>
       ),
     },
   ]

--- a/src/components/experiments/single-view/overview/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/src/components/experiments/single-view/overview/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -195,7 +195,7 @@ exports[`renders as expected at large width 1`] = `
                     <span
                       class="makeStyles-monospace-5"
                     >
-                      Fresh: The cache matches the database for this experiment
+                      ✅ Fresh: The cache matches the database for this experiment
                        (
                       <a
                         class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
@@ -965,7 +965,7 @@ exports[`renders as expected at small width 1`] = `
                     <span
                       class="makeStyles-monospace-40"
                     >
-                      Fresh: The cache matches the database for this experiment
+                      ✅ Fresh: The cache matches the database for this experiment
                        (
                       <a
                         class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
@@ -1737,7 +1737,7 @@ exports[`renders as expected with conclusion data 1`] = `
                     <span
                       class="makeStyles-monospace-75"
                     >
-                      Fresh: The cache matches the database for this experiment
+                      ✅ Fresh: The cache matches the database for this experiment
                        (
                       <a
                         class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
@@ -2613,7 +2613,7 @@ exports[`renders as expected without conclusion data 1`] = `
                     <span
                       class="makeStyles-monospace-112"
                     >
-                      Fresh: The cache matches the database for this experiment
+                      ✅ Fresh: The cache matches the database for this experiment
                        (
                       <a
                         class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"

--- a/src/components/experiments/single-view/overview/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/src/components/experiments/single-view/overview/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -195,7 +195,7 @@ exports[`renders as expected at large width 1`] = `
                     <span
                       class="makeStyles-monospace-5"
                     >
-                      ✅ Fresh: The cache matches the database for this experiment
+                      ✅ Fresh: Production cache is up to date, but manual sandbox updates may be needed
                        (
                       <a
                         class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
@@ -965,7 +965,7 @@ exports[`renders as expected at small width 1`] = `
                     <span
                       class="makeStyles-monospace-40"
                     >
-                      ✅ Fresh: The cache matches the database for this experiment
+                      ✅ Fresh: Production cache is up to date, but manual sandbox updates may be needed
                        (
                       <a
                         class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
@@ -1737,7 +1737,7 @@ exports[`renders as expected with conclusion data 1`] = `
                     <span
                       class="makeStyles-monospace-75"
                     >
-                      ✅ Fresh: The cache matches the database for this experiment
+                      ✅ Fresh: Production cache is up to date, but manual sandbox updates may be needed
                        (
                       <a
                         class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
@@ -2613,7 +2613,7 @@ exports[`renders as expected without conclusion data 1`] = `
                     <span
                       class="makeStyles-monospace-112"
                     >
-                      ✅ Fresh: The cache matches the database for this experiment
+                      ✅ Fresh: Production cache is up to date, but manual sandbox updates may be needed
                        (
                       <a
                         class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"

--- a/src/components/experiments/single-view/overview/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/src/components/experiments/single-view/overview/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -179,6 +179,26 @@ exports[`renders as expected at large width 1`] = `
                     </a>
                   </td>
                 </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="cell"
+                    scope="row"
+                  >
+                    Assignment Cache Entry
+                  </th>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    <span
+                      class="makeStyles-monospace-5"
+                    >
+                      Fresh: The cache matches the database for this experiment
+                    </span>
+                  </td>
+                </tr>
               </tbody>
             </table>
           </div>
@@ -917,6 +937,26 @@ exports[`renders as expected at small width 1`] = `
                     >
                       https://wordpress.com/experiment_1
                     </a>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="cell"
+                    scope="row"
+                  >
+                    Assignment Cache Entry
+                  </th>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    <span
+                      class="makeStyles-monospace-40"
+                    >
+                      Fresh: The cache matches the database for this experiment
+                    </span>
                   </td>
                 </tr>
               </tbody>
@@ -1659,6 +1699,26 @@ exports[`renders as expected with conclusion data 1`] = `
                     >
                       https://wordpress.com/experiment_1
                     </a>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="cell"
+                    scope="row"
+                  >
+                    Assignment Cache Entry
+                  </th>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    <span
+                      class="makeStyles-monospace-75"
+                    >
+                      Fresh: The cache matches the database for this experiment
+                    </span>
                   </td>
                 </tr>
               </tbody>
@@ -2505,6 +2565,26 @@ exports[`renders as expected without conclusion data 1`] = `
                     >
                       https://wordpress.com/experiment_1
                     </a>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head"
+                    role="cell"
+                    scope="row"
+                  >
+                    Assignment Cache Entry
+                  </th>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body"
+                  >
+                    <span
+                      class="makeStyles-monospace-112"
+                    >
+                      Fresh: The cache matches the database for this experiment
+                    </span>
                   </td>
                 </tr>
               </tbody>

--- a/src/components/experiments/single-view/overview/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/src/components/experiments/single-view/overview/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -196,6 +196,16 @@ exports[`renders as expected at large width 1`] = `
                       class="makeStyles-monospace-5"
                     >
                       Fresh: The cache matches the database for this experiment
+                       (
+                      <a
+                        class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+                        href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#the-file-system-cache"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        learn more
+                      </a>
+                      )
                     </span>
                   </td>
                 </tr>
@@ -956,6 +966,16 @@ exports[`renders as expected at small width 1`] = `
                       class="makeStyles-monospace-40"
                     >
                       Fresh: The cache matches the database for this experiment
+                       (
+                      <a
+                        class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+                        href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#the-file-system-cache"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        learn more
+                      </a>
+                      )
                     </span>
                   </td>
                 </tr>
@@ -1718,6 +1738,16 @@ exports[`renders as expected with conclusion data 1`] = `
                       class="makeStyles-monospace-75"
                     >
                       Fresh: The cache matches the database for this experiment
+                       (
+                      <a
+                        class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+                        href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#the-file-system-cache"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        learn more
+                      </a>
+                      )
                     </span>
                   </td>
                 </tr>
@@ -2584,6 +2614,16 @@ exports[`renders as expected without conclusion data 1`] = `
                       class="makeStyles-monospace-112"
                     >
                       Fresh: The cache matches the database for this experiment
+                       (
+                      <a
+                        class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+                        href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#the-file-system-cache"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        learn more
+                      </a>
+                      )
                     </span>
                   </td>
                 </tr>

--- a/src/components/experiments/wizard/ExperimentForm.test.tsx
+++ b/src/components/experiments/wizard/ExperimentForm.test.tsx
@@ -626,14 +626,15 @@ test('form submits an edited experiment without any changes', async () => {
   )
 
   // We need to remove Ids, status, conclusion data, reformat exposure events to make it like new
-  const newShapedExperiment = _.clone(experiment)
-  // @ts-ignore
-  delete newShapedExperiment.experimentId
-  // @ts-ignore
-  delete newShapedExperiment.status
-  delete newShapedExperiment.conclusionUrl
-  delete newShapedExperiment.deployedVariationId
-  delete newShapedExperiment.endReason
+  const newShapedExperiment = _.omit(
+    _.clone(experiment),
+    'experimentId',
+    'status',
+    'assignmentCacheStatus',
+    'conclusionUrl',
+    'deployedVariationId',
+    'endReason',
+  )
   // @ts-ignore
   newShapedExperiment.metricAssignments.forEach((metricAssignment) => delete metricAssignment.metricAssignmentId)
   // @ts-ignore

--- a/src/lib/experiments.ts
+++ b/src/lib/experiments.ts
@@ -49,6 +49,6 @@ export const PlatformToHuman: Record<Platform, string> = {
 
 export const AssignmentCacheStatusToHuman: Record<AssignmentCacheStatus, string> = {
   [AssignmentCacheStatus.Fresh]: 'Fresh: The cache matches the database for this experiment',
-  [AssignmentCacheStatus.Missing]: 'Missing: Expected for new or disabled experiments',
+  [AssignmentCacheStatus.Missing]: 'Missing: Expected for new, renamed, or disabled experiments',
   [AssignmentCacheStatus.Stale]: 'Stale: Recent changes take up to ten minutes to propagate',
 }

--- a/src/lib/experiments.ts
+++ b/src/lib/experiments.ts
@@ -1,4 +1,4 @@
-import { AnalysisStrategy, ExperimentFull, Platform, Variation } from './schemas'
+import { AnalysisStrategy, AssignmentCacheStatus, ExperimentFull, Platform, Variation } from './schemas'
 
 /**
  * Return the deployed variation if one has been selected, otherwise `null`.
@@ -45,4 +45,10 @@ export const PlatformToHuman: Record<Platform, string> = {
   [Platform.Wpandroid]: 'WordPress Android app',
   [Platform.Wpcom]: 'WordPress.com back-end',
   [Platform.Wpios]: 'WordPress iOS app',
+}
+
+export const AssignmentCacheStatusToHuman: Record<AssignmentCacheStatus, string> = {
+  [AssignmentCacheStatus.Fresh]: 'Fresh: The cache matches the database for this experiment',
+  [AssignmentCacheStatus.Missing]: 'Missing: Expected for new or disabled experiments',
+  [AssignmentCacheStatus.Stale]: 'Stale: Recent changes take up to ten minutes to propagate',
 }

--- a/src/lib/experiments.ts
+++ b/src/lib/experiments.ts
@@ -48,7 +48,7 @@ export const PlatformToHuman: Record<Platform, string> = {
 }
 
 export const AssignmentCacheStatusToHuman: Record<AssignmentCacheStatus, string> = {
-  [AssignmentCacheStatus.Fresh]: 'Fresh: The cache matches the database for this experiment',
-  [AssignmentCacheStatus.Missing]: 'Missing: Expected for new, renamed, or disabled experiments',
-  [AssignmentCacheStatus.Stale]: 'Stale: Recent changes take up to ten minutes to propagate',
+  [AssignmentCacheStatus.Fresh]: '✅ Fresh: The cache matches the database for this experiment',
+  [AssignmentCacheStatus.Missing]: '❌️ Missing: Expected for new, renamed, or disabled experiments',
+  [AssignmentCacheStatus.Stale]: '❌️ Stale: Recent changes take up to ten minutes to propagate',
 }

--- a/src/lib/experiments.ts
+++ b/src/lib/experiments.ts
@@ -48,7 +48,7 @@ export const PlatformToHuman: Record<Platform, string> = {
 }
 
 export const AssignmentCacheStatusToHuman: Record<AssignmentCacheStatus, string> = {
-  [AssignmentCacheStatus.Fresh]: '✅ Fresh: The cache matches the database for this experiment',
+  [AssignmentCacheStatus.Fresh]: '✅ Fresh: Production cache is up to date, but manual sandbox updates may be needed',
   [AssignmentCacheStatus.Missing]: '❌️ Missing: Expected for new, renamed, or disabled experiments',
   [AssignmentCacheStatus.Stale]: '❌️ Stale: Recent changes take up to ten minutes to propagate',
 }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -255,6 +255,12 @@ export enum Status {
   Disabled = 'disabled',
 }
 
+export enum AssignmentCacheStatus {
+  Fresh = 'fresh',
+  Missing = 'missing',
+  Stale = 'stale',
+}
+
 export const MAX_DISTANCE_BETWEEN_NOW_AND_START_DATE_IN_MONTHS = 12
 export const MAX_DISTANCE_BETWEEN_START_AND_END_DATE_IN_MONTHS = 12
 export const experimentBareSchema = yup
@@ -301,16 +307,19 @@ export const experimentFullSchema = experimentBareSchema
     segmentAssignments: yup.array(segmentAssignmentSchema).defined(),
     variations: yup.array<Variation>(variationSchema).defined().min(2),
     exclusionGroupTagIds: yup.array(idSchema.defined()),
+    assignmentCacheStatus: yup.string().oneOf(Object.values(AssignmentCacheStatus)).defined(),
   })
   .defined()
   .camelCase()
 export interface ExperimentFull extends yup.InferType<typeof experimentFullSchema> {}
 
 const now = new Date()
+// The following definition is a bit hacky, but it effectively undefines a field from the parent schema.
+const yupUndefined = yup.mixed().oneOf([]).notRequired()
 export const experimentFullNewSchema = experimentFullSchema.shape({
   experimentId: idSchema.nullable(),
-  // This effectively makes status undefined (best I could do in yup)
-  status: yup.mixed().oneOf([]).notRequired(),
+  status: yupUndefined,
+  assignmentCacheStatus: yupUndefined,
   startDatetime: dateSchema
     .defined()
     .test(

--- a/src/test-helpers/fixtures.ts
+++ b/src/test-helpers/fixtures.ts
@@ -9,6 +9,7 @@ import _ from 'lodash'
 import {
   Analysis,
   AnalysisStrategy,
+  AssignmentCacheStatus,
   AttributionWindowSeconds,
   ExperimentFull,
   ExperimentFullNew,
@@ -328,11 +329,13 @@ function createExperimentFull(fieldOverrides: Partial<ExperimentFull> = {}): Exp
     'metricAssignments',
     'segmentAssignments',
     'exposureEvents',
+    'assignmentCacheStatus',
   ]
   const newExperimentFieldOverrides = {
     ..._.omit(fieldOverrides, fieldsOnlyForExistingExperiments),
     exposureEvents: undefined,
     status: undefined,
+    assignmentCacheStatus: undefined,
   }
   const existingExperimentFieldOverrides = _.pick(fieldOverrides, fieldsOnlyForExistingExperiments)
 
@@ -412,6 +415,7 @@ function createExperimentFull(fieldOverrides: Partial<ExperimentFull> = {}): Exp
       },
     ],
     exclusionGroupTagIds: [1],
+    assignmentCacheStatus: AssignmentCacheStatus.Fresh,
     ...existingExperimentFieldOverrides,
   }
 }


### PR DESCRIPTION
Add a very basic indicator of an experiment's caching status to the overview page. It can probably benefit from more exciting styling, but I think it's good enough to get us started and aid with debugging once we change all the assigners to use the file system cache.

[This is what it looks like with dummy data](https://github.com/Automattic/abacus/pull/465#issuecomment-786466340).

## How has this been tested?

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
- Manual testing with mock data (locally and on Vercel)
