### PR TITLE
Add Akismet and LOHP as supported platforms

### DIFF
--- a/src/lib/experiments.ts
+++ b/src/lib/experiments.ts
@@ -39,8 +39,10 @@ export function getDefaultAnalysisStrategy(experiment: ExperimentFull): Analysis
 }
 
 export const PlatformToHuman: Record<Platform, string> = {
+  [Platform.Akismet]: 'Spam protection for WordPress',
   [Platform.Calypso]: 'Calypso front-end',
   [Platform.Email]: 'Guides and other email systems',
+  [Platform.Lohp]: 'WordPress.com logged out homepage',
   [Platform.Pipe]: 'Machine learning pipeline',
   [Platform.Wpandroid]: 'WordPress Android app',
   [Platform.Wpcom]: 'WordPress.com back-end',

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -240,8 +240,10 @@ export const variationSchema = variationNewSchema
 export interface Variation extends yup.InferType<typeof variationSchema> {}
 
 export enum Platform {
+  Akismet = 'akismet',
   Calypso = 'calypso',
   Email = 'email',
+  Lohp = 'lohp',
   Pipe = 'pipe',
   Wpandroid = 'wpandroid',
   Wpcom = 'wpcom',


### PR DESCRIPTION
Does what it says in the title.

This is a part of addressing 588-gh-Automattic/experimentation-platform and should only be merged once the backend changes are deployed.

## How has this been tested?

Ran the dev server and manually checked the drop-down menu when creating an experiment:

![image](https://user-images.githubusercontent.com/3952615/109892386-35a84d80-7cd6-11eb-9d97-178a1df0422a.png)
