### PR TITLE
Add stopping recommendation to aggregate recommendation decision

### DIFF
--- a/src/components/experiments/single-view/results/AggregateRecommendationDisplay.test.tsx
+++ b/src/components/experiments/single-view/results/AggregateRecommendationDisplay.test.tsx
@@ -43,20 +43,28 @@ test('renders ManualAnalysisRequired correctly', () => {
   `)
 })
 
-test('renders Inconclusive correctly', () => {
+test('renders TooShort correctly', () => {
   const { container } = render(
     <AggregateRecommendationDisplay
       aggregateRecommendation={{
-        decision: AggregateRecommendationDecision.Inconclusive,
+        decision: AggregateRecommendationDecision.TooShort,
       }}
       experiment={Fixtures.createExperimentFull()}
     />,
   )
-  expect(container).toMatchInlineSnapshot(`
-    <div>
-      Inconclusive
-    </div>
-  `)
+  expect(container).toMatchInlineSnapshot()
+})
+
+test('renders TooLong correctly', () => {
+  const { container } = render(
+    <AggregateRecommendationDisplay
+      aggregateRecommendation={{
+        decision: AggregateRecommendationDecision.TooLong,
+      }}
+      experiment={Fixtures.createExperimentFull()}
+    />,
+  )
+  expect(container).toMatchInlineSnapshot()
 })
 
 test('renders DeployAnyVariation correctly', () => {

--- a/src/components/experiments/single-view/results/AggregateRecommendationDisplay.test.tsx
+++ b/src/components/experiments/single-view/results/AggregateRecommendationDisplay.test.tsx
@@ -17,7 +17,12 @@ test('renders MissingAnalysis correctly', () => {
   )
   expect(container).toMatchInlineSnapshot(`
     <div>
-      Not analyzed yet
+      <span
+        class="makeStyles-tooltipped-1"
+        title="It takes 24-48 hours for data to be analyzed."
+      >
+         Not analyzed yet 
+      </span>
     </div>
   `)
 })
@@ -34,7 +39,7 @@ test('renders ManualAnalysisRequired correctly', () => {
   expect(container).toMatchInlineSnapshot(`
     <div>
       <span
-        class="makeStyles-tooltipped-2"
+        class="makeStyles-tooltipped-3"
         title="Contact @experimentation-review on #a8c-experiments"
       >
         Manual analysis required
@@ -52,19 +57,11 @@ test('renders TooShort correctly', () => {
       experiment={Fixtures.createExperimentFull()}
     />,
   )
-  expect(container).toMatchInlineSnapshot()
-})
-
-test('renders TooLong correctly', () => {
-  const { container } = render(
-    <AggregateRecommendationDisplay
-      aggregateRecommendation={{
-        decision: AggregateRecommendationDecision.TooLong,
-      }}
-      experiment={Fixtures.createExperimentFull()}
-    />,
-  )
-  expect(container).toMatchInlineSnapshot()
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      More data needed
+    </div>
+  `)
 })
 
 test('renders DeployAnyVariation correctly', () => {
@@ -79,6 +76,30 @@ test('renders DeployAnyVariation correctly', () => {
   expect(container).toMatchInlineSnapshot(`
     <div>
       Deploy either variation
+    </div>
+  `)
+})
+
+test('renders DeployAnyVariation correctly with stopping recommendation', () => {
+  const { container } = render(
+    <AggregateRecommendationDisplay
+      aggregateRecommendation={{
+        decision: AggregateRecommendationDecision.DeployAnyVariation,
+        shouldStop: true,
+      }}
+      experiment={Fixtures.createExperimentFull()}
+    />,
+  )
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      Deploy either variation
+      <br />
+      <span
+        class="makeStyles-shouldStopAsterisk-10 makeStyles-tooltipped-9"
+        title="This experiment has run for too long."
+      >
+        Stop Experiment
+      </span>
     </div>
   `)
 })
@@ -148,6 +169,8 @@ test('throws error for uncovered AggregateRecommendation', () => {
         })}
       />,
     ),
-  ).toThrowErrorMatchingInlineSnapshot(`"Missing AggregateRecommendationDecision."`)
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"Missing AggregateRecommendationDecision: Unknown AggregateRecommendationDecision."`,
+  )
   console.error = originalConsoleError
 })

--- a/src/components/experiments/single-view/results/AggregateRecommendationDisplay.tsx
+++ b/src/components/experiments/single-view/results/AggregateRecommendationDisplay.tsx
@@ -12,7 +12,7 @@ const useStyles = makeStyles((theme: Theme) =>
       borderBottomStyle: 'dashed',
       borderBottomColor: theme.palette.grey[500],
     },
-    shouldStopAsterisk: {
+    shouldStop: {
       color: theme.palette.error.main,
     },
   }),
@@ -34,7 +34,7 @@ export default function AggregateRecommendationDisplay({
     <>
       <br />
       <Tooltip title='This experiment has run for too long.'>
-        <span className={clsx(classes.shouldStopAsterisk, classes.tooltipped)}>Stop Experiment</span>
+        <span className={clsx(classes.shouldStop, classes.tooltipped)}>Stop Experiment</span>
       </Tooltip>
     </>
   )

--- a/src/components/experiments/single-view/results/AggregateRecommendationDisplay.tsx
+++ b/src/components/experiments/single-view/results/AggregateRecommendationDisplay.tsx
@@ -33,9 +33,19 @@ export default function AggregateRecommendationDisplay({
         </Tooltip>
       )
     case AggregateRecommendationDecision.MissingAnalysis:
-      return <>Not analyzed yet</>
-    case AggregateRecommendationDecision.Inconclusive:
-      return <>Inconclusive</>
+      return (
+        <Tooltip title='It takes 24-48 hours for data to be analyzed.'>
+          <span className={classes.tooltipped}> Not analyzed yet </span>
+        </Tooltip>
+      )
+    case AggregateRecommendationDecision.TooShort:
+      return <>More data needed</>
+    case AggregateRecommendationDecision.TooLong:
+      return (
+        <Tooltip title='Experiments that run too long may be unsound.'>
+          <span className={classes.tooltipped}>Stop experiment</span>
+        </Tooltip>
+      )
     case AggregateRecommendationDecision.DeployAnyVariation:
       return <>Deploy either variation</>
     case AggregateRecommendationDecision.DeployChosenVariation: {

--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentDebug.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentDebug.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`renders the full tables with some analyses and a different primary metr
     style="position: relative;"
   >
     <div
-      class="Component-horizontalScrollContainer-13"
+      class="Component-horizontalScrollContainer-14"
       style="overflow-x: auto; position: relative;"
     >
       <div>
@@ -31,28 +31,28 @@ exports[`renders the full tables with some analyses and a different primary metr
                   class="MuiTableRow-root MuiTableRow-head"
                 >
                   <th
-                    class="MuiTableCell-root MuiTableCell-head MTableHeader-header-14 MuiTableCell-alignLeft"
+                    class="MuiTableCell-root MuiTableCell-head MTableHeader-header-15 MuiTableCell-alignLeft"
                     scope="col"
                     style="font-weight: 700; box-sizing: border-box;"
                   >
                     Strategy
                   </th>
                   <th
-                    class="MuiTableCell-root MuiTableCell-head MTableHeader-header-14 MuiTableCell-alignLeft"
+                    class="MuiTableCell-root MuiTableCell-head MTableHeader-header-15 MuiTableCell-alignLeft"
                     scope="col"
                     style="font-weight: 700; box-sizing: border-box;"
                   >
                     Total
                   </th>
                   <th
-                    class="MuiTableCell-root MuiTableCell-head MTableHeader-header-14 MuiTableCell-alignLeft"
+                    class="MuiTableCell-root MuiTableCell-head MTableHeader-header-15 MuiTableCell-alignLeft"
                     scope="col"
                     style="font-weight: 700; box-sizing: border-box;"
                   >
                     control
                   </th>
                   <th
-                    class="MuiTableCell-root MuiTableCell-head MTableHeader-header-14 MuiTableCell-alignLeft"
+                    class="MuiTableCell-root MuiTableCell-head MTableHeader-header-15 MuiTableCell-alignLeft"
                     scope="col"
                     style="font-weight: 700; box-sizing: border-box;"
                   >
@@ -459,8 +459,7 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy 
-                      test
+                      More data needed
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -503,7 +502,7 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Inconclusive
+                      More data needed
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -575,8 +574,7 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy 
-                      test
+                      More data needed
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -619,8 +617,7 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy 
-                      test
+                      More data needed
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -846,7 +843,12 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Not analyzed yet
+                      <span
+                        class="makeStyles-tooltipped-8"
+                        title="It takes 24-48 hours for data to be analyzed."
+                      >
+                         Not analyzed yet 
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -978,8 +980,7 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy 
-                      test
+                      More data needed
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -1022,8 +1023,7 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy 
-                      test
+                      More data needed
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -1066,8 +1066,7 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy 
-                      test
+                      More data needed
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -1110,8 +1109,7 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy 
-                      test
+                      More data needed
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -1154,8 +1152,7 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy 
-                      test
+                      More data needed
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"

--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -50,8 +50,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
             <h3
               class="MuiTypography-root makeStyles-summaryStatsStat-11 MuiTypography-h3 MuiTypography-colorPrimary"
             >
-              Deploy 
-              test
+              More data needed
             </h3>
             <h6
               class="MuiTypography-root MuiTypography-subtitle1"
@@ -64,7 +63,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
           </div>
         </div>
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-8 makeStyles-root-16 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-8 makeStyles-root-17 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             class=""
@@ -167,7 +166,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-21"
+        class="Component-horizontalScrollContainer-22"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -186,26 +185,26 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-22 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-23 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-22 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-23 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-22 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-23 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Attribution window
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-22 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-23 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -278,8 +277,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Deploy 
-                      test
+                      More data needed
                     </td>
                   </tr>
                   <tr
@@ -334,7 +332,12 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Not analyzed yet
+                      <span
+                        class="makeStyles-tooltipped-15"
+                        title="It takes 24-48 hours for data to be analyzed."
+                      >
+                         Not analyzed yet 
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -389,7 +392,12 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Not analyzed yet
+                      <span
+                        class="makeStyles-tooltipped-15"
+                        title="It takes 24-48 hours for data to be analyzed."
+                      >
+                         Not analyzed yet 
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -444,7 +452,12 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Not analyzed yet
+                      <span
+                        class="makeStyles-tooltipped-15"
+                        title="It takes 24-48 hours for data to be analyzed."
+                      >
+                         Not analyzed yet 
+                      </span>
                     </td>
                   </tr>
                 </tbody>
@@ -460,15 +473,15 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
 
 exports[`renders correctly for 1 analysis datapoint 2`] = `
 <div
-  class="MuiTableContainer-root makeStyles-root-23 analysis-detail-panel"
+  class="MuiTableContainer-root makeStyles-root-24 analysis-detail-panel"
 >
   <p
-    class="MuiTypography-root makeStyles-noPlotMessage-29 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-noPlotMessage-30 MuiTypography-body1"
   >
     Past values will be plotted once we have more than one day of results.
   </p>
   <h4
-    class="MuiTypography-root makeStyles-tableHeader-30 MuiTypography-h4"
+    class="MuiTypography-root makeStyles-tableHeader-31 MuiTypography-h4"
   >
     Latest Estimates
   </h4>
@@ -482,20 +495,20 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-31 makeStyles-headerCell-24"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-32 makeStyles-headerCell-25"
           role="cell"
           scope="row"
         >
           Difference
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-26"
         >
           [
           
           -1
           <span
-            class="makeStyles-root-32"
+            class="makeStyles-root-33"
             title="Percentage points."
           >
             pp
@@ -504,7 +517,7 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
           
           1
           <span
-            class="makeStyles-root-32"
+            class="makeStyles-root-33"
             title="Percentage points."
           >
             pp
@@ -521,7 +534,7 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
           
           -1
           <span
-            class="makeStyles-root-32"
+            class="makeStyles-root-33"
             title="Percentage points."
           >
             pp
@@ -532,7 +545,7 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
           
           1
           <span
-            class="makeStyles-root-32"
+            class="makeStyles-root-33"
             title="Percentage points."
           >
             pp
@@ -544,19 +557,19 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-31 makeStyles-headerCell-24"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-32 makeStyles-headerCell-25"
           role="cell"
           scope="row"
           valign="top"
         >
           <span
-            class="makeStyles-monospace-25"
+            class="makeStyles-monospace-26"
           >
             test
           </span>
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-26"
         >
           [
           
@@ -591,19 +604,19 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-31 makeStyles-headerCell-24"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-32 makeStyles-headerCell-25"
           role="cell"
           scope="row"
           valign="top"
         >
           <span
-            class="makeStyles-monospace-25"
+            class="makeStyles-monospace-26"
           >
             control
           </span>
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-26"
         >
           [
           
@@ -638,7 +651,7 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-24"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-25"
           role="cell"
           scope="row"
         >
@@ -652,7 +665,7 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
           Warnings
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-26"
         >
           <div>
             Experiment period is too short. Wait a few days to be safer.
@@ -665,7 +678,7 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
     </tbody>
   </table>
   <h4
-    class="MuiTypography-root makeStyles-tableHeader-30 MuiTypography-h4"
+    class="MuiTypography-root makeStyles-tableHeader-31 MuiTypography-h4"
   >
     Metric Assignment Details
   </h4>
@@ -679,14 +692,14 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-24"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-25"
           role="cell"
           scope="row"
         >
           Metric Description
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-26"
         >
           This is metric 1
         </td>
@@ -695,19 +708,19 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-24"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-25"
           role="cell"
           scope="row"
         >
           Minimum Practical Difference
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-26"
         >
           
           10
           <span
-            class="makeStyles-root-32"
+            class="makeStyles-root-33"
             title="Percentage points."
           >
             pp
@@ -718,14 +731,14 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-24"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-25"
           role="cell"
           scope="row"
         >
           Change Expected
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-26"
         >
           Yes
         </td>
@@ -733,7 +746,7 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
     </tbody>
   </table>
   <h4
-    class="MuiTypography-root makeStyles-tableHeader-30 MuiTypography-h4"
+    class="MuiTypography-root makeStyles-tableHeader-31 MuiTypography-h4"
   >
     Analysis Fine Print
   </h4>
@@ -747,7 +760,7 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-24"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-25"
           role="cell"
           scope="row"
         >
@@ -757,7 +770,7 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
           class="MuiTableCell-root MuiTableCell-body"
         >
           <span
-            class="makeStyles-root-33"
+            class="makeStyles-root-34"
             title="09/05/2020, 20:00:00"
           >
             2020-05-10
@@ -768,14 +781,14 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-24"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-25"
           role="cell"
           scope="row"
         >
           Analysis strategy
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-26"
         >
           Exposed without crossovers and spammers
         </td>
@@ -784,14 +797,14 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-24"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-25"
           role="cell"
           scope="row"
         >
           Analyzed participants
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-26"
         >
           1000
            (
@@ -877,13 +890,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-34"
+    class="makeStyles-root-35"
   >
     <div
-      class="makeStyles-summary-36"
+      class="makeStyles-summary-37"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-46 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-47 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -892,16 +905,16 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-40"
+        class="makeStyles-summaryColumn-41"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-41 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-42 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-42"
+            class="makeStyles-summaryStatsPart-43"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-44 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-45 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               700
             </h3>
@@ -917,13 +930,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-42"
+            class="makeStyles-summaryStatsPart-43"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-44 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-45 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               <span
-                class="makeStyles-tooltipped-48"
+                class="makeStyles-tooltipped-49"
                 title="Contact @experimentation-review on #a8c-experiments"
               >
                 Manual analysis required
@@ -940,7 +953,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           </div>
         </div>
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-41 makeStyles-root-49 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-42 makeStyles-root-51 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             class=""
@@ -1043,7 +1056,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-54"
+        class="Component-horizontalScrollContainer-56"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -1062,26 +1075,26 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-55 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-57 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-55 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-57 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-55 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-57 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Attribution window
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-55 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-57 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -1133,7 +1146,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                        
                       <div
                         aria-disabled="true"
-                        class="MuiChip-root makeStyles-primaryChip-35 MuiChip-outlined Mui-disabled"
+                        class="MuiChip-root makeStyles-primaryChip-36 MuiChip-outlined Mui-disabled"
                       >
                         <span
                           class="MuiChip-label"
@@ -1153,7 +1166,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
                       <span
-                        class="makeStyles-tooltipped-48"
+                        class="makeStyles-tooltipped-49"
                         title="Contact @experimentation-review on #a8c-experiments"
                       >
                         Manual analysis required
@@ -1212,7 +1225,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Not analyzed yet
+                      <span
+                        class="makeStyles-tooltipped-49"
+                        title="It takes 24-48 hours for data to be analyzed."
+                      >
+                         Not analyzed yet 
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -1267,7 +1285,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Not analyzed yet
+                      <span
+                        class="makeStyles-tooltipped-49"
+                        title="It takes 24-48 hours for data to be analyzed."
+                      >
+                         Not analyzed yet 
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -1322,8 +1345,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Deploy 
-                      test
+                      More data needed
                     </td>
                   </tr>
                 </tbody>
@@ -1339,13 +1361,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
 
 exports[`renders the condensed table with some analyses in non-debug mode for a Conversion Metric 2`] = `
 <div
-  class="MuiTableContainer-root makeStyles-root-56 analysis-detail-panel"
+  class="MuiTableContainer-root makeStyles-root-58 analysis-detail-panel"
 >
   <div
-    class="makeStyles-metricEstimatePlots-59"
+    class="makeStyles-metricEstimatePlots-61"
   />
   <h4
-    class="MuiTypography-root makeStyles-tableHeader-63 MuiTypography-h4"
+    class="MuiTypography-root makeStyles-tableHeader-65 MuiTypography-h4"
   >
     Latest Estimates
   </h4>
@@ -1359,20 +1381,20 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-64 makeStyles-headerCell-57"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-66 makeStyles-headerCell-59"
           role="cell"
           scope="row"
         >
           Difference
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
         >
           [
           
           -1
           <span
-            class="makeStyles-root-65"
+            class="makeStyles-root-67"
             title="Percentage points."
           >
             pp
@@ -1381,7 +1403,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           
           1
           <span
-            class="makeStyles-root-65"
+            class="makeStyles-root-67"
             title="Percentage points."
           >
             pp
@@ -1398,7 +1420,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           
           -1
           <span
-            class="makeStyles-root-65"
+            class="makeStyles-root-67"
             title="Percentage points."
           >
             pp
@@ -1409,7 +1431,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           
           1
           <span
-            class="makeStyles-root-65"
+            class="makeStyles-root-67"
             title="Percentage points."
           >
             pp
@@ -1421,19 +1443,19 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-64 makeStyles-headerCell-57"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-66 makeStyles-headerCell-59"
           role="cell"
           scope="row"
           valign="top"
         >
           <span
-            class="makeStyles-monospace-58"
+            class="makeStyles-monospace-60"
           >
             test
           </span>
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
         >
           [
           
@@ -1468,19 +1490,19 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-64 makeStyles-headerCell-57"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-66 makeStyles-headerCell-59"
           role="cell"
           scope="row"
           valign="top"
         >
           <span
-            class="makeStyles-monospace-58"
+            class="makeStyles-monospace-60"
           >
             control
           </span>
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
         >
           [
           
@@ -1515,7 +1537,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-57"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-59"
           role="cell"
           scope="row"
         >
@@ -1529,7 +1551,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           Warnings
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
         >
           <div>
             Experiment period is too short. Wait a few days to be safer.
@@ -1542,7 +1564,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </tbody>
   </table>
   <h4
-    class="MuiTypography-root makeStyles-tableHeader-63 MuiTypography-h4"
+    class="MuiTypography-root makeStyles-tableHeader-65 MuiTypography-h4"
   >
     Metric Assignment Details
   </h4>
@@ -1556,14 +1578,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-57"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-59"
           role="cell"
           scope="row"
         >
           Metric Description
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
         >
           This is metric 3
         </td>
@@ -1572,19 +1594,19 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-57"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-59"
           role="cell"
           scope="row"
         >
           Minimum Practical Difference
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
         >
           
           1200
           <span
-            class="makeStyles-root-65"
+            class="makeStyles-root-67"
             title="Percentage points."
           >
             pp
@@ -1595,14 +1617,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-57"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-59"
           role="cell"
           scope="row"
         >
           Change Expected
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
         >
           Yes
         </td>
@@ -1610,7 +1632,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </tbody>
   </table>
   <h4
-    class="MuiTypography-root makeStyles-tableHeader-63 MuiTypography-h4"
+    class="MuiTypography-root makeStyles-tableHeader-65 MuiTypography-h4"
   >
     Analysis Fine Print
   </h4>
@@ -1624,7 +1646,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-57"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-59"
           role="cell"
           scope="row"
         >
@@ -1634,7 +1656,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           class="MuiTableCell-root MuiTableCell-body"
         >
           <span
-            class="makeStyles-root-66"
+            class="makeStyles-root-68"
             title="10/06/2020, 20:00:00"
           >
             2020-06-11
@@ -1645,14 +1667,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-57"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-59"
           role="cell"
           scope="row"
         >
           Analysis strategy
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
         >
           Exposed without crossovers and spammers
         </td>
@@ -1661,14 +1683,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-57"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-59"
           role="cell"
           scope="row"
         >
           Analyzed participants
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
         >
           1200
            (
@@ -1686,7 +1708,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-47",
+        "className": "makeStyles-participantsPlot-48",
         "data": Array [
           Object {
             "line": Object {
@@ -1745,7 +1767,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-60",
+        "className": "makeStyles-metricEstimatePlot-62",
         "data": Array [
           Object {
             "line": Object {
@@ -1841,7 +1863,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-60",
+        "className": "makeStyles-metricEstimatePlot-62",
         "data": Array [
           Object {
             "line": Object {
@@ -1964,13 +1986,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-67"
+    class="makeStyles-root-69"
   >
     <div
-      class="makeStyles-summary-69"
+      class="makeStyles-summary-71"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-79 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-81 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -1979,16 +2001,16 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-73"
+        class="makeStyles-summaryColumn-75"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-74 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-76 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-75"
+            class="makeStyles-summaryStatsPart-77"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-77 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-79 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               700
             </h3>
@@ -2004,13 +2026,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-75"
+            class="makeStyles-summaryStatsPart-77"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-77 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-79 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               <span
-                class="makeStyles-tooltipped-81"
+                class="makeStyles-tooltipped-83"
                 title="Contact @experimentation-review on #a8c-experiments"
               >
                 Manual analysis required
@@ -2027,7 +2049,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           </div>
         </div>
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-74 makeStyles-root-82 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-76 makeStyles-root-85 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             class=""
@@ -2130,7 +2152,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-87"
+        class="Component-horizontalScrollContainer-90"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -2149,26 +2171,26 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-88 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-91 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-88 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-91 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-88 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-91 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Attribution window
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-88 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-91 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -2220,7 +2242,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                        
                       <div
                         aria-disabled="true"
-                        class="MuiChip-root makeStyles-primaryChip-68 MuiChip-outlined Mui-disabled"
+                        class="MuiChip-root makeStyles-primaryChip-70 MuiChip-outlined Mui-disabled"
                       >
                         <span
                           class="MuiChip-label"
@@ -2240,7 +2262,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
                       <span
-                        class="makeStyles-tooltipped-81"
+                        class="makeStyles-tooltipped-83"
                         title="Contact @experimentation-review on #a8c-experiments"
                       >
                         Manual analysis required
@@ -2299,7 +2321,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Not analyzed yet
+                      <span
+                        class="makeStyles-tooltipped-83"
+                        title="It takes 24-48 hours for data to be analyzed."
+                      >
+                         Not analyzed yet 
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -2354,7 +2381,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Not analyzed yet
+                      <span
+                        class="makeStyles-tooltipped-83"
+                        title="It takes 24-48 hours for data to be analyzed."
+                      >
+                         Not analyzed yet 
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -2409,8 +2441,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Deploy 
-                      test
+                      More data needed
                     </td>
                   </tr>
                 </tbody>
@@ -2426,13 +2457,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
 
 exports[`renders the condensed table with some analyses in non-debug mode for a Revenue Metric 2`] = `
 <div
-  class="MuiTableContainer-root makeStyles-root-89 analysis-detail-panel"
+  class="MuiTableContainer-root makeStyles-root-92 analysis-detail-panel"
 >
   <div
-    class="makeStyles-metricEstimatePlots-92"
+    class="makeStyles-metricEstimatePlots-95"
   />
   <h4
-    class="MuiTypography-root makeStyles-tableHeader-96 MuiTypography-h4"
+    class="MuiTypography-root makeStyles-tableHeader-99 MuiTypography-h4"
   >
     Latest Estimates
   </h4>
@@ -2446,14 +2477,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-97 makeStyles-headerCell-90"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-100 makeStyles-headerCell-93"
           role="cell"
           scope="row"
         >
           Difference
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-91"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-94"
         >
           [
           USD 
@@ -2488,19 +2519,19 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-97 makeStyles-headerCell-90"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-100 makeStyles-headerCell-93"
           role="cell"
           scope="row"
           valign="top"
         >
           <span
-            class="makeStyles-monospace-91"
+            class="makeStyles-monospace-94"
           >
             test
           </span>
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-91"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-94"
         >
           [
           USD 
@@ -2535,19 +2566,19 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-97 makeStyles-headerCell-90"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-100 makeStyles-headerCell-93"
           role="cell"
           scope="row"
           valign="top"
         >
           <span
-            class="makeStyles-monospace-91"
+            class="makeStyles-monospace-94"
           >
             control
           </span>
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-91"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-94"
         >
           [
           USD 
@@ -2582,7 +2613,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-90"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-93"
           role="cell"
           scope="row"
         >
@@ -2596,7 +2627,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           Warnings
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-91"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-94"
         >
           <div>
             Experiment period is too short. Wait a few days to be safer.
@@ -2609,7 +2640,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </tbody>
   </table>
   <h4
-    class="MuiTypography-root makeStyles-tableHeader-96 MuiTypography-h4"
+    class="MuiTypography-root makeStyles-tableHeader-99 MuiTypography-h4"
   >
     Metric Assignment Details
   </h4>
@@ -2623,14 +2654,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-90"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-93"
           role="cell"
           scope="row"
         >
           Metric Description
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-91"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-94"
         >
           This is metric 3
         </td>
@@ -2639,14 +2670,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-90"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-93"
           role="cell"
           scope="row"
         >
           Minimum Practical Difference
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-91"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-94"
         >
           USD 
           12
@@ -2657,14 +2688,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-90"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-93"
           role="cell"
           scope="row"
         >
           Change Expected
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-91"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-94"
         >
           Yes
         </td>
@@ -2672,7 +2703,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </tbody>
   </table>
   <h4
-    class="MuiTypography-root makeStyles-tableHeader-96 MuiTypography-h4"
+    class="MuiTypography-root makeStyles-tableHeader-99 MuiTypography-h4"
   >
     Analysis Fine Print
   </h4>
@@ -2686,7 +2717,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-90"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-93"
           role="cell"
           scope="row"
         >
@@ -2696,7 +2727,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           class="MuiTableCell-root MuiTableCell-body"
         >
           <span
-            class="makeStyles-root-98"
+            class="makeStyles-root-101"
             title="10/06/2020, 20:00:00"
           >
             2020-06-11
@@ -2707,14 +2738,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-90"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-93"
           role="cell"
           scope="row"
         >
           Analysis strategy
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-91"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-94"
         >
           Exposed without crossovers and spammers
         </td>
@@ -2723,14 +2754,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-90"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-93"
           role="cell"
           scope="row"
         >
           Analyzed participants
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-91"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-94"
         >
           1200
            (
@@ -2748,7 +2779,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-80",
+        "className": "makeStyles-participantsPlot-82",
         "data": Array [
           Object {
             "line": Object {
@@ -2807,7 +2838,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-93",
+        "className": "makeStyles-metricEstimatePlot-96",
         "data": Array [
           Object {
             "line": Object {
@@ -2903,7 +2934,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-93",
+        "className": "makeStyles-metricEstimatePlot-96",
         "data": Array [
           Object {
             "line": Object {

--- a/src/lib/analyses.test.ts
+++ b/src/lib/analyses.test.ts
@@ -1,7 +1,7 @@
 import Fixtures from 'src/test-helpers/fixtures'
 
 import * as Analyses from './analyses'
-import { AnalysisStrategy, RecommendationReason, RecommendationWarning } from './schemas'
+import { AnalysisStrategy, RecommendationReason, RecommendationWarning, Status } from './schemas'
 
 describe('getAggregateRecommendation', () => {
   it('should work correctly for single analyses', () => {
@@ -104,27 +104,6 @@ describe('getAggregateRecommendation', () => {
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
-              endExperiment: false,
-              chosenVariationId: null,
-              reason: RecommendationReason.CiGreaterThanRope,
-              warnings: [RecommendationWarning.LongPeriod],
-            },
-          }),
-        ],
-        defaultStrategy: AnalysisStrategy.PpNaive,
-      }),
-    ).toEqual({
-      decision: Analyses.AggregateRecommendationDecision.TooLong,
-    })
-    expect(
-      Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull(),
-        metric: Fixtures.createMetricBares(1)[0],
-        metricAssignment: Fixtures.createMetricAssignment(),
-        analyses: [
-          Fixtures.createAnalysis({
-            analysisStrategy: AnalysisStrategy.PpNaive,
-            recommendation: {
               endExperiment: true,
               chosenVariationId: null,
               reason: RecommendationReason.CiGreaterThanRope,
@@ -136,6 +115,51 @@ describe('getAggregateRecommendation', () => {
       }),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.DeployAnyVariation,
+      shouldStop: false,
+    })
+    expect(
+      Analyses.getAggregateRecommendation({
+        experiment: Fixtures.createExperimentFull({ status: Status.Running }),
+        metric: Fixtures.createMetricBares(1)[0],
+        metricAssignment: Fixtures.createMetricAssignment(),
+        analyses: [
+          Fixtures.createAnalysis({
+            analysisStrategy: AnalysisStrategy.PpNaive,
+            recommendation: {
+              endExperiment: true,
+              chosenVariationId: null,
+              reason: RecommendationReason.CiGreaterThanRope,
+              warnings: [RecommendationWarning.LongPeriod],
+            },
+          }),
+        ],
+        defaultStrategy: AnalysisStrategy.PpNaive,
+      }),
+    ).toEqual({
+      decision: Analyses.AggregateRecommendationDecision.DeployAnyVariation,
+      shouldStop: true,
+    })
+    expect(
+      Analyses.getAggregateRecommendation({
+        experiment: Fixtures.createExperimentFull({ status: Status.Disabled }),
+        metric: Fixtures.createMetricBares(1)[0],
+        metricAssignment: Fixtures.createMetricAssignment(),
+        analyses: [
+          Fixtures.createAnalysis({
+            analysisStrategy: AnalysisStrategy.PpNaive,
+            recommendation: {
+              endExperiment: true,
+              chosenVariationId: null,
+              reason: RecommendationReason.CiGreaterThanRope,
+              warnings: [RecommendationWarning.LongPeriod],
+            },
+          }),
+        ],
+        defaultStrategy: AnalysisStrategy.PpNaive,
+      }),
+    ).toEqual({
+      decision: Analyses.AggregateRecommendationDecision.DeployAnyVariation,
+      shouldStop: false,
     })
     expect(
       Analyses.getAggregateRecommendation({
@@ -158,6 +182,30 @@ describe('getAggregateRecommendation', () => {
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.DeployChosenVariation,
       chosenVariationId: 123,
+      shouldStop: false,
+    })
+    expect(
+      Analyses.getAggregateRecommendation({
+        experiment: Fixtures.createExperimentFull(),
+        metric: Fixtures.createMetricBares(1)[0],
+        metricAssignment: Fixtures.createMetricAssignment(),
+        analyses: [
+          Fixtures.createAnalysis({
+            analysisStrategy: AnalysisStrategy.PpNaive,
+            recommendation: {
+              endExperiment: true,
+              chosenVariationId: 123,
+              reason: RecommendationReason.CiGreaterThanRope,
+              warnings: [RecommendationWarning.LongPeriod],
+            },
+          }),
+        ],
+        defaultStrategy: AnalysisStrategy.PpNaive,
+      }),
+    ).toEqual({
+      decision: Analyses.AggregateRecommendationDecision.DeployChosenVariation,
+      chosenVariationId: 123,
+      shouldStop: false,
     })
   })
 
@@ -192,6 +240,7 @@ describe('getAggregateRecommendation', () => {
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.DeployChosenVariation,
       chosenVariationId: 123,
+      shouldStop: false,
     })
 
     expect(
@@ -219,6 +268,7 @@ describe('getAggregateRecommendation', () => {
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.DeployChosenVariation,
       chosenVariationId: 123,
+      shouldStop: false,
     })
 
     expect(
@@ -245,6 +295,7 @@ describe('getAggregateRecommendation', () => {
       }),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.DeployAnyVariation,
+      shouldStop: false,
     })
 
     expect(

--- a/src/lib/analyses.test.ts
+++ b/src/lib/analyses.test.ts
@@ -1,7 +1,7 @@
 import Fixtures from 'src/test-helpers/fixtures'
 
 import * as Analyses from './analyses'
-import { AnalysisStrategy, RecommendationReason } from './schemas'
+import { AnalysisStrategy, RecommendationReason, RecommendationWarning } from './schemas'
 
 describe('getAggregateRecommendation', () => {
   it('should work correctly for single analyses', () => {
@@ -51,7 +51,70 @@ describe('getAggregateRecommendation', () => {
         defaultStrategy: AnalysisStrategy.PpNaive,
       }),
     ).toEqual({
-      decision: Analyses.AggregateRecommendationDecision.Inconclusive,
+      decision: Analyses.AggregateRecommendationDecision.TooShort,
+    })
+    expect(
+      Analyses.getAggregateRecommendation({
+        experiment: Fixtures.createExperimentFull(),
+        metric: Fixtures.createMetricBares(1)[0],
+        metricAssignment: Fixtures.createMetricAssignment(),
+        analyses: [
+          Fixtures.createAnalysis({
+            analysisStrategy: AnalysisStrategy.PpNaive,
+            recommendation: {
+              endExperiment: false,
+              chosenVariationId: null,
+              reason: RecommendationReason.CiGreaterThanRope,
+              warnings: [RecommendationWarning.ShortPeriod],
+            },
+          }),
+        ],
+        defaultStrategy: AnalysisStrategy.PpNaive,
+      }),
+    ).toEqual({
+      decision: Analyses.AggregateRecommendationDecision.TooShort,
+    })
+    expect(
+      Analyses.getAggregateRecommendation({
+        experiment: Fixtures.createExperimentFull(),
+        metric: Fixtures.createMetricBares(1)[0],
+        metricAssignment: Fixtures.createMetricAssignment(),
+        analyses: [
+          Fixtures.createAnalysis({
+            analysisStrategy: AnalysisStrategy.PpNaive,
+            recommendation: {
+              endExperiment: true,
+              chosenVariationId: null,
+              reason: RecommendationReason.CiGreaterThanRope,
+              warnings: [RecommendationWarning.WideCi],
+            },
+          }),
+        ],
+        defaultStrategy: AnalysisStrategy.PpNaive,
+      }),
+    ).toEqual({
+      decision: Analyses.AggregateRecommendationDecision.TooShort,
+    })
+    expect(
+      Analyses.getAggregateRecommendation({
+        experiment: Fixtures.createExperimentFull(),
+        metric: Fixtures.createMetricBares(1)[0],
+        metricAssignment: Fixtures.createMetricAssignment(),
+        analyses: [
+          Fixtures.createAnalysis({
+            analysisStrategy: AnalysisStrategy.PpNaive,
+            recommendation: {
+              endExperiment: false,
+              chosenVariationId: null,
+              reason: RecommendationReason.CiGreaterThanRope,
+              warnings: [RecommendationWarning.LongPeriod],
+            },
+          }),
+        ],
+        defaultStrategy: AnalysisStrategy.PpNaive,
+      }),
+    ).toEqual({
+      decision: Analyses.AggregateRecommendationDecision.TooLong,
     })
     expect(
       Analyses.getAggregateRecommendation({
@@ -212,7 +275,7 @@ describe('getAggregateRecommendation', () => {
         defaultStrategy: AnalysisStrategy.PpNaive,
       }),
     ).toEqual({
-      decision: Analyses.AggregateRecommendationDecision.Inconclusive,
+      decision: Analyses.AggregateRecommendationDecision.TooShort,
     })
     expect(
       Analyses.getAggregateRecommendation({

--- a/src/lib/analyses.ts
+++ b/src/lib/analyses.ts
@@ -7,6 +7,7 @@ import {
   MetricAssignment,
   MetricBare,
   RecommendationWarning,
+  Status,
 } from './schemas'
 
 // I can't get stdlib to work as an import...:
@@ -49,6 +50,7 @@ export enum AggregateRecommendationDecision {
 export interface AggregateRecommendation {
   decision: AggregateRecommendationDecision
   chosenVariationId?: number
+  shouldStop?: boolean
 }
 
 /**
@@ -58,6 +60,7 @@ export interface AggregateRecommendation {
  * @param defaultStrategy Default strategy in the context of an aggregateRecommendation..
  */
 export function getAggregateRecommendation({
+  experiment,
   analyses,
   defaultStrategy,
 }: {
@@ -96,21 +99,20 @@ export function getAggregateRecommendation({
     }
   }
 
-  if (recommendation.warnings.includes(RecommendationWarning.LongPeriod)) {
-    return {
-      decision: AggregateRecommendationDecision.TooLong,
-    }
-  }
+  const shouldStop =
+    experiment.status === Status.Running && recommendation.warnings.includes(RecommendationWarning.LongPeriod)
 
   if (!recommendation.chosenVariationId) {
     return {
       decision: AggregateRecommendationDecision.DeployAnyVariation,
+      shouldStop,
     }
   }
 
   return {
     decision: AggregateRecommendationDecision.DeployChosenVariation,
     chosenVariationId: recommendation.chosenVariationId,
+    shouldStop,
   }
 }
 

--- a/src/lib/analyses.ts
+++ b/src/lib/analyses.ts
@@ -40,7 +40,8 @@ export const RecommendationWarningToHuman = {
 export enum AggregateRecommendationDecision {
   ManualAnalysisRequired = 'ManualAnalysisRequired',
   MissingAnalysis = 'MissingAnalysis',
-  Inconclusive = 'Inconclusive',
+  TooShort = 'TooShort',
+  TooLong = 'TooLong',
   DeployAnyVariation = 'DeployAnyVariation',
   DeployChosenVariation = 'DeployChosenVariation',
 }
@@ -84,9 +85,20 @@ export function getAggregateRecommendation({
     }
   }
 
-  if (!recommendation.endExperiment) {
+  // Following the endExperiment+warnings description in experiments/recommender.py:Recommendation:
+  if (
+    !recommendation.endExperiment ||
+    recommendation.warnings.includes(RecommendationWarning.ShortPeriod) ||
+    recommendation.warnings.includes(RecommendationWarning.WideCi)
+  ) {
     return {
-      decision: AggregateRecommendationDecision.Inconclusive,
+      decision: AggregateRecommendationDecision.TooShort,
+    }
+  }
+
+  if (recommendation.warnings.includes(RecommendationWarning.LongPeriod)) {
+    return {
+      decision: AggregateRecommendationDecision.TooLong,
     }
   }
 


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR extends aggregate recommendation decision to include the stopping recommendation:**


We have an `endExperiment` field as well the warnings which all relate to experiment length, `experiments/recommender.py#L40-L47` explains that the warnings take precedence. We then get three stopping recommendation states: `TooShort`, `GoodLength`, `TooLong`.

- `Inconclusive` and `TooShort` are the same, but `TooShort` is actionable and more understandable so we change the name and messaging:

<img width="1274" alt="Screen Shot 2021-03-25 at 10 04 08 pm" src="https://user-images.githubusercontent.com/971886/112487983-22aa0a00-8db8-11eb-9a67-80aeccd78515.png">

- `GoodLength` means we can just display the recommendation.

- `TooLong` is a soft cutoff (I am assuming, @yanirs do we want a hard cut off?) where we tell experimenters to stop the experiment:

<img width="1262" alt="Screen Shot 2021-03-25 at 11 18 00 pm" src="https://user-images.githubusercontent.com/971886/112503001-88e95980-8dc5-11eb-8a69-d13e14612c38.png">


Yanir also mentioned in https://github.com/Automattic/abacus/issues/419#issuecomment-758314643 that email-like experiments shouldn't have `TooShort`, I will be addressing that in the next PR to keep this one smallish.


<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Part of #419 

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
