### PR TITLE
Add links to the assignment cache wiki

### DIFF
--- a/src/components/experiments/single-view/ExperimentCodeSetup.tsx
+++ b/src/components/experiments/single-view/ExperimentCodeSetup.tsx
@@ -29,8 +29,9 @@ export default function ExperimentCodeSetup(): JSX.Element {
         </Link>{' '}
         for platform-specific instructions.
       </Typography>
+      <br />
       <Typography variant='body1'>
-        When testing manually, note that changes may take up to ten minutes to propagate due to{' '}
+        When testing manually, note that <strong>changes may take up to ten minutes to propagate</strong> due to{' '}
         <Link
           href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#the-file-system-cache"
           rel='noopener noreferrer'

--- a/src/components/experiments/single-view/ExperimentCodeSetup.tsx
+++ b/src/components/experiments/single-view/ExperimentCodeSetup.tsx
@@ -16,24 +16,31 @@ export default function ExperimentCodeSetup(): JSX.Element {
   return (
     <Paper className={classes.root}>
       <Typography variant='h4'>Experiment Code Setup</Typography>
-      <Typography variant='subtitle1' gutterBottom>
-        Connect this experiment to your code.
-      </Typography>
       <br />
-      <Typography variant='h5' gutterBottom>
-        Using React
+      <Typography variant='body1'>
+        See{' '}
+        <Link
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#writing-the-controlvariant-code-experiences"
+          rel='noopener noreferrer'
+          target='_blank'
+          underline='always'
+        >
+          the wiki
+        </Link>{' '}
+        for platform-specific instructions.
       </Typography>
       <Typography variant='body1'>
-        <Link href='https://github.com/Automattic/wp-calypso/tree/master/client/components/experiment'>
-          See this Readme
+        When testing manually, note that changes may take up to ten minutes to propagate due to{' '}
+        <Link
+          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#the-file-system-cache"
+          rel='noopener noreferrer'
+          target='_blank'
+          underline='always'
+        >
+          the file system assignment cache
         </Link>
-      </Typography>
-      <br />
-      <Typography variant='h5' gutterBottom>
-        Using PHP
-      </Typography>
-      <Typography variant='body1'>
-        See <Code>wp-content/lib/wpcom-abtest/wpcom-experiment.php</Code>
+        . As specified in the wiki, you will need to run <Code>svn up</Code> to update your sandbox copy of the cache to
+        reflect the latest changes.
       </Typography>
     </Paper>
   )

--- a/src/components/experiments/single-view/ExperimentDisableButton.tsx
+++ b/src/components/experiments/single-view/ExperimentDisableButton.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Tooltip, Typography } from '@material-ui/core'
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Link, Tooltip, Typography } from '@material-ui/core'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
 import clsx from 'clsx'
 import { useSnackbar } from 'notistack'
@@ -89,7 +89,16 @@ const ExperimentDisableButton = ({
         <DialogContent>
           {isDisablingDangerous && (
             <Typography variant='body2' gutterBottom>
-              Disabling an experiment will <strong>trigger the default experience to all users</strong>.
+              Disabling an experiment will <strong>trigger the default experience to all users</strong>. Due to{' '}
+              <Link
+                href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#the-file-system-cache"
+                rel='noopener noreferrer'
+                target='_blank'
+              >
+                the file system assignment cache
+              </Link>
+              , changes may take up to ten minutes to propagate to all servers (and possibly longer to all clients).
+              Consider deploying code changes if this is an emergency.
             </Typography>
           )}
           <Typography variant='body2' gutterBottom>

--- a/src/components/experiments/single-view/ExperimentRunButton.tsx
+++ b/src/components/experiments/single-view/ExperimentRunButton.tsx
@@ -5,6 +5,7 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  Link,
   makeStyles,
   Tooltip,
   Typography,
@@ -91,10 +92,19 @@ const ExperimentRunButton = ({
         </DialogTitle>
         <DialogContent>
           <Typography variant='body2' gutterBottom>
-            Deploying will <strong>release experiment code to our users.</strong>
+            Deploying will <strong>release experiment code to our users.</strong> This may take up to ten minutes to
+            propagate to all servers due to{' '}
+            <Link
+              href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#the-file-system-cache"
+              rel='noopener noreferrer'
+              target='_blank'
+            >
+              the file system assignment cache
+            </Link>
+            .
           </Typography>
           <Typography variant='body2' gutterBottom>
-            It also changes the experiment&apos;s status to running, which is <strong>irreversible</strong>.
+            Deploying also changes the experiment&apos;s status to running, which is <strong>irreversible</strong>.
           </Typography>
           <div className={classes.dangerImage}>
             <img src='/img/danger.gif' alt='DANGER!' />

--- a/src/components/experiments/single-view/__snapshots__/ExperimentCodeSetup.test.tsx.snap
+++ b/src/components/experiments/single-view/__snapshots__/ExperimentCodeSetup.test.tsx.snap
@@ -14,7 +14,8 @@ exports[`renders as expected 1`] = `
     <p
       class="MuiTypography-root MuiTypography-body1"
     >
-      See 
+      See
+       
       <a
         class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
         href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#writing-the-controlvariant-code-experiences"
@@ -23,7 +24,8 @@ exports[`renders as expected 1`] = `
       >
         the wiki
       </a>
-       for platform-specific instructions.
+       
+      for platform-specific instructions.
     </p>
     <p
       class="MuiTypography-root MuiTypography-body1"
@@ -44,7 +46,7 @@ exports[`renders as expected 1`] = `
       >
         svn up
       </code>
-       to manually update your sandbox copy of the cache to see the latest changes.
+       to update your sandbox copy of the cache to reflect the latest changes.
     </p>
   </div>
 </div>

--- a/src/components/experiments/single-view/__snapshots__/ExperimentCodeSetup.test.tsx.snap
+++ b/src/components/experiments/single-view/__snapshots__/ExperimentCodeSetup.test.tsx.snap
@@ -10,42 +10,41 @@ exports[`renders as expected 1`] = `
     >
       Experiment Code Setup
     </h4>
-    <h6
-      class="MuiTypography-root MuiTypography-subtitle1 MuiTypography-gutterBottom"
-    >
-      Connect this experiment to your code.
-    </h6>
     <br />
-    <h5
-      class="MuiTypography-root MuiTypography-h5 MuiTypography-gutterBottom"
-    >
-      Using React
-    </h5>
-    <p
-      class="MuiTypography-root MuiTypography-body1"
-    >
-      <a
-        class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-        href="https://github.com/Automattic/wp-calypso/tree/master/client/components/experiment"
-      >
-        See this Readme
-      </a>
-    </p>
-    <br />
-    <h5
-      class="MuiTypography-root MuiTypography-h5 MuiTypography-gutterBottom"
-    >
-      Using PHP
-    </h5>
     <p
       class="MuiTypography-root MuiTypography-body1"
     >
       See 
+      <a
+        class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+        href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#writing-the-controlvariant-code-experiences"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        the wiki
+      </a>
+       for platform-specific instructions.
+    </p>
+    <p
+      class="MuiTypography-root MuiTypography-body1"
+    >
+      When testing manually, note that changes may take up to ten minutes to propagate due to
+       
+      <a
+        class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
+        href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#the-file-system-cache"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        the file system assignment cache
+      </a>
+      . As specified in the wiki, you will need to run 
       <code
         class="MuiTypography-root makeStyles-root-2 MuiTypography-body1"
       >
-        wp-content/lib/wpcom-abtest/wpcom-experiment.php
+        svn up
       </code>
+       to manually update your sandbox copy of the cache to see the latest changes.
     </p>
   </div>
 </div>

--- a/src/components/experiments/single-view/__snapshots__/ExperimentCodeSetup.test.tsx.snap
+++ b/src/components/experiments/single-view/__snapshots__/ExperimentCodeSetup.test.tsx.snap
@@ -27,10 +27,15 @@ exports[`renders as expected 1`] = `
        
       for platform-specific instructions.
     </p>
+    <br />
     <p
       class="MuiTypography-root MuiTypography-body1"
     >
-      When testing manually, note that changes may take up to ten minutes to propagate due to
+      When testing manually, note that 
+      <strong>
+        changes may take up to ten minutes to propagate
+      </strong>
+       due to
        
       <a
         class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"


### PR DESCRIPTION
Sprinkle a few links to the wiki and mention cache propagation in a few places:

* Code setup page (also includes the removal of old instructions):

![image](https://user-images.githubusercontent.com/3952615/109274405-2f8e1900-785f-11eb-83ef-74cfeb54e489.png)

* When running an experiment:

![image](https://user-images.githubusercontent.com/3952615/109274478-46cd0680-785f-11eb-9605-c673a36ebc10.png)

* When disabling a running/completed experiment:

![image](https://user-images.githubusercontent.com/3952615/109274842-ae835180-785f-11eb-9210-c7e79734e94c.png)

Happy to add more and tweak the wording if necessary.

## How has this been tested?

- Automated tests that cover added/changed functionality
- Manual testing with mock data (locally or on Vercel)
