### PR TITLE
Alter recommendation decision for experiments that are assigned upfront

### DIFF
--- a/src/lib/analyses.test.ts
+++ b/src/lib/analyses.test.ts
@@ -5,6 +5,7 @@ import {
   Analysis,
   AnalysisStrategy,
   ExperimentFull,
+  Platform,
   RecommendationReason,
   RecommendationWarning,
   Status,
@@ -117,6 +118,30 @@ describe('getAggregateRecommendation', () => {
       ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.MoreDataNeeded,
+    })
+    expect(
+      Analyses.getAggregateRecommendation(
+        createAggregateRecommendationInput(
+          {
+            status: Status.Running,
+            platform: Platform.Email,
+          },
+          [
+            Fixtures.createAnalysis({
+              analysisStrategy: AnalysisStrategy.PpNaive,
+              recommendation: {
+                endExperiment: true,
+                chosenVariationId: null,
+                reason: RecommendationReason.CiGreaterThanRope,
+                warnings: [RecommendationWarning.ShortPeriod],
+              },
+            }),
+          ],
+        ),
+      ),
+    ).toEqual({
+      decision: Analyses.AggregateRecommendationDecision.DeployAnyVariation,
+      shouldStop: false,
     })
     expect(
       Analyses.getAggregateRecommendation(

--- a/src/lib/analyses.ts
+++ b/src/lib/analyses.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 
+import * as Experiments from './experiments'
 import {
   Analysis,
   AnalysisStrategy,
@@ -89,9 +90,11 @@ export function getAggregateRecommendation({
   }
 
   // Following the endExperiment+warnings description in experiments/recommender.py:Recommendation:
+  // In the future we will move the recommendation logic here.
   if (
     !recommendation.endExperiment ||
-    recommendation.warnings.includes(RecommendationWarning.ShortPeriod) ||
+    (recommendation.warnings.includes(RecommendationWarning.ShortPeriod) &&
+      !Experiments.isExperimentAssignedUpfront(experiment)) ||
     recommendation.warnings.includes(RecommendationWarning.WideCi)
   ) {
     if (experiment.status === Status.Running) {

--- a/src/lib/experiments.test.ts
+++ b/src/lib/experiments.test.ts
@@ -1,50 +1,59 @@
 import Fixtures from 'src/test-helpers/fixtures'
 
 import * as Experiments from './experiments'
-import { AnalysisStrategy } from './schemas'
+import { AnalysisStrategy, Platform } from './schemas'
 
-describe('lib/experiments.ts module', () => {
-  describe('getDeployedVariation', () => {
-    it('should return null when no deployed variation declared', () => {
-      expect(Experiments.getDeployedVariation(Fixtures.createExperimentFull())).toBeNull()
-    })
+describe('getDeployedVariation', () => {
+  it('should return null when no deployed variation declared', () => {
+    expect(Experiments.getDeployedVariation(Fixtures.createExperimentFull())).toBeNull()
+  })
 
-    it('should return the deployed variation when declared', () => {
-      expect(Experiments.getDeployedVariation(Fixtures.createExperimentFull({ deployedVariationId: 1 }))).toEqual({
-        variationId: 1,
-        name: 'control',
-        isDefault: true,
-        allocatedPercentage: 60,
-      })
-    })
-
-    it('should throw an error when deployed variation is declared but cannot be resolved', () => {
-      expect(() => {
-        Experiments.getDeployedVariation(Fixtures.createExperimentFull({ deployedVariationId: 0 }))
-      }).toThrowError()
+  it('should return the deployed variation when declared', () => {
+    expect(Experiments.getDeployedVariation(Fixtures.createExperimentFull({ deployedVariationId: 1 }))).toEqual({
+      variationId: 1,
+      name: 'control',
+      isDefault: true,
+      allocatedPercentage: 60,
     })
   })
 
-  describe('getPrimaryMetricAssignmentId', () => {
-    it('returns the primary assignment ID when it exists', () => {
-      expect(Experiments.getPrimaryMetricAssignmentId(Fixtures.createExperimentFull())).toBe(123)
-    })
+  it('should throw an error when deployed variation is declared but cannot be resolved', () => {
+    expect(() => {
+      Experiments.getDeployedVariation(Fixtures.createExperimentFull({ deployedVariationId: 0 }))
+    }).toThrowError()
+  })
+})
 
-    it('returns undefined when no primary assignment ID exists', () => {
-      expect(
-        Experiments.getPrimaryMetricAssignmentId(Fixtures.createExperimentFull({ metricAssignments: [] })),
-      ).toBeNull()
-    })
+describe('getPrimaryMetricAssignmentId', () => {
+  it('returns the primary assignment ID when it exists', () => {
+    expect(Experiments.getPrimaryMetricAssignmentId(Fixtures.createExperimentFull())).toBe(123)
   })
 
-  describe('getDefaultAnalysisSummary', () => {
-    it('returns the correct strategy based on the exposureEvents', () => {
-      expect(Experiments.getDefaultAnalysisStrategy(Fixtures.createExperimentFull({ exposureEvents: null }))).toBe(
-        AnalysisStrategy.MittNoSpammersNoCrossovers,
-      )
-      expect(
-        Experiments.getDefaultAnalysisStrategy(Fixtures.createExperimentFull({ exposureEvents: [{ event: 'ev1' }] })),
-      ).toBe(AnalysisStrategy.PpNaive)
-    })
+  it('returns undefined when no primary assignment ID exists', () => {
+    expect(
+      Experiments.getPrimaryMetricAssignmentId(Fixtures.createExperimentFull({ metricAssignments: [] })),
+    ).toBeNull()
+  })
+})
+
+describe('getDefaultAnalysisSummary', () => {
+  it('returns the correct strategy based on the exposureEvents', () => {
+    expect(Experiments.getDefaultAnalysisStrategy(Fixtures.createExperimentFull({ exposureEvents: null }))).toBe(
+      AnalysisStrategy.MittNoSpammersNoCrossovers,
+    )
+    expect(
+      Experiments.getDefaultAnalysisStrategy(Fixtures.createExperimentFull({ exposureEvents: [{ event: 'ev1' }] })),
+    ).toBe(AnalysisStrategy.PpNaive)
+  })
+})
+
+describe('isExperimentAssignedUpfront', () => {
+  it('works correctly', () => {
+    expect(Experiments.isExperimentAssignedUpfront(Fixtures.createExperimentFull({ platform: Platform.Email }))).toBe(
+      true,
+    )
+    expect(Experiments.isExperimentAssignedUpfront(Fixtures.createExperimentFull({ platform: Platform.Calypso }))).toBe(
+      false,
+    )
   })
 })

--- a/src/lib/experiments.ts
+++ b/src/lib/experiments.ts
@@ -55,3 +55,14 @@ export const AssignmentCacheStatusToHuman: Record<AssignmentCacheStatus, string>
   [AssignmentCacheStatus.Missing]: '❌️ Missing: Expected for new, renamed, or disabled experiments',
   [AssignmentCacheStatus.Stale]: '❌️ Stale: Recent changes take up to ten minutes to propagate',
 }
+
+const platformsAssignedUpfront = [Platform.Email]
+
+/**
+ * An Assigned Upfront Experiment is an experiment where all assignments are performed up front,
+ * this means that there is no posibility of getting more data. E.g. email experiments where all
+ * emails are sent at once.
+ */
+export function isExperimentAssignedUpfront(experiment: ExperimentFull): boolean {
+  return platformsAssignedUpfront.includes(experiment.platform)
+}


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR:**
- Introduces the idea of experiments assigned up front.
- Ignores the time based warning for these experiments.
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
