### PR TITLE
Fix tab history behaviour

### DIFF
--- a/src/components/experiments/single-view/ExperimentPageView.tsx
+++ b/src/components/experiments/single-view/ExperimentPageView.tsx
@@ -187,7 +187,7 @@ export default function ExperimentPageView({
                 value={ExperimentView.Debug}
                 component={Link}
                 to={`/experiments/${experimentIdSlug}/debug`}
-              replace
+                replace
               />
             )}
             <Tab

--- a/src/components/experiments/single-view/ExperimentPageView.tsx
+++ b/src/components/experiments/single-view/ExperimentPageView.tsx
@@ -170,6 +170,7 @@ export default function ExperimentPageView({
               value={ExperimentView.Overview}
               component={Link}
               to={`/experiments/${experimentIdSlug}/overview`}
+              replace
             />
             <Tab
               className={classes.topBarTab}
@@ -177,6 +178,7 @@ export default function ExperimentPageView({
               value={ExperimentView.Results}
               component={Link}
               to={`/experiments/${experimentIdSlug}/results`}
+              replace
             />
             {debugMode && (
               <Tab
@@ -185,6 +187,7 @@ export default function ExperimentPageView({
                 value={ExperimentView.Debug}
                 component={Link}
                 to={`/experiments/${experimentIdSlug}/debug`}
+              replace
               />
             )}
             <Tab
@@ -193,6 +196,7 @@ export default function ExperimentPageView({
               value={ExperimentView.CodeSetup}
               component={Link}
               to={`/experiments/${experimentIdSlug}/code-setup`}
+              replace
             />
           </Tabs>
           <div className={classes.topBarActions}>


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR fixes the Experiment tab history behaviour.**

By adding `replace` to the links in the tab it stops flooding the history causing you to need multiple back presses to get back to the experiment list.
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Manual testing with production data (locally)
