### PR TITLE
Fix recommendation shouldStop

### DIFF
--- a/src/lib/analyses.test.ts
+++ b/src/lib/analyses.test.ts
@@ -23,6 +23,7 @@ describe('getAggregateRecommendation', () => {
   it('should work correctly for single analyses', () => {
     expect(Analyses.getAggregateRecommendation(createAggregateRecommendationInput({}, []))).toEqual({
       decision: Analyses.AggregateRecommendationDecision.MissingAnalysis,
+      shouldStop: false,
     })
     expect(
       Analyses.getAggregateRecommendation(
@@ -35,6 +36,7 @@ describe('getAggregateRecommendation', () => {
       ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.MissingAnalysis,
+      shouldStop: false,
     })
     expect(
       Analyses.getAggregateRecommendation(
@@ -52,6 +54,7 @@ describe('getAggregateRecommendation', () => {
       ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.MoreDataNeeded,
+      shouldStop: false,
     })
     expect(
       Analyses.getAggregateRecommendation(
@@ -74,6 +77,7 @@ describe('getAggregateRecommendation', () => {
       ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.Inconclusive,
+      shouldStop: false,
     })
     expect(
       Analyses.getAggregateRecommendation(
@@ -96,6 +100,7 @@ describe('getAggregateRecommendation', () => {
       ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.Inconclusive,
+      shouldStop: false,
     })
     expect(
       Analyses.getAggregateRecommendation(
@@ -118,6 +123,7 @@ describe('getAggregateRecommendation', () => {
       ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.MoreDataNeeded,
+      shouldStop: false,
     })
     expect(
       Analyses.getAggregateRecommendation(
@@ -164,6 +170,7 @@ describe('getAggregateRecommendation', () => {
       ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.MoreDataNeeded,
+      shouldStop: false,
     })
     expect(
       Analyses.getAggregateRecommendation(
@@ -371,6 +378,7 @@ describe('getAggregateRecommendation', () => {
       ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.Inconclusive,
+      shouldStop: false,
     })
     expect(
       Analyses.getAggregateRecommendation(
@@ -392,6 +400,7 @@ describe('getAggregateRecommendation', () => {
       ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.MissingAnalysis,
+      shouldStop: false,
     })
   })
   it('should work correctly for multiple analyses with conflict', () => {
@@ -420,6 +429,7 @@ describe('getAggregateRecommendation', () => {
       ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.ManualAnalysisRequired,
+      shouldStop: false,
     })
 
     expect(
@@ -447,6 +457,7 @@ describe('getAggregateRecommendation', () => {
       ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.ManualAnalysisRequired,
+      shouldStop: false,
     })
 
     expect(
@@ -487,6 +498,7 @@ describe('getAggregateRecommendation', () => {
       ),
     ).toEqual({
       decision: Analyses.AggregateRecommendationDecision.ManualAnalysisRequired,
+      shouldStop: false,
     })
   })
 })


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
This PR displays `shouldStop` under decisions except for `MissingAnalysis`.
- Makes `shouldStop` not optional.
- Moves Manual Analysis after Missing analysis.
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
