### PR TITLE
Extend inputs to getAggregateRecommendation

### DIFF
--- a/src/components/experiments/single-view/results/ActualExperimentResults.tsx
+++ b/src/components/experiments/single-view/results/ActualExperimentResults.tsx
@@ -141,12 +141,15 @@ export default function ActualExperimentResults({
       metricAssignment,
       metric,
       analysesByStrategyDateAsc,
-      aggregateRecommendation: getAggregateRecommendation(
-        Object.values(analysesByStrategyDateAsc)
+      aggregateRecommendation: getAggregateRecommendation({
+        experiment,
+        metric,
+        metricAssignment,
+        analyses: Object.values(analysesByStrategyDateAsc)
           .map(_.last.bind(null))
           .filter((x) => x !== undefined) as Analysis[],
-        strategy,
-      ),
+        defaultStrategy: strategy,
+      }),
     }),
   )
 
@@ -185,10 +188,13 @@ export default function ActualExperimentResults({
   const latestPrimaryMetricAnalysis = primaryMetricLatestAnalysesByStrategy[strategy]
   // istanbul ignore next; trivial
   const totalParticipants = latestPrimaryMetricAnalysis?.participantStats['total'] ?? 0
-  const primaryMetricAggregateRecommendation = getAggregateRecommendation(
-    Object.values(primaryMetricLatestAnalysesByStrategy).filter((x) => x) as Analysis[],
-    strategy,
-  )
+  const primaryMetricAggregateRecommendation = getAggregateRecommendation({
+    experiment,
+    metric: primaryMetricAssignmentAnalysesData.metric,
+    metricAssignment: primaryMetricAssignmentAnalysesData.metricAssignment,
+    analyses: Object.values(primaryMetricLatestAnalysesByStrategy).filter((x) => x) as Analysis[],
+    defaultStrategy: strategy,
+  })
 
   const experimentHealthStats = getExperimentHealthStats(experiment, primaryMetricLatestAnalysesByStrategy)
   const experimentHealthIndicators = getExperimentHealthIndicators(experimentHealthStats)

--- a/src/lib/analyses.test.ts
+++ b/src/lib/analyses.test.ts
@@ -5,25 +5,39 @@ import { AnalysisStrategy, RecommendationReason } from './schemas'
 
 describe('getAggregateRecommendation', () => {
   it('should work correctly for single analyses', () => {
-    expect(Analyses.getAggregateRecommendation([], AnalysisStrategy.PpNaive)).toEqual({
+    expect(
+      Analyses.getAggregateRecommendation({
+        experiment: Fixtures.createExperimentFull(),
+        metric: Fixtures.createMetricBares(1)[0],
+        metricAssignment: Fixtures.createMetricAssignment(),
+        analyses: [],
+        defaultStrategy: AnalysisStrategy.PpNaive,
+      }),
+    ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.MissingAnalysis,
     })
     expect(
-      Analyses.getAggregateRecommendation(
-        [
+      Analyses.getAggregateRecommendation({
+        experiment: Fixtures.createExperimentFull(),
+        metric: Fixtures.createMetricBares(1)[0],
+        metricAssignment: Fixtures.createMetricAssignment(),
+        analyses: [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: undefined,
           }),
         ],
-        AnalysisStrategy.PpNaive,
-      ),
+        defaultStrategy: AnalysisStrategy.PpNaive,
+      }),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.MissingAnalysis,
     })
     expect(
-      Analyses.getAggregateRecommendation(
-        [
+      Analyses.getAggregateRecommendation({
+        experiment: Fixtures.createExperimentFull(),
+        metric: Fixtures.createMetricBares(1)[0],
+        metricAssignment: Fixtures.createMetricAssignment(),
+        analyses: [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
@@ -34,14 +48,17 @@ describe('getAggregateRecommendation', () => {
             },
           }),
         ],
-        AnalysisStrategy.PpNaive,
-      ),
+        defaultStrategy: AnalysisStrategy.PpNaive,
+      }),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.Inconclusive,
     })
     expect(
-      Analyses.getAggregateRecommendation(
-        [
+      Analyses.getAggregateRecommendation({
+        experiment: Fixtures.createExperimentFull(),
+        metric: Fixtures.createMetricBares(1)[0],
+        metricAssignment: Fixtures.createMetricAssignment(),
+        analyses: [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
@@ -52,14 +69,17 @@ describe('getAggregateRecommendation', () => {
             },
           }),
         ],
-        AnalysisStrategy.PpNaive,
-      ),
+        defaultStrategy: AnalysisStrategy.PpNaive,
+      }),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.DeployAnyVariation,
     })
     expect(
-      Analyses.getAggregateRecommendation(
-        [
+      Analyses.getAggregateRecommendation({
+        experiment: Fixtures.createExperimentFull(),
+        metric: Fixtures.createMetricBares(1)[0],
+        metricAssignment: Fixtures.createMetricAssignment(),
+        analyses: [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
@@ -70,8 +90,8 @@ describe('getAggregateRecommendation', () => {
             },
           }),
         ],
-        AnalysisStrategy.PpNaive,
-      ),
+        defaultStrategy: AnalysisStrategy.PpNaive,
+      }),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.DeployChosenVariation,
       chosenVariationId: 123,
@@ -80,8 +100,11 @@ describe('getAggregateRecommendation', () => {
 
   it('should work correctly for multiple analyses without conflict', () => {
     expect(
-      Analyses.getAggregateRecommendation(
-        [
+      Analyses.getAggregateRecommendation({
+        experiment: Fixtures.createExperimentFull(),
+        metric: Fixtures.createMetricBares(1)[0],
+        metricAssignment: Fixtures.createMetricAssignment(),
+        analyses: [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
@@ -101,16 +124,19 @@ describe('getAggregateRecommendation', () => {
             },
           }),
         ],
-        AnalysisStrategy.PpNaive,
-      ),
+        defaultStrategy: AnalysisStrategy.PpNaive,
+      }),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.DeployChosenVariation,
       chosenVariationId: 123,
     })
 
     expect(
-      Analyses.getAggregateRecommendation(
-        [
+      Analyses.getAggregateRecommendation({
+        experiment: Fixtures.createExperimentFull(),
+        metric: Fixtures.createMetricBares(1)[0],
+        metricAssignment: Fixtures.createMetricAssignment(),
+        analyses: [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
@@ -125,16 +151,19 @@ describe('getAggregateRecommendation', () => {
             recommendation: null,
           }),
         ],
-        AnalysisStrategy.PpNaive,
-      ),
+        defaultStrategy: AnalysisStrategy.PpNaive,
+      }),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.DeployChosenVariation,
       chosenVariationId: 123,
     })
 
     expect(
-      Analyses.getAggregateRecommendation(
-        [
+      Analyses.getAggregateRecommendation({
+        experiment: Fixtures.createExperimentFull(),
+        metric: Fixtures.createMetricBares(1)[0],
+        metricAssignment: Fixtures.createMetricAssignment(),
+        analyses: [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
@@ -149,15 +178,18 @@ describe('getAggregateRecommendation', () => {
             recommendation: null,
           }),
         ],
-        AnalysisStrategy.PpNaive,
-      ),
+        defaultStrategy: AnalysisStrategy.PpNaive,
+      }),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.DeployAnyVariation,
     })
 
     expect(
-      Analyses.getAggregateRecommendation(
-        [
+      Analyses.getAggregateRecommendation({
+        experiment: Fixtures.createExperimentFull(),
+        metric: Fixtures.createMetricBares(1)[0],
+        metricAssignment: Fixtures.createMetricAssignment(),
+        analyses: [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
@@ -177,14 +209,17 @@ describe('getAggregateRecommendation', () => {
             },
           }),
         ],
-        AnalysisStrategy.PpNaive,
-      ),
+        defaultStrategy: AnalysisStrategy.PpNaive,
+      }),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.Inconclusive,
     })
     expect(
-      Analyses.getAggregateRecommendation(
-        [
+      Analyses.getAggregateRecommendation({
+        experiment: Fixtures.createExperimentFull(),
+        metric: Fixtures.createMetricBares(1)[0],
+        metricAssignment: Fixtures.createMetricAssignment(),
+        analyses: [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: null,
@@ -199,16 +234,19 @@ describe('getAggregateRecommendation', () => {
             },
           }),
         ],
-        AnalysisStrategy.PpNaive,
-      ),
+        defaultStrategy: AnalysisStrategy.PpNaive,
+      }),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.MissingAnalysis,
     })
   })
   it('should work correctly for multiple analyses with conflict', () => {
     expect(
-      Analyses.getAggregateRecommendation(
-        [
+      Analyses.getAggregateRecommendation({
+        experiment: Fixtures.createExperimentFull(),
+        metric: Fixtures.createMetricBares(1)[0],
+        metricAssignment: Fixtures.createMetricAssignment(),
+        analyses: [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
@@ -228,15 +266,18 @@ describe('getAggregateRecommendation', () => {
             },
           }),
         ],
-        AnalysisStrategy.PpNaive,
-      ),
+        defaultStrategy: AnalysisStrategy.PpNaive,
+      }),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.ManualAnalysisRequired,
     })
 
     expect(
-      Analyses.getAggregateRecommendation(
-        [
+      Analyses.getAggregateRecommendation({
+        experiment: Fixtures.createExperimentFull(),
+        metric: Fixtures.createMetricBares(1)[0],
+        metricAssignment: Fixtures.createMetricAssignment(),
+        analyses: [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
@@ -256,15 +297,18 @@ describe('getAggregateRecommendation', () => {
             },
           }),
         ],
-        AnalysisStrategy.PpNaive,
-      ),
+        defaultStrategy: AnalysisStrategy.PpNaive,
+      }),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.ManualAnalysisRequired,
     })
 
     expect(
-      Analyses.getAggregateRecommendation(
-        [
+      Analyses.getAggregateRecommendation({
+        experiment: Fixtures.createExperimentFull(),
+        metric: Fixtures.createMetricBares(1)[0],
+        metricAssignment: Fixtures.createMetricAssignment(),
+        analyses: [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
@@ -297,8 +341,8 @@ describe('getAggregateRecommendation', () => {
             recommendation: null,
           }),
         ],
-        AnalysisStrategy.PpNaive,
-      ),
+        defaultStrategy: AnalysisStrategy.PpNaive,
+      }),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.ManualAnalysisRequired,
     })

--- a/src/lib/analyses.ts
+++ b/src/lib/analyses.ts
@@ -1,6 +1,13 @@
 import _ from 'lodash'
 
-import { Analysis, AnalysisStrategy, ExperimentFull, RecommendationWarning } from './schemas'
+import {
+  Analysis,
+  AnalysisStrategy,
+  ExperimentFull,
+  MetricAssignment,
+  MetricBare,
+  RecommendationWarning,
+} from './schemas'
 
 // I can't get stdlib to work as an import...:
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -49,10 +56,16 @@ export interface AggregateRecommendation {
  * @param analyses Analyses of different strategies for the same day.
  * @param defaultStrategy Default strategy in the context of an aggregateRecommendation..
  */
-export function getAggregateRecommendation(
-  analyses: Analysis[],
-  defaultStrategy: AnalysisStrategy,
-): AggregateRecommendation {
+export function getAggregateRecommendation({
+  analyses,
+  defaultStrategy,
+}: {
+  experiment: ExperimentFull
+  metric: MetricBare
+  metricAssignment: MetricAssignment
+  analyses: Analysis[]
+  defaultStrategy: AnalysisStrategy
+}): AggregateRecommendation {
   const recommendationChosenVariationIds = analyses
     .map((analysis) => analysis.recommendation)
     .filter((x) => x)

--- a/src/test-helpers/fixtures.ts
+++ b/src/test-helpers/fixtures.ts
@@ -239,7 +239,7 @@ function createAnalyses(): Analysis[] {
   ]
 }
 
-function createMetricAssignment(fieldOverrides: Partial<MetricAssignment>): MetricAssignment {
+function createMetricAssignment(fieldOverrides?: Partial<MetricAssignment>): MetricAssignment {
   return {
     metricAssignmentId: 123,
     metricId: 1,


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR extends the inputs to getAggregateRecommendation in preparation for moving the stopping/warning logic from the ETL to Abacus**
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Part of #419 

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
