### PR TITLE
Implement extended number schema

### DIFF
--- a/src/lib/schemas.test.ts
+++ b/src/lib/schemas.test.ts
@@ -338,4 +338,49 @@ describe('lib/schemas.ts module', () => {
       }
     })
   })
+
+  describe('extendedNumberSchema', () => {
+    it('should work as expected with normal numbers', () => {
+      expect(Schemas.extendedNumberSchema.validateSync(Number.MIN_SAFE_INTEGER)).toBe(Number.MIN_SAFE_INTEGER)
+      expect(Schemas.extendedNumberSchema.validateSync(-1)).toBe(-1)
+      expect(Schemas.extendedNumberSchema.validateSync(0)).toBe(0)
+      expect(Schemas.extendedNumberSchema.validateSync(1)).toBe(1)
+      expect(Schemas.extendedNumberSchema.validateSync(Number.MIN_VALUE)).toBe(Number.MIN_VALUE)
+      expect(Schemas.extendedNumberSchema.validateSync(Number.MAX_SAFE_INTEGER)).toBe(Number.MAX_SAFE_INTEGER)
+    })
+    it('should work as expected with number extensions', () => {
+      expect(Schemas.extendedNumberSchema.validateSync(NaN)).toBe(NaN)
+      expect(Schemas.extendedNumberSchema.validateSync('nan')).toBe(NaN)
+      expect(Schemas.extendedNumberSchema.validateSync(Infinity)).toBe(Infinity)
+      expect(Schemas.extendedNumberSchema.validateSync('inf')).toBe(Infinity)
+      expect(Schemas.extendedNumberSchema.validateSync(-Infinity)).toBe(-Infinity)
+      expect(Schemas.extendedNumberSchema.validateSync('-inf')).toBe(-Infinity)
+    })
+    it('should throw validation errors for non extended-numbers', () => {
+      expect(() => Schemas.extendedNumberSchema.validateSync('')).toThrowErrorMatchingInlineSnapshot(
+        `"this is not a number"`,
+      )
+      expect(() => Schemas.extendedNumberSchema.validateSync('asdf')).toThrowErrorMatchingInlineSnapshot(
+        `"this is not a number"`,
+      )
+      expect(() => Schemas.extendedNumberSchema.validateSync({})).toThrowErrorMatchingInlineSnapshot(
+        `"this is not a number"`,
+      )
+      expect(() => Schemas.extendedNumberSchema.validateSync(true)).toThrowErrorMatchingInlineSnapshot(
+        `"this is not a number"`,
+      )
+      expect(() => Schemas.extendedNumberSchema.validateSync(false)).toThrowErrorMatchingInlineSnapshot(
+        `"this is not a number"`,
+      )
+      expect(() => Schemas.extendedNumberSchema.validateSync(null)).toThrowErrorMatchingInlineSnapshot(
+        `"this is not a number"`,
+      )
+    })
+    it('should respect undefined', () => {
+      expect(Schemas.extendedNumberSchema.validateSync(undefined)).toBe(undefined)
+      expect(() => Schemas.extendedNumberSchema.defined().validateSync(undefined)).toThrowErrorMatchingInlineSnapshot(
+        `"this must be defined"`,
+      )
+    })
+  })
 })

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -31,7 +31,7 @@ const dateSchema = yup
  * See https://github.com/jquense/yup/issues/1330
  */
 export const extendedNumberSchema = yup
-  .mixed()
+  .mixed<number | undefined>()
   .transform((value: unknown, originalValue: unknown) => {
     if (originalValue === 'nan' || (typeof originalValue === 'number' && isNaN(originalValue))) {
       return NaN

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -445,9 +445,20 @@ export interface Recommendation extends yup.InferType<typeof recommendationSchem
 
 export const metricEstimateSchema = yup
   .object({
+    /**
+     * @deprecated Misleading, use the CIs below.
+     */
     estimate: extendedNumberSchema.defined(),
+    // These are for 95% CI, and should become deprecated when top_95 and bottom_95 are used
     top: extendedNumberSchema.defined(),
     bottom: extendedNumberSchema.defined(),
+    // For future use:
+    top_99: extendedNumberSchema,
+    bottom_99: extendedNumberSchema,
+    top_95: extendedNumberSchema,
+    bottom_95: extendedNumberSchema,
+    top_50: extendedNumberSchema,
+    bottom_50: extendedNumberSchema,
   })
   .defined()
   .camelCase()


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR:**
- Adds an extended number schema to allow string representations of `NaN`, `Infinity` coming from python
   See p1617871045009900/1617865429.001800-slack-G01BQ5WMR8Q
- Uses it in metricEstimates
- Prepares metricEstimates for multiple confidence intervals
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Part of 443-gh-Automattic/experimentation-platform

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
