### PR TITLE
Integrate stopping info into AggregateRecommendation

### DIFF
--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentDebug.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentDebug.test.tsx.snap
@@ -459,8 +459,7 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy 
-                      test
+                      Inconclusive
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -575,8 +574,7 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy 
-                      test
+                      Inconclusive
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -619,8 +617,7 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy 
-                      test
+                      Inconclusive
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -978,8 +975,7 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy 
-                      test
+                      Inconclusive
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -1022,8 +1018,7 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy 
-                      test
+                      Inconclusive
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -1066,8 +1061,7 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy 
-                      test
+                      Inconclusive
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -1110,8 +1104,7 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy 
-                      test
+                      Inconclusive
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -1154,8 +1147,7 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy 
-                      test
+                      Inconclusive
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"

--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -50,8 +50,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
             <h3
               class="MuiTypography-root makeStyles-summaryStatsStat-11 MuiTypography-h3 MuiTypography-colorPrimary"
             >
-              Deploy 
-              test
+              Inconclusive
             </h3>
             <h6
               class="MuiTypography-root MuiTypography-subtitle1"
@@ -278,8 +277,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Deploy 
-                      test
+                      Inconclusive
                     </td>
                   </tr>
                   <tr
@@ -1322,8 +1320,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Deploy 
-                      test
+                      Inconclusive
                     </td>
                   </tr>
                 </tbody>
@@ -2409,8 +2406,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Deploy 
-                      test
+                      Inconclusive
                     </td>
                   </tr>
                 </tbody>

--- a/src/lib/analyses.test.ts
+++ b/src/lib/analyses.test.ts
@@ -1,43 +1,43 @@
 import Fixtures from 'src/test-helpers/fixtures'
 
 import * as Analyses from './analyses'
-import { AnalysisStrategy, RecommendationReason, RecommendationWarning, Status } from './schemas'
+import {
+  Analysis,
+  AnalysisStrategy,
+  ExperimentFull,
+  RecommendationReason,
+  RecommendationWarning,
+  Status,
+} from './schemas'
+
+const createAggregateRecommendationInput = (experimentOverrides: Partial<ExperimentFull>, analyses: Analysis[]) => ({
+  experiment: Fixtures.createExperimentFull(experimentOverrides),
+  metric: Fixtures.createMetricBares(1)[0],
+  metricAssignment: Fixtures.createMetricAssignment(),
+  analyses,
+  defaultStrategy: AnalysisStrategy.PpNaive,
+})
 
 describe('getAggregateRecommendation', () => {
   it('should work correctly for single analyses', () => {
-    expect(
-      Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull(),
-        metric: Fixtures.createMetricBares(1)[0],
-        metricAssignment: Fixtures.createMetricAssignment(),
-        analyses: [],
-        defaultStrategy: AnalysisStrategy.PpNaive,
-      }),
-    ).toEqual({
+    expect(Analyses.getAggregateRecommendation(createAggregateRecommendationInput({}, []))).toEqual({
       decision: Analyses.AggregateRecommendationDecision.MissingAnalysis,
     })
     expect(
-      Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull(),
-        metric: Fixtures.createMetricBares(1)[0],
-        metricAssignment: Fixtures.createMetricAssignment(),
-        analyses: [
+      Analyses.getAggregateRecommendation(
+        createAggregateRecommendationInput({}, [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: undefined,
           }),
-        ],
-        defaultStrategy: AnalysisStrategy.PpNaive,
-      }),
+        ]),
+      ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.MissingAnalysis,
     })
     expect(
-      Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull({ status: Status.Running }),
-        metric: Fixtures.createMetricBares(1)[0],
-        metricAssignment: Fixtures.createMetricAssignment(),
-        analyses: [
+      Analyses.getAggregateRecommendation(
+        createAggregateRecommendationInput({ status: Status.Running }, [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
@@ -47,168 +47,166 @@ describe('getAggregateRecommendation', () => {
               warnings: [],
             },
           }),
-        ],
-        defaultStrategy: AnalysisStrategy.PpNaive,
-      }),
+        ]),
+      ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.MoreDataNeeded,
     })
     expect(
-      Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull({ status: Status.Completed }),
-        metric: Fixtures.createMetricBares(1)[0],
-        metricAssignment: Fixtures.createMetricAssignment(),
-        analyses: [
-          Fixtures.createAnalysis({
-            analysisStrategy: AnalysisStrategy.PpNaive,
-            recommendation: {
-              endExperiment: false,
-              chosenVariationId: null,
-              reason: RecommendationReason.CiGreaterThanRope,
-              warnings: [],
-            },
-          }),
-        ],
-        defaultStrategy: AnalysisStrategy.PpNaive,
-      }),
+      Analyses.getAggregateRecommendation(
+        createAggregateRecommendationInput(
+          {
+            status: Status.Completed,
+          },
+          [
+            Fixtures.createAnalysis({
+              analysisStrategy: AnalysisStrategy.PpNaive,
+              recommendation: {
+                endExperiment: false,
+                chosenVariationId: null,
+                reason: RecommendationReason.CiGreaterThanRope,
+                warnings: [],
+              },
+            }),
+          ],
+        ),
+      ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.Inconclusive,
     })
     expect(
-      Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull({ status: Status.Disabled }),
-        metric: Fixtures.createMetricBares(1)[0],
-        metricAssignment: Fixtures.createMetricAssignment(),
-        analyses: [
-          Fixtures.createAnalysis({
-            analysisStrategy: AnalysisStrategy.PpNaive,
-            recommendation: {
-              endExperiment: false,
-              chosenVariationId: null,
-              reason: RecommendationReason.CiGreaterThanRope,
-              warnings: [],
-            },
-          }),
-        ],
-        defaultStrategy: AnalysisStrategy.PpNaive,
-      }),
+      Analyses.getAggregateRecommendation(
+        createAggregateRecommendationInput(
+          {
+            status: Status.Disabled,
+          },
+          [
+            Fixtures.createAnalysis({
+              analysisStrategy: AnalysisStrategy.PpNaive,
+              recommendation: {
+                endExperiment: false,
+                chosenVariationId: null,
+                reason: RecommendationReason.CiGreaterThanRope,
+                warnings: [],
+              },
+            }),
+          ],
+        ),
+      ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.Inconclusive,
     })
     expect(
-      Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull({ status: Status.Running }),
-        metric: Fixtures.createMetricBares(1)[0],
-        metricAssignment: Fixtures.createMetricAssignment(),
-        analyses: [
-          Fixtures.createAnalysis({
-            analysisStrategy: AnalysisStrategy.PpNaive,
-            recommendation: {
-              endExperiment: false,
-              chosenVariationId: null,
-              reason: RecommendationReason.CiGreaterThanRope,
-              warnings: [RecommendationWarning.ShortPeriod],
-            },
-          }),
-        ],
-        defaultStrategy: AnalysisStrategy.PpNaive,
-      }),
+      Analyses.getAggregateRecommendation(
+        createAggregateRecommendationInput(
+          {
+            status: Status.Running,
+          },
+          [
+            Fixtures.createAnalysis({
+              analysisStrategy: AnalysisStrategy.PpNaive,
+              recommendation: {
+                endExperiment: false,
+                chosenVariationId: null,
+                reason: RecommendationReason.CiGreaterThanRope,
+                warnings: [RecommendationWarning.ShortPeriod],
+              },
+            }),
+          ],
+        ),
+      ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.MoreDataNeeded,
     })
     expect(
-      Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull({ status: Status.Running }),
-        metric: Fixtures.createMetricBares(1)[0],
-        metricAssignment: Fixtures.createMetricAssignment(),
-        analyses: [
+      Analyses.getAggregateRecommendation(
+        createAggregateRecommendationInput(
+          {
+            status: Status.Running,
+          },
+          [
+            Fixtures.createAnalysis({
+              analysisStrategy: AnalysisStrategy.PpNaive,
+              recommendation: {
+                endExperiment: true,
+                chosenVariationId: null,
+                reason: RecommendationReason.CiGreaterThanRope,
+                warnings: [RecommendationWarning.WideCi],
+              },
+            }),
+          ],
+        ),
+      ),
+    ).toEqual({
+      decision: Analyses.AggregateRecommendationDecision.MoreDataNeeded,
+    })
+    expect(
+      Analyses.getAggregateRecommendation(
+        createAggregateRecommendationInput({}, [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
               endExperiment: true,
               chosenVariationId: null,
               reason: RecommendationReason.CiGreaterThanRope,
-              warnings: [RecommendationWarning.WideCi],
-            },
-          }),
-        ],
-        defaultStrategy: AnalysisStrategy.PpNaive,
-      }),
-    ).toEqual({
-      decision: Analyses.AggregateRecommendationDecision.MoreDataNeeded,
-    })
-    expect(
-      Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull(),
-        metric: Fixtures.createMetricBares(1)[0],
-        metricAssignment: Fixtures.createMetricAssignment(),
-        analyses: [
-          Fixtures.createAnalysis({
-            analysisStrategy: AnalysisStrategy.PpNaive,
-            recommendation: {
-              endExperiment: true,
-              chosenVariationId: null,
-              reason: RecommendationReason.CiGreaterThanRope,
               warnings: [],
             },
           }),
-        ],
-        defaultStrategy: AnalysisStrategy.PpNaive,
-      }),
+        ]),
+      ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.DeployAnyVariation,
       shouldStop: false,
     })
     expect(
-      Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull({ status: Status.Running }),
-        metric: Fixtures.createMetricBares(1)[0],
-        metricAssignment: Fixtures.createMetricAssignment(),
-        analyses: [
-          Fixtures.createAnalysis({
-            analysisStrategy: AnalysisStrategy.PpNaive,
-            recommendation: {
-              endExperiment: true,
-              chosenVariationId: null,
-              reason: RecommendationReason.CiGreaterThanRope,
-              warnings: [RecommendationWarning.LongPeriod],
-            },
-          }),
-        ],
-        defaultStrategy: AnalysisStrategy.PpNaive,
-      }),
+      Analyses.getAggregateRecommendation(
+        createAggregateRecommendationInput(
+          {
+            status: Status.Running,
+          },
+          [
+            Fixtures.createAnalysis({
+              analysisStrategy: AnalysisStrategy.PpNaive,
+              recommendation: {
+                endExperiment: true,
+                chosenVariationId: null,
+                reason: RecommendationReason.CiGreaterThanRope,
+                warnings: [RecommendationWarning.LongPeriod],
+              },
+            }),
+          ],
+        ),
+      ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.DeployAnyVariation,
       shouldStop: true,
     })
     expect(
-      Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull({ status: Status.Disabled }),
-        metric: Fixtures.createMetricBares(1)[0],
-        metricAssignment: Fixtures.createMetricAssignment(),
-        analyses: [
-          Fixtures.createAnalysis({
-            analysisStrategy: AnalysisStrategy.PpNaive,
-            recommendation: {
-              endExperiment: true,
-              chosenVariationId: null,
-              reason: RecommendationReason.CiGreaterThanRope,
-              warnings: [RecommendationWarning.LongPeriod],
-            },
-          }),
-        ],
-        defaultStrategy: AnalysisStrategy.PpNaive,
-      }),
+      Analyses.getAggregateRecommendation(
+        createAggregateRecommendationInput(
+          {
+            status: Status.Disabled,
+          },
+          [
+            Fixtures.createAnalysis({
+              analysisStrategy: AnalysisStrategy.PpNaive,
+              recommendation: {
+                endExperiment: true,
+                chosenVariationId: null,
+                reason: RecommendationReason.CiGreaterThanRope,
+                warnings: [RecommendationWarning.LongPeriod],
+              },
+            }),
+          ],
+        ),
+      ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.DeployAnyVariation,
       shouldStop: false,
     })
     expect(
-      Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull(),
-        metric: Fixtures.createMetricBares(1)[0],
-        metricAssignment: Fixtures.createMetricAssignment(),
-        analyses: [
+      Analyses.getAggregateRecommendation(
+        createAggregateRecommendationInput({}, [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
@@ -218,20 +216,16 @@ describe('getAggregateRecommendation', () => {
               warnings: [],
             },
           }),
-        ],
-        defaultStrategy: AnalysisStrategy.PpNaive,
-      }),
+        ]),
+      ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.DeployChosenVariation,
       chosenVariationId: 123,
       shouldStop: false,
     })
     expect(
-      Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull(),
-        metric: Fixtures.createMetricBares(1)[0],
-        metricAssignment: Fixtures.createMetricAssignment(),
-        analyses: [
+      Analyses.getAggregateRecommendation(
+        createAggregateRecommendationInput({}, [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
@@ -241,9 +235,8 @@ describe('getAggregateRecommendation', () => {
               warnings: [RecommendationWarning.LongPeriod],
             },
           }),
-        ],
-        defaultStrategy: AnalysisStrategy.PpNaive,
-      }),
+        ]),
+      ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.DeployChosenVariation,
       chosenVariationId: 123,
@@ -253,11 +246,8 @@ describe('getAggregateRecommendation', () => {
 
   it('should work correctly for multiple analyses without conflict', () => {
     expect(
-      Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull(),
-        metric: Fixtures.createMetricBares(1)[0],
-        metricAssignment: Fixtures.createMetricAssignment(),
-        analyses: [
+      Analyses.getAggregateRecommendation(
+        createAggregateRecommendationInput({}, [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
@@ -276,9 +266,8 @@ describe('getAggregateRecommendation', () => {
               warnings: [],
             },
           }),
-        ],
-        defaultStrategy: AnalysisStrategy.PpNaive,
-      }),
+        ]),
+      ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.DeployChosenVariation,
       chosenVariationId: 123,
@@ -286,11 +275,8 @@ describe('getAggregateRecommendation', () => {
     })
 
     expect(
-      Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull(),
-        metric: Fixtures.createMetricBares(1)[0],
-        metricAssignment: Fixtures.createMetricAssignment(),
-        analyses: [
+      Analyses.getAggregateRecommendation(
+        createAggregateRecommendationInput({}, [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
@@ -304,9 +290,8 @@ describe('getAggregateRecommendation', () => {
             analysisStrategy: AnalysisStrategy.MittNoSpammersNoCrossovers,
             recommendation: null,
           }),
-        ],
-        defaultStrategy: AnalysisStrategy.PpNaive,
-      }),
+        ]),
+      ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.DeployChosenVariation,
       chosenVariationId: 123,
@@ -314,11 +299,8 @@ describe('getAggregateRecommendation', () => {
     })
 
     expect(
-      Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull(),
-        metric: Fixtures.createMetricBares(1)[0],
-        metricAssignment: Fixtures.createMetricAssignment(),
-        analyses: [
+      Analyses.getAggregateRecommendation(
+        createAggregateRecommendationInput({}, [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
@@ -332,20 +314,16 @@ describe('getAggregateRecommendation', () => {
             analysisStrategy: AnalysisStrategy.MittNoSpammersNoCrossovers,
             recommendation: null,
           }),
-        ],
-        defaultStrategy: AnalysisStrategy.PpNaive,
-      }),
+        ]),
+      ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.DeployAnyVariation,
       shouldStop: false,
     })
 
     expect(
-      Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull(),
-        metric: Fixtures.createMetricBares(1)[0],
-        metricAssignment: Fixtures.createMetricAssignment(),
-        analyses: [
+      Analyses.getAggregateRecommendation(
+        createAggregateRecommendationInput({}, [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
@@ -364,18 +342,14 @@ describe('getAggregateRecommendation', () => {
               warnings: [],
             },
           }),
-        ],
-        defaultStrategy: AnalysisStrategy.PpNaive,
-      }),
+        ]),
+      ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.Inconclusive,
     })
     expect(
-      Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull(),
-        metric: Fixtures.createMetricBares(1)[0],
-        metricAssignment: Fixtures.createMetricAssignment(),
-        analyses: [
+      Analyses.getAggregateRecommendation(
+        createAggregateRecommendationInput({}, [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: null,
@@ -389,20 +363,16 @@ describe('getAggregateRecommendation', () => {
               warnings: [],
             },
           }),
-        ],
-        defaultStrategy: AnalysisStrategy.PpNaive,
-      }),
+        ]),
+      ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.MissingAnalysis,
     })
   })
   it('should work correctly for multiple analyses with conflict', () => {
     expect(
-      Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull(),
-        metric: Fixtures.createMetricBares(1)[0],
-        metricAssignment: Fixtures.createMetricAssignment(),
-        analyses: [
+      Analyses.getAggregateRecommendation(
+        createAggregateRecommendationInput({}, [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
@@ -421,19 +391,15 @@ describe('getAggregateRecommendation', () => {
               warnings: [],
             },
           }),
-        ],
-        defaultStrategy: AnalysisStrategy.PpNaive,
-      }),
+        ]),
+      ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.ManualAnalysisRequired,
     })
 
     expect(
-      Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull(),
-        metric: Fixtures.createMetricBares(1)[0],
-        metricAssignment: Fixtures.createMetricAssignment(),
-        analyses: [
+      Analyses.getAggregateRecommendation(
+        createAggregateRecommendationInput({}, [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
@@ -452,19 +418,15 @@ describe('getAggregateRecommendation', () => {
               warnings: [],
             },
           }),
-        ],
-        defaultStrategy: AnalysisStrategy.PpNaive,
-      }),
+        ]),
+      ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.ManualAnalysisRequired,
     })
 
     expect(
-      Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull(),
-        metric: Fixtures.createMetricBares(1)[0],
-        metricAssignment: Fixtures.createMetricAssignment(),
-        analyses: [
+      Analyses.getAggregateRecommendation(
+        createAggregateRecommendationInput({}, [
           Fixtures.createAnalysis({
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: {
@@ -496,9 +458,8 @@ describe('getAggregateRecommendation', () => {
             analysisStrategy: AnalysisStrategy.PpNaive,
             recommendation: null,
           }),
-        ],
-        defaultStrategy: AnalysisStrategy.PpNaive,
-      }),
+        ]),
+      ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.ManualAnalysisRequired,
     })

--- a/src/lib/analyses.test.ts
+++ b/src/lib/analyses.test.ts
@@ -34,7 +34,7 @@ describe('getAggregateRecommendation', () => {
     })
     expect(
       Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull({ status: Status.Running}),
+        experiment: Fixtures.createExperimentFull({ status: Status.Running }),
         metric: Fixtures.createMetricBares(1)[0],
         metricAssignment: Fixtures.createMetricAssignment(),
         analyses: [
@@ -55,7 +55,7 @@ describe('getAggregateRecommendation', () => {
     })
     expect(
       Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull({ status: Status.Completed}),
+        experiment: Fixtures.createExperimentFull({ status: Status.Completed }),
         metric: Fixtures.createMetricBares(1)[0],
         metricAssignment: Fixtures.createMetricAssignment(),
         analyses: [
@@ -76,7 +76,7 @@ describe('getAggregateRecommendation', () => {
     })
     expect(
       Analyses.getAggregateRecommendation({
-        experiment: Fixtures.createExperimentFull({ status: Status.Disabled}),
+        experiment: Fixtures.createExperimentFull({ status: Status.Disabled }),
         metric: Fixtures.createMetricBares(1)[0],
         metricAssignment: Fixtures.createMetricAssignment(),
         analyses: [


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
_I've decided to split this up differently, with the presentation seperate to the logic changes as much as I can._

**This PR integrates stopping info into AggregateRecommendation:**
- Added "MoreDataNeeded" decision for running experiments that need more data.
  - In the ETL code `experiments/recommender.py#L40-L47` we find that warnings take precedence.
  - We want to integrate that into the top level decision, otherwise it will just get ignored as a warning or experimenters won't know what to do with it.
  - This does cause some "Deploy" recommendations to become "Inconclusive" but we will rebalance this by adding _lift_ as a column to the top level metric assignment line.
  - As a decision we switch it to "Inconclusive" once the experiment has stopped running and running it longer is no longer a choice.
- Added `shouldStop` as a soft stopping recommendation.
- Decided that we don't need to move the python code here yet, we have isolated all our recommendation in one pure function with a nice recommendation interface forming. It should be simple to do so later if we need and won't particularly add anything at the moment.
- Refactored the test code as it was getting quite large
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
