### PR TITLE
Demo: Experiments AgGrid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10930,6 +10930,14 @@
       "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-25.1.0.tgz",
       "integrity": "sha512-sKJp6SZG8J50OlOeECtrLFSp/iwdx1mcG0+BmIkHsXmWoyXv5ZaTJyVg1/hMk6s3JVTm1ipg6LepbTaigWEL2A=="
     },
+    "ag-grid-react": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/ag-grid-react/-/ag-grid-react-25.1.0.tgz",
+      "integrity": "sha512-9xboQWDde2oANitsI/RbsS/rMFVLzXLGyteEBjxSyKGrGDOwAK6XHgvfbGSBL2yWVrYDUD5HRHCdfNejO4FPGA==",
+      "requires": {
+        "prop-types": "^15.6.2"
+      }
+    },
     "agent-base": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6495,11 +6495,135 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@stdlib/array": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/array"
+    },
+    "@stdlib/assert": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/assert"
+    },
+    "@stdlib/bench": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/bench"
+    },
+    "@stdlib/blas": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/blas"
+    },
+    "@stdlib/buffer": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/buffer"
+    },
+    "@stdlib/complex": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/complex"
+    },
+    "@stdlib/constants": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/constants"
+    },
+    "@stdlib/crypto": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/crypto"
+    },
+    "@stdlib/datasets": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/datasets"
+    },
+    "@stdlib/error": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/error"
+    },
+    "@stdlib/fastmath": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/fastmath"
+    },
+    "@stdlib/fs": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/fs"
+    },
+    "@stdlib/iter": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/iter"
+    },
+    "@stdlib/math": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/math"
+    },
+    "@stdlib/ml": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/ml"
+    },
+    "@stdlib/namespace": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/namespace"
+    },
+    "@stdlib/ndarray": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/ndarray"
+    },
+    "@stdlib/net": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/net"
+    },
+    "@stdlib/nlp": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/nlp"
+    },
+    "@stdlib/number": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/number"
+    },
+    "@stdlib/os": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/os"
+    },
+    "@stdlib/plot": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/plot"
+    },
+    "@stdlib/process": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/process"
+    },
+    "@stdlib/proxy": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/proxy"
+    },
+    "@stdlib/random": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/random"
+    },
+    "@stdlib/regexp": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/regexp"
+    },
+    "@stdlib/repl": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/repl"
+    },
+    "@stdlib/simulate": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/simulate"
+    },
+    "@stdlib/stats": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/stats"
+    },
     "@stdlib/stdlib": {
       "version": "0.0.93",
       "resolved": "https://registry.npmjs.org/@stdlib/stdlib/-/stdlib-0.0.93.tgz",
       "integrity": "sha512-PhdIt1GqpA1qKwoaghTo3jy1pXew9c6mnzT+QTp0P6Qze6hmww3qJCFOniB2NeOAYe0eOA0OriWX3wrpCRSQKA==",
       "requires": {
+        "@stdlib/array": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/array",
+        "@stdlib/assert": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/assert",
+        "@stdlib/bench": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/bench",
+        "@stdlib/blas": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/blas",
+        "@stdlib/buffer": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/buffer",
+        "@stdlib/complex": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/complex",
+        "@stdlib/constants": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/constants",
+        "@stdlib/crypto": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/crypto",
+        "@stdlib/datasets": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/datasets",
+        "@stdlib/error": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/error",
+        "@stdlib/fastmath": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/fastmath",
+        "@stdlib/fs": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/fs",
+        "@stdlib/iter": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/iter",
+        "@stdlib/math": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/math",
+        "@stdlib/ml": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/ml",
+        "@stdlib/namespace": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/namespace",
+        "@stdlib/ndarray": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/ndarray",
+        "@stdlib/net": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/net",
+        "@stdlib/nlp": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/nlp",
+        "@stdlib/number": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/number",
+        "@stdlib/os": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/os",
+        "@stdlib/plot": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/plot",
+        "@stdlib/process": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/process",
+        "@stdlib/proxy": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/proxy",
+        "@stdlib/random": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/random",
+        "@stdlib/regexp": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/regexp",
+        "@stdlib/repl": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/repl",
+        "@stdlib/simulate": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/simulate",
+        "@stdlib/stats": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/stats",
+        "@stdlib/streams": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/streams",
+        "@stdlib/strided": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/strided",
+        "@stdlib/string": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/string",
+        "@stdlib/symbol": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/symbol",
+        "@stdlib/time": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/time",
+        "@stdlib/tools": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/tools",
+        "@stdlib/types": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/types",
+        "@stdlib/utils": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/utils",
         "acorn": "^7.0.0",
         "acorn-loose": "^7.0.0",
         "acorn-walk": "^7.0.0",
@@ -6537,6 +6661,30 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
+    },
+    "@stdlib/streams": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/streams"
+    },
+    "@stdlib/strided": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/strided"
+    },
+    "@stdlib/string": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/string"
+    },
+    "@stdlib/symbol": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/symbol"
+    },
+    "@stdlib/time": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/time"
+    },
+    "@stdlib/tools": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/tools"
+    },
+    "@stdlib/types": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/types"
+    },
+    "@stdlib/utils": {
+      "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/utils"
     },
     "@storybook/addons": {
       "version": "6.0.28",
@@ -10776,6 +10924,11 @@
       "requires": {
         "robust-orientation": "^1.1.3"
       }
+    },
+    "ag-grid-community": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-25.1.0.tgz",
+      "integrity": "sha512-sKJp6SZG8J50OlOeECtrLFSp/iwdx1mcG0+BmIkHsXmWoyXv5ZaTJyVg1/hMk6s3JVTm1ipg6LepbTaigWEL2A=="
     },
     "agent-base": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@stdlib/stdlib": "0.0.93",
     "@types/react-plotly.js": "^2.2.4",
     "@types/react-router-dom": "^5.1.6",
+    "ag-grid-community": "^25.1.0",
     "clsx": "^1.1.1",
     "date-fns": "^2.13.0",
     "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@types/react-plotly.js": "^2.2.4",
     "@types/react-router-dom": "^5.1.6",
     "ag-grid-community": "^25.1.0",
+    "ag-grid-react": "^25.1.0",
     "clsx": "^1.1.1",
     "date-fns": "^2.13.0",
     "debug": "^4.1.1",

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter as Router, Redirect, Route, Switch } from 'react-router-d
 import AuthCallback from 'src/pages/AuthCallback'
 import Experiment from 'src/pages/experiments/Experiment'
 import Experiments from 'src/pages/experiments/Experiments'
+import ExperimentsAgGrid from 'src/pages/experiments/ExperimentsAgGrid'
 import ExperimentWizard, { ExperimentWizardMode } from 'src/pages/experiments/ExperimentWizard'
 import Metrics from 'src/pages/Metrics'
 import Tags from 'src/pages/Tags'
@@ -28,6 +29,10 @@ export default function Routes(): JSX.Element {
 
         <Route path='/experiments' exact>
           <Experiments />
+        </Route>
+
+        <Route path='/experiments-ag-grid' exact>
+          <ExperimentsAgGrid />
         </Route>
 
         <Route path='/experiments/new' exact>

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -31,7 +31,7 @@ export default function Routes(): JSX.Element {
           <Experiments />
         </Route>
 
-        <Route path='/experiments-ag-grid' exact>
+        <Route path='/experiments-ag' exact>
           <ExperimentsAgGrid />
         </Route>
 

--- a/src/components/experiments/multi-view/ExperimentsTableAgGrid.tsx
+++ b/src/components/experiments/multi-view/ExperimentsTableAgGrid.tsx
@@ -1,0 +1,81 @@
+import { useTheme } from '@material-ui/core'
+import debugFactory from 'debug'
+import MaterialTable from 'material-table'
+import React from 'react'
+import { useHistory } from 'react-router-dom'
+
+import DatetimeText from 'src/components/general/DatetimeText'
+import { ExperimentBare } from 'src/lib/schemas'
+import { createIdSlug } from 'src/utils/general'
+import { defaultTableOptions } from 'src/utils/material-table'
+
+import ExperimentStatus from '../ExperimentStatus'
+
+const debug = debugFactory('abacus:components/ExperimentsTable.tsx')
+
+/**
+ * Renders a table of "bare" experiment information.
+ */
+const ExperimentsTable = ({ experiments }: { experiments: ExperimentBare[] }): JSX.Element => {
+  debug('ExperimentsTable#render')
+  const history = useHistory()
+  const theme = useTheme()
+
+  /* istanbul ignore next; to be handled by an e2e test */
+  const handleRowClick = (event?: React.MouseEvent, rowData?: ExperimentBare) => {
+    if (!rowData) {
+      throw new Error('Missing experimentId')
+    }
+    history.push(`/experiments/${createIdSlug(rowData.experimentId, rowData.name)}`)
+  }
+
+  return (
+    <MaterialTable
+      columns={[
+        {
+          title: 'Name',
+          field: 'name',
+          cellStyle: {
+            fontFamily: theme.custom.fonts.monospace,
+            fontWeight: 600,
+          },
+        },
+        {
+          title: 'Status',
+          field: 'status',
+          render: (experiment) => <ExperimentStatus status={experiment.status} />,
+        },
+        {
+          title: 'Platform',
+          field: 'platform',
+          cellStyle: {
+            fontFamily: theme.custom.fonts.monospace,
+          },
+        },
+        {
+          title: 'Owner',
+          field: 'ownerLogin',
+          cellStyle: {
+            fontFamily: theme.custom.fonts.monospace,
+          },
+        },
+        {
+          title: 'Start',
+          field: 'startDatetime',
+          defaultSort: 'desc',
+          render: (experiment) => <DatetimeText datetime={experiment.startDatetime} excludeTime />,
+        },
+        {
+          title: 'End',
+          field: 'endDatetime',
+          render: (experiment) => <DatetimeText datetime={experiment.endDatetime} excludeTime />,
+        },
+      ]}
+      data={experiments}
+      onRowClick={handleRowClick}
+      options={defaultTableOptions}
+    />
+  )
+}
+
+export default ExperimentsTable

--- a/src/components/experiments/multi-view/ExperimentsTableAgGrid.tsx
+++ b/src/components/experiments/multi-view/ExperimentsTableAgGrid.tsx
@@ -95,9 +95,8 @@ const ExperimentsTable = ({ experiments }: { experiments: ExperimentBare[] }): J
             cellRendererFramework: ({ value: startDatetime }: { value: Date }) => {
               return <DatetimeText datetime={startDatetime} excludeTime />
             },
-            // defaultSort: 'desc',
             sortable: true,
-            filter: true,
+            filter: 'agDateColumnFilter',
             resizable: true,
           },
           {
@@ -107,7 +106,7 @@ const ExperimentsTable = ({ experiments }: { experiments: ExperimentBare[] }): J
               return <DatetimeText datetime={endDatetime} excludeTime />
             },
             sortable: true,
-            filter: true,
+            filter: 'agDateColumnFilter',
             resizable: true,
           },
         ]}

--- a/src/components/experiments/multi-view/ExperimentsTableAgGrid.tsx
+++ b/src/components/experiments/multi-view/ExperimentsTableAgGrid.tsx
@@ -1,80 +1,135 @@
-import { useTheme } from '@material-ui/core'
-import debugFactory from 'debug'
-import MaterialTable from 'material-table'
+// istanbul ignore file; demo
+import 'ag-grid-community/dist/styles/ag-grid.css'
+import 'ag-grid-community/dist/styles/ag-theme-alpine.css'
+
+import { createStyles, makeStyles, Theme, useTheme } from '@material-ui/core'
+import { AgGridReact } from 'ag-grid-react'
+import clsx from 'clsx'
 import React from 'react'
-import { useHistory } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 
 import DatetimeText from 'src/components/general/DatetimeText'
-import { ExperimentBare } from 'src/lib/schemas'
+import { ExperimentBare, Status } from 'src/lib/schemas'
 import { createIdSlug } from 'src/utils/general'
-import { defaultTableOptions } from 'src/utils/material-table'
 
 import ExperimentStatus from '../ExperimentStatus'
 
-const debug = debugFactory('abacus:components/ExperimentsTable.tsx')
+const statusOrder = {
+  [Status.Completed]: 0,
+  [Status.Running]: 1,
+  [Status.Staging]: 2,
+  [Status.Disabled]: 3,
+}
+const statusComparator = (statusA: Status, statusB: Status) => {
+  return statusOrder[statusA] - statusOrder[statusB]
+}
+
+const useStyles = makeStyles((_theme: Theme) =>
+  createStyles({
+    root: {
+      height: 600,
+    },
+  }),
+)
 
 /**
  * Renders a table of "bare" experiment information.
  */
 const ExperimentsTable = ({ experiments }: { experiments: ExperimentBare[] }): JSX.Element => {
-  debug('ExperimentsTable#render')
-  const history = useHistory()
   const theme = useTheme()
-
-  /* istanbul ignore next; to be handled by an e2e test */
-  const handleRowClick = (event?: React.MouseEvent, rowData?: ExperimentBare) => {
-    if (!rowData) {
-      throw new Error('Missing experimentId')
-    }
-    history.push(`/experiments/${createIdSlug(rowData.experimentId, rowData.name)}`)
-  }
+  const classes = useStyles()
 
   return (
-    <MaterialTable
-      columns={[
-        {
-          title: 'Name',
-          field: 'name',
-          cellStyle: {
-            fontFamily: theme.custom.fonts.monospace,
-            fontWeight: 600,
+    <div className={clsx('ag-theme-alpine', classes.root)}>
+      <AgGridReact
+        columnDefs={[
+          {
+            headerName: 'Name',
+            field: 'name',
+            cellStyle: {
+              fontFamily: theme.custom.fonts.monospace,
+              fontWeight: 600,
+            },
+            cellRendererFramework: ({ value: name, data }: { value: Status; data: ExperimentBare }) => (
+              <Link to={`/experiments/${createIdSlug(data.experimentId, data.name)}`}>{name}</Link>
+            ),
+            sortable: true,
+            filter: true,
+            resizable: true,
+            flex: 0,
           },
-        },
-        {
-          title: 'Status',
-          field: 'status',
-          render: (experiment) => <ExperimentStatus status={experiment.status} />,
-        },
-        {
-          title: 'Platform',
-          field: 'platform',
-          cellStyle: {
-            fontFamily: theme.custom.fonts.monospace,
+          {
+            headerName: 'Status',
+            field: 'status',
+            cellRendererFramework: ({ value: status }: { value: Status }) => <ExperimentStatus status={status} />,
+            comparator: statusComparator,
+            sortable: true,
+            filter: true,
+            resizable: true,
           },
-        },
-        {
-          title: 'Owner',
-          field: 'ownerLogin',
-          cellStyle: {
-            fontFamily: theme.custom.fonts.monospace,
+          {
+            headerName: 'Platform',
+            field: 'platform',
+            cellStyle: {
+              fontFamily: theme.custom.fonts.monospace,
+            },
+            sortable: true,
+            filter: true,
+            resizable: true,
           },
-        },
-        {
-          title: 'Start',
-          field: 'startDatetime',
-          defaultSort: 'desc',
-          render: (experiment) => <DatetimeText datetime={experiment.startDatetime} excludeTime />,
-        },
-        {
-          title: 'End',
-          field: 'endDatetime',
-          render: (experiment) => <DatetimeText datetime={experiment.endDatetime} excludeTime />,
-        },
-      ]}
-      data={experiments}
-      onRowClick={handleRowClick}
-      options={defaultTableOptions}
-    />
+          {
+            headerName: 'Owner',
+            field: 'ownerLogin',
+            cellStyle: {
+              fontFamily: theme.custom.fonts.monospace,
+            },
+            sortable: true,
+            filter: true,
+            resizable: true,
+          },
+          {
+            headerName: 'Start',
+            field: 'startDatetime',
+            cellRendererFramework: ({ value: startDatetime }: { value: Date }) => {
+              return <DatetimeText datetime={startDatetime} excludeTime />
+            },
+            // defaultSort: 'desc',
+            sortable: true,
+            filter: true,
+            resizable: true,
+          },
+          {
+            headerName: 'End',
+            field: 'endDatetime',
+            cellRendererFramework: ({ value: endDatetime }: { value: Date }) => {
+              return <DatetimeText datetime={endDatetime} excludeTime />
+            },
+            sortable: true,
+            filter: true,
+            resizable: true,
+          },
+        ]}
+        rowData={experiments}
+        onFirstDataRendered={(event) => {
+          event.columnApi.autoSizeAllColumns()
+          event.columnApi.applyColumnState({
+            state: [
+              {
+                colId: 'status',
+                sort: 'asc',
+                sortIndex: 0,
+              },
+              {
+                colId: 'startDatetime',
+                sort: 'desc',
+                sortIndex: 1,
+              },
+            ],
+            defaultState: { sort: null },
+          })
+        }}
+      />
+    </div>
   )
 }
 

--- a/src/components/experiments/multi-view/ExperimentsTableAgGrid.tsx
+++ b/src/components/experiments/multi-view/ExperimentsTableAgGrid.tsx
@@ -2,11 +2,11 @@
 import 'ag-grid-community/dist/styles/ag-grid.css'
 import 'ag-grid-community/dist/styles/ag-theme-alpine.css'
 
-import { createStyles, makeStyles, Theme, useTheme } from '@material-ui/core'
+import { createStyles, Link, makeStyles, Theme, useTheme } from '@material-ui/core'
 import { AgGridReact } from 'ag-grid-react'
 import clsx from 'clsx'
 import React from 'react'
-import { Link } from 'react-router-dom'
+import { Link as RouterLink } from 'react-router-dom'
 
 import DatetimeText from 'src/components/general/DatetimeText'
 import { ExperimentBare, Status } from 'src/lib/schemas'
@@ -51,7 +51,9 @@ const ExperimentsTable = ({ experiments }: { experiments: ExperimentBare[] }): J
               fontWeight: 600,
             },
             cellRendererFramework: ({ value: name, data }: { value: Status; data: ExperimentBare }) => (
-              <Link to={`/experiments/${createIdSlug(data.experimentId, data.name)}`}>{name}</Link>
+              <Link component={RouterLink} to={`/experiments/${createIdSlug(data.experimentId, data.name)}`}>
+                {name}
+              </Link>
             ),
             sortable: true,
             filter: true,

--- a/src/pages/experiments/ExperimentsAgGrid.tsx
+++ b/src/pages/experiments/ExperimentsAgGrid.tsx
@@ -1,0 +1,26 @@
+import { LinearProgress } from '@material-ui/core'
+import debugFactory from 'debug'
+import React from 'react'
+
+import ExperimentsApi from 'src/api/ExperimentsApi'
+import ExperimentsTableAgGrid from 'src/components/experiments/multi-view/ExperimentsTableAgGrid'
+import Layout from 'src/components/page-parts/Layout'
+import { useDataLoadingError, useDataSource } from 'src/utils/data-loading'
+
+const debug = debugFactory('abacus:pages/experiments/Experiments.tsx')
+
+const Experiments = function (): JSX.Element {
+  debug('ExperimentsPage#render')
+
+  const { isLoading, data: experiments, error } = useDataSource(() => ExperimentsApi.findAll(), [])
+
+  useDataLoadingError(error, 'Experiment')
+
+  return (
+    <Layout title='Experiments'>
+      {isLoading ? <LinearProgress /> : <ExperimentsTableAgGrid experiments={experiments || []} />}
+    </Layout>
+  )
+}
+
+export default Experiments


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR adds a demo Experiments table using AgGrid:**
- Better status sorting
- Better default sort - status then start date
- Advanced column filtering
- Using links for the experiment name, can open them in a new tab

See p1617909144001200-slack-G01BQ5WMR8Q for a demo vid.

<!-- Remember to include context: Why is this change required? What problem does it solve? -->
Ultimately it makes visiting the experiments page much more useful dashboard of running experiments, so experimenters are more likely to use it. Also the lack of open experiment in a new tab was quite aggravating.
<!-- If it fixes an open issue, please link to the issue here. -->

Notably it is missing the search, I want to re-add the search to the right of the nav bar at a later point.

## How has this been tested?

It actually shouldn't require that much to get it to full coverage, I think just a snapshot and unit testing the custom sort

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Manual testing with production data (locally)