### PR TITLE
Refactor health indicators

### DIFF
--- a/src/components/experiments/single-view/results/ActualExperimentResults.tsx
+++ b/src/components/experiments/single-view/results/ActualExperimentResults.tsx
@@ -23,8 +23,8 @@ import {
   AggregateRecommendationDecision,
   AnalysisStrategyToHuman,
   getAggregateRecommendation,
-  getExperimentHealthIndicators,
-  getExperimentHealthStats,
+  getExperimentParticipantHealthIndicators,
+  getExperimentParticipantStats,
 } from 'src/lib/analyses'
 import * as Experiments from 'src/lib/experiments'
 import { AttributionWindowSecondsToHuman } from 'src/lib/metric-assignments'
@@ -190,8 +190,8 @@ export default function ActualExperimentResults({
     strategy,
   )
 
-  const experimentHealthStats = getExperimentHealthStats(experiment, primaryMetricLatestAnalysesByStrategy)
-  const experimentHealthIndicators = getExperimentHealthIndicators(experimentHealthStats)
+  const experimentParticipantStats = getExperimentParticipantStats(experiment, primaryMetricLatestAnalysesByStrategy)
+  const experimentHealthIndicators = getExperimentParticipantHealthIndicators(experimentParticipantStats)
 
   // ### Metric Assignments Table
 
@@ -351,7 +351,7 @@ export default function ActualExperimentResults({
       {
         // Displaying these temporarily:
         // istanbul ignore next; debug only
-        isDebugMode() && <DebugOutput label='Health Stats' content={experimentHealthStats} />
+        isDebugMode() && <DebugOutput label='Health Stats' content={experimentParticipantStats} />
       }
     </div>
   )

--- a/src/components/experiments/single-view/results/HealthIndicators.tsx
+++ b/src/components/experiments/single-view/results/HealthIndicators.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx'
 import _ from 'lodash'
 import React from 'react'
 
-import { HealthIndication, HealthIndicator, HealthIndicatorUnit } from 'src/lib/analyses'
+import { HealthIndicationCode, HealthIndicator, HealthIndicatorUnit } from 'src/lib/analyses'
 
 const useStyles = makeStyles((_theme: Theme) =>
   createStyles({
@@ -13,18 +13,18 @@ const useStyles = makeStyles((_theme: Theme) =>
   }),
 )
 
-const indicationToMessage: Record<HealthIndication, React.ReactNode> = {
-  [HealthIndication.Nominal]: (
+const indicationCodeToMessage: Record<HealthIndicationCode, React.ReactNode> = {
+  [HealthIndicationCode.Nominal]: (
     <span role='img' aria-label='Nominal'>
       🆗
     </span>
   ),
-  [HealthIndication.PossibleIssue]: (
+  [HealthIndicationCode.PossibleIssue]: (
     <span role='img' aria-label='PossibleIssue'>
       ✴️
     </span>
   ),
-  [HealthIndication.ProbableIssue]: (
+  [HealthIndicationCode.ProbableIssue]: (
     <span role='img' aria-label='CertainIssue'>
       🆘
     </span>
@@ -54,7 +54,7 @@ export default function HealthIndicators({
           key={indicator.name}
         >
           <div>
-            {indicationToMessage[indicator.indication]} <Link href={indicator.link}>{indicator.name}</Link>
+            {indicationCodeToMessage[indicator.indication.code]} <Link href={indicator.link}>{indicator.name}</Link>
           </div>
         </Tooltip>
       ))}

--- a/src/lib/analyses.test.ts
+++ b/src/lib/analyses.test.ts
@@ -559,7 +559,9 @@ describe('getExperimentHealthIndicators', () => {
       ),
     ).toEqual([
       {
-        indication: 'ProbableIssue',
+        indication: {
+            code: 'ProbableIssue',
+        },
         link:
           'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#assignment-distribution-matching-allocated',
         name: 'Assignment distribution matching allocated',
@@ -567,7 +569,9 @@ describe('getExperimentHealthIndicators', () => {
         value: 0.000013715068445169529,
       },
       {
-        indication: 'PossibleIssue',
+        indication: {
+          code: 'PossibleIssue',
+        },
         link:
           'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#exposure-event-distribution-matching-allocated-sample-ratio-mismatch',
         name: 'Exposure event distribution matching allocated',
@@ -575,7 +579,9 @@ describe('getExperimentHealthIndicators', () => {
         value: 0.03847730828420026,
       },
       {
-        indication: 'ProbableIssue',
+        indication: {
+          code: 'ProbableIssue',
+        },
         link:
           'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#spammer-distribution-matching-allocated',
         name: 'Spammer distribution matching allocated',
@@ -583,14 +589,18 @@ describe('getExperimentHealthIndicators', () => {
         value: 5.684341886080802e-14,
       },
       {
-        indication: 'ProbableIssue',
+        indication: {
+          code: 'ProbableIssue',
+        },
         link: 'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#total-crossovers',
         name: 'Total crossovers',
         unit: 'Ratio',
         value: 0.3076923076923077,
       },
       {
-        indication: 'ProbableIssue',
+        indication: {
+          code: 'ProbableIssue',
+        },
         link: 'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#total-spammers',
         name: 'Total spammers',
         unit: 'Ratio',

--- a/src/lib/analyses.test.ts
+++ b/src/lib/analyses.test.ts
@@ -413,10 +413,10 @@ describe('getParticipantCounts', () => {
   })
 })
 
-describe('getExperimentHealthStats', () => {
+describe('getExperimentParticipantStats', () => {
   it('should work correctly', () => {
     expect(
-      Analyses.getExperimentHealthStats(
+      Analyses.getExperimentParticipantStats(
         Fixtures.createExperimentFull({
           variations: [
             { variationId: 1, allocatedPercentage: 50, isDefault: true, name: 'variation_name_1' },
@@ -510,8 +510,8 @@ describe('getExperimentHealthStats', () => {
 describe('getExperimentHealthIndicators', () => {
   it('should work correctly', () => {
     expect(
-      Analyses.getExperimentHealthIndicators(
-        Analyses.getExperimentHealthStats(
+      Analyses.getExperimentParticipantHealthIndicators(
+        Analyses.getExperimentParticipantStats(
           Fixtures.createExperimentFull({
             variations: [
               { variationId: 1, allocatedPercentage: 50, isDefault: true, name: 'variation_name_1' },

--- a/src/lib/analyses.test.ts
+++ b/src/lib/analyses.test.ts
@@ -562,6 +562,7 @@ describe('getExperimentHealthIndicators', () => {
         indication: {
           code: 'ProbableIssue',
           reason: '−∞ < x ≤ 0.001',
+          severity: Analyses.HealthIndicationSeverity.Error,
         },
         link:
           'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#assignment-distribution-matching-allocated',
@@ -573,6 +574,7 @@ describe('getExperimentHealthIndicators', () => {
         indication: {
           code: 'PossibleIssue',
           reason: '0.001 < x ≤ 0.05',
+          severity: Analyses.HealthIndicationSeverity.Warning,
         },
         link:
           'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#exposure-event-distribution-matching-allocated-sample-ratio-mismatch',
@@ -584,6 +586,7 @@ describe('getExperimentHealthIndicators', () => {
         indication: {
           code: 'ProbableIssue',
           reason: '−∞ < x ≤ 0.001',
+          severity: Analyses.HealthIndicationSeverity.Error,
         },
         link:
           'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#spammer-distribution-matching-allocated',
@@ -595,6 +598,7 @@ describe('getExperimentHealthIndicators', () => {
         indication: {
           code: 'ProbableIssue',
           reason: '0.05 < x ≤ 1',
+          severity: Analyses.HealthIndicationSeverity.Error,
         },
         link: 'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#total-crossovers',
         name: 'Total crossovers',
@@ -605,6 +609,7 @@ describe('getExperimentHealthIndicators', () => {
         indication: {
           code: 'ProbableIssue',
           reason: '0.3 < x ≤ 1',
+          severity: Analyses.HealthIndicationSeverity.Error,
         },
         link: 'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#total-spammers',
         name: 'Total spammers',

--- a/src/lib/analyses.test.ts
+++ b/src/lib/analyses.test.ts
@@ -560,8 +560,8 @@ describe('getExperimentHealthIndicators', () => {
     ).toEqual([
       {
         indication: {
-            code: 'ProbableIssue',
-            reason: '−∞ < x ≤ 0.001',
+          code: 'ProbableIssue',
+          reason: '−∞ < x ≤ 0.001',
         },
         link:
           'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#assignment-distribution-matching-allocated',

--- a/src/lib/analyses.test.ts
+++ b/src/lib/analyses.test.ts
@@ -561,6 +561,7 @@ describe('getExperimentHealthIndicators', () => {
       {
         indication: {
             code: 'ProbableIssue',
+            reason: '−∞ < x ≤ 0.001',
         },
         link:
           'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#assignment-distribution-matching-allocated',
@@ -571,6 +572,7 @@ describe('getExperimentHealthIndicators', () => {
       {
         indication: {
           code: 'PossibleIssue',
+          reason: '0.001 < x ≤ 0.05',
         },
         link:
           'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#exposure-event-distribution-matching-allocated-sample-ratio-mismatch',
@@ -581,6 +583,7 @@ describe('getExperimentHealthIndicators', () => {
       {
         indication: {
           code: 'ProbableIssue',
+          reason: '−∞ < x ≤ 0.001',
         },
         link:
           'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#spammer-distribution-matching-allocated',
@@ -591,6 +594,7 @@ describe('getExperimentHealthIndicators', () => {
       {
         indication: {
           code: 'ProbableIssue',
+          reason: '0.05 < x ≤ 1',
         },
         link: 'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#total-crossovers',
         name: 'Total crossovers',
@@ -600,6 +604,7 @@ describe('getExperimentHealthIndicators', () => {
       {
         indication: {
           code: 'ProbableIssue',
+          reason: '0.3 < x ≤ 1',
         },
         link: 'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#total-spammers',
         name: 'Total spammers',

--- a/src/lib/analyses.ts
+++ b/src/lib/analyses.ts
@@ -246,9 +246,16 @@ export enum HealthIndicationCode {
   ProbableIssue = 'ProbableIssue',
 }
 
+export enum HealthIndicationSeverity {
+  Clear = 'Clear',
+  Warning = 'Warning',
+  Error = 'Error',
+}
+
 interface HealthIndication {
   code: HealthIndicationCode
   reason: string
+  severity: HealthIndicationSeverity
 }
 
 export enum HealthIndicatorUnit {
@@ -328,18 +335,21 @@ export function getExperimentParticipantHealthIndicators(
           max: 0.001,
           indication: {
             code: HealthIndicationCode.ProbableIssue,
+            severity: HealthIndicationSeverity.Error,
           },
         },
         {
           max: 0.05,
           indication: {
             code: HealthIndicationCode.PossibleIssue,
+            severity: HealthIndicationSeverity.Warning,
           },
         },
         {
           max: 1,
           indication: {
             code: HealthIndicationCode.Nominal,
+            severity: HealthIndicationSeverity.Clear,
           },
         },
       ],
@@ -355,18 +365,21 @@ export function getExperimentParticipantHealthIndicators(
           max: 0.001,
           indication: {
             code: HealthIndicationCode.ProbableIssue,
+            severity: HealthIndicationSeverity.Error,
           },
         },
         {
           max: 0.05,
           indication: {
             code: HealthIndicationCode.PossibleIssue,
+            severity: HealthIndicationSeverity.Warning,
           },
         },
         {
           max: 1,
           indication: {
             code: HealthIndicationCode.Nominal,
+            severity: HealthIndicationSeverity.Clear,
           },
         },
       ],
@@ -382,18 +395,21 @@ export function getExperimentParticipantHealthIndicators(
           max: 0.001,
           indication: {
             code: HealthIndicationCode.ProbableIssue,
+            severity: HealthIndicationSeverity.Error,
           },
         },
         {
           max: 0.05,
           indication: {
             code: HealthIndicationCode.PossibleIssue,
+            severity: HealthIndicationSeverity.Warning,
           },
         },
         {
           max: 1,
           indication: {
             code: HealthIndicationCode.Nominal,
+            severity: HealthIndicationSeverity.Clear,
           },
         },
       ],
@@ -408,18 +424,21 @@ export function getExperimentParticipantHealthIndicators(
           max: 0.01,
           indication: {
             code: HealthIndicationCode.Nominal,
+            severity: HealthIndicationSeverity.Clear,
           },
         },
         {
           max: 0.05,
           indication: {
             code: HealthIndicationCode.PossibleIssue,
+            severity: HealthIndicationSeverity.Warning,
           },
         },
         {
           max: 1,
           indication: {
             code: HealthIndicationCode.ProbableIssue,
+            severity: HealthIndicationSeverity.Error,
           },
         },
       ],
@@ -434,18 +453,21 @@ export function getExperimentParticipantHealthIndicators(
           max: 0.075,
           indication: {
             code: HealthIndicationCode.Nominal,
+            severity: HealthIndicationSeverity.Clear,
           },
         },
         {
           max: 0.3,
           indication: {
             code: HealthIndicationCode.PossibleIssue,
+            severity: HealthIndicationSeverity.Warning,
           },
         },
         {
           max: 1,
           indication: {
             code: HealthIndicationCode.ProbableIssue,
+            severity: HealthIndicationSeverity.Error,
           },
         },
       ],

--- a/src/lib/analyses.ts
+++ b/src/lib/analyses.ts
@@ -240,16 +240,21 @@ export function getExperimentParticipantStats(
   }
 }
 
-export enum HealthIndication {
+export enum HealthIndicationCode {
   Nominal = 'Nominal',
   PossibleIssue = 'PossibleIssue',
   ProbableIssue = 'ProbableIssue',
+}
+
+interface HealthIndication {
+  code: HealthIndicationCode,
 }
 
 export enum HealthIndicatorUnit {
   Pvalue = 'P-Value',
   Ratio = 'Ratio',
 }
+
 
 /**
  * Indicators are the important stats that give us clear direction on how an experiment is going.
@@ -307,15 +312,21 @@ export function getExperimentParticipantHealthIndicators(experimentParticipantSt
       indicationBrackets: [
         {
           max: 0.001,
-          indication: HealthIndication.ProbableIssue,
+          indication: {
+            code: HealthIndicationCode.ProbableIssue,
+          }
         },
         {
           max: 0.05,
-          indication: HealthIndication.PossibleIssue,
+          indication: {
+            code: HealthIndicationCode.PossibleIssue,
+          }
         },
         {
           max: 1,
-          indication: HealthIndication.Nominal,
+          indication: {
+            code: HealthIndicationCode.Nominal,
+          }
         },
       ],
     },
@@ -328,15 +339,21 @@ export function getExperimentParticipantHealthIndicators(experimentParticipantSt
       indicationBrackets: [
         {
           max: 0.001,
-          indication: HealthIndication.ProbableIssue,
+          indication: {
+            code: HealthIndicationCode.ProbableIssue,
+          }
         },
         {
           max: 0.05,
-          indication: HealthIndication.PossibleIssue,
+          indication: {
+            code: HealthIndicationCode.PossibleIssue,
+          }
         },
         {
           max: 1,
-          indication: HealthIndication.Nominal,
+          indication: {
+            code: HealthIndicationCode.Nominal,
+          }
         },
       ],
     },
@@ -349,15 +366,21 @@ export function getExperimentParticipantHealthIndicators(experimentParticipantSt
       indicationBrackets: [
         {
           max: 0.001,
-          indication: HealthIndication.ProbableIssue,
+          indication: {
+            code: HealthIndicationCode.ProbableIssue,
+          }
         },
         {
           max: 0.05,
-          indication: HealthIndication.PossibleIssue,
+          indication: {
+            code: HealthIndicationCode.PossibleIssue,
+          }
         },
         {
           max: 1,
-          indication: HealthIndication.Nominal,
+          indication: {
+            code: HealthIndicationCode.Nominal,
+          }
         },
       ],
     },
@@ -369,15 +392,21 @@ export function getExperimentParticipantHealthIndicators(experimentParticipantSt
       indicationBrackets: [
         {
           max: 0.01,
-          indication: HealthIndication.Nominal,
+          indication: {
+            code: HealthIndicationCode.Nominal,
+          }
         },
         {
           max: 0.05,
-          indication: HealthIndication.PossibleIssue,
+          indication: {
+            code: HealthIndicationCode.PossibleIssue,
+          }
         },
         {
           max: 1,
-          indication: HealthIndication.ProbableIssue,
+          indication: {
+            code: HealthIndicationCode.ProbableIssue,
+          }
         },
       ],
     },
@@ -389,15 +418,21 @@ export function getExperimentParticipantHealthIndicators(experimentParticipantSt
       indicationBrackets: [
         {
           max: 0.075,
-          indication: HealthIndication.Nominal,
+          indication: {
+            code: HealthIndicationCode.Nominal,
+          }
         },
         {
           max: 0.3,
-          indication: HealthIndication.PossibleIssue,
+          indication: {
+            code: HealthIndicationCode.PossibleIssue,
+          }
         },
         {
           max: 1,
-          indication: HealthIndication.ProbableIssue,
+          indication: {
+            code: HealthIndicationCode.ProbableIssue,
+          }
         },
       ],
     },

--- a/src/lib/analyses.ts
+++ b/src/lib/analyses.ts
@@ -247,7 +247,7 @@ export enum HealthIndicationCode {
 }
 
 export enum HealthIndicationSeverity {
-  Clear = 'Clear',
+  Ok = 'Ok',
   Warning = 'Warning',
   Error = 'Error',
 }
@@ -349,7 +349,7 @@ export function getExperimentParticipantHealthIndicators(
           max: 1,
           indication: {
             code: HealthIndicationCode.Nominal,
-            severity: HealthIndicationSeverity.Clear,
+            severity: HealthIndicationSeverity.Ok,
           },
         },
       ],
@@ -379,7 +379,7 @@ export function getExperimentParticipantHealthIndicators(
           max: 1,
           indication: {
             code: HealthIndicationCode.Nominal,
-            severity: HealthIndicationSeverity.Clear,
+            severity: HealthIndicationSeverity.Ok,
           },
         },
       ],
@@ -409,7 +409,7 @@ export function getExperimentParticipantHealthIndicators(
           max: 1,
           indication: {
             code: HealthIndicationCode.Nominal,
-            severity: HealthIndicationSeverity.Clear,
+            severity: HealthIndicationSeverity.Ok,
           },
         },
       ],
@@ -424,7 +424,7 @@ export function getExperimentParticipantHealthIndicators(
           max: 0.01,
           indication: {
             code: HealthIndicationCode.Nominal,
-            severity: HealthIndicationSeverity.Clear,
+            severity: HealthIndicationSeverity.Ok,
           },
         },
         {
@@ -453,7 +453,7 @@ export function getExperimentParticipantHealthIndicators(
           max: 0.075,
           indication: {
             code: HealthIndicationCode.Nominal,
-            severity: HealthIndicationSeverity.Clear,
+            severity: HealthIndicationSeverity.Ok,
           },
         },
         {

--- a/src/lib/analyses.ts
+++ b/src/lib/analyses.ts
@@ -153,7 +153,7 @@ interface VariationProbabilities {
   assignedSpammersDistributionMatchingAllocated: number
 }
 
-export interface ExperimentHealthStats {
+export interface ExperimentParticipantStats {
   ratios: {
     overall: {
       exposedToAssigned: number
@@ -170,10 +170,10 @@ export interface ExperimentHealthStats {
 /**
  * Gets Experiment Health Stats for an experiment
  */
-export function getExperimentHealthStats(
+export function getExperimentParticipantStats(
   experiment: ExperimentFull,
   analysesByStrategy: AnalysesByStrategy,
-): ExperimentHealthStats {
+): ExperimentParticipantStats {
   const participantCounts = getParticipantCounts(experiment, analysesByStrategy)
 
   const ratios = {
@@ -263,11 +263,11 @@ export interface HealthIndicator {
 }
 
 /**
- * Returns indicators from experimentHealthStats.
+ * Returns indicators from experimentParticipantStats.
  */
-export function getExperimentHealthIndicators(experimentHealthStats: ExperimentHealthStats): HealthIndicator[] {
+export function getExperimentParticipantHealthIndicators(experimentParticipantStats: ExperimentParticipantStats): HealthIndicator[] {
   // Getting the min p-values across variations:
-  const minVariationProbabilities = Object.values(experimentHealthStats.probabilities.byVariationId).reduce(
+  const minVariationProbabilities = Object.values(experimentParticipantStats.probabilities.byVariationId).reduce(
     (acc: VariationProbabilities, cur: VariationProbabilities) => ({
       assignedDistributionMatchingAllocated: Math.min(
         acc.assignedDistributionMatchingAllocated,
@@ -363,7 +363,7 @@ export function getExperimentHealthIndicators(experimentHealthStats: ExperimentH
     },
     {
       name: 'Total crossovers',
-      value: experimentHealthStats.ratios.overall.assignedCrossoversToAssigned,
+      value: experimentParticipantStats.ratios.overall.assignedCrossoversToAssigned,
       unit: HealthIndicatorUnit.Ratio,
       link: 'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#total-crossovers',
       indicationBrackets: [
@@ -383,7 +383,7 @@ export function getExperimentHealthIndicators(experimentHealthStats: ExperimentH
     },
     {
       name: 'Total spammers',
-      value: experimentHealthStats.ratios.overall.assignedSpammersToAssigned,
+      value: experimentParticipantStats.ratios.overall.assignedSpammersToAssigned,
       unit: HealthIndicatorUnit.Ratio,
       link: 'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#total-spammers',
       indicationBrackets: [

--- a/src/lib/analyses.ts
+++ b/src/lib/analyses.ts
@@ -247,15 +247,14 @@ export enum HealthIndicationCode {
 }
 
 interface HealthIndication {
-  code: HealthIndicationCode,
-  reason: string,
+  code: HealthIndicationCode
+  reason: string
 }
 
 export enum HealthIndicatorUnit {
   Pvalue = 'P-Value',
   Ratio = 'Ratio',
 }
-
 
 /**
  * Indicators are the important stats that give us clear direction on how an experiment is going.
@@ -266,11 +265,11 @@ export interface HealthIndicator {
   unit: HealthIndicatorUnit
   link?: string
   indication: HealthIndication
-} 
+}
 
 interface IndicationBracket {
-  max: number,
-  indication: Omit<HealthIndication, 'reason'>,
+  max: number
+  indication: Omit<HealthIndication, 'reason'>
 }
 
 /**
@@ -292,7 +291,9 @@ function getIndicationFromBrackets(sortedBracketsMaxAsc: IndicationBracket[], va
 /**
  * Returns indicators from experimentParticipantStats.
  */
-export function getExperimentParticipantHealthIndicators(experimentParticipantStats: ExperimentParticipantStats): HealthIndicator[] {
+export function getExperimentParticipantHealthIndicators(
+  experimentParticipantStats: ExperimentParticipantStats,
+): HealthIndicator[] {
   // Getting the min p-values across variations:
   const minVariationProbabilities = Object.values(experimentParticipantStats.probabilities.byVariationId).reduce(
     (acc: VariationProbabilities, cur: VariationProbabilities) => ({
@@ -327,19 +328,19 @@ export function getExperimentParticipantHealthIndicators(experimentParticipantSt
           max: 0.001,
           indication: {
             code: HealthIndicationCode.ProbableIssue,
-          }
+          },
         },
         {
           max: 0.05,
           indication: {
             code: HealthIndicationCode.PossibleIssue,
-          }
+          },
         },
         {
           max: 1,
           indication: {
             code: HealthIndicationCode.Nominal,
-          }
+          },
         },
       ],
     },
@@ -354,19 +355,19 @@ export function getExperimentParticipantHealthIndicators(experimentParticipantSt
           max: 0.001,
           indication: {
             code: HealthIndicationCode.ProbableIssue,
-          }
+          },
         },
         {
           max: 0.05,
           indication: {
             code: HealthIndicationCode.PossibleIssue,
-          }
+          },
         },
         {
           max: 1,
           indication: {
             code: HealthIndicationCode.Nominal,
-          }
+          },
         },
       ],
     },
@@ -381,19 +382,19 @@ export function getExperimentParticipantHealthIndicators(experimentParticipantSt
           max: 0.001,
           indication: {
             code: HealthIndicationCode.ProbableIssue,
-          }
+          },
         },
         {
           max: 0.05,
           indication: {
             code: HealthIndicationCode.PossibleIssue,
-          }
+          },
         },
         {
           max: 1,
           indication: {
             code: HealthIndicationCode.Nominal,
-          }
+          },
         },
       ],
     },
@@ -407,19 +408,19 @@ export function getExperimentParticipantHealthIndicators(experimentParticipantSt
           max: 0.01,
           indication: {
             code: HealthIndicationCode.Nominal,
-          }
+          },
         },
         {
           max: 0.05,
           indication: {
             code: HealthIndicationCode.PossibleIssue,
-          }
+          },
         },
         {
           max: 1,
           indication: {
             code: HealthIndicationCode.ProbableIssue,
-          }
+          },
         },
       ],
     },
@@ -433,19 +434,19 @@ export function getExperimentParticipantHealthIndicators(experimentParticipantSt
           max: 0.075,
           indication: {
             code: HealthIndicationCode.Nominal,
-          }
+          },
         },
         {
           max: 0.3,
           indication: {
             code: HealthIndicationCode.PossibleIssue,
-          }
+          },
         },
         {
           max: 1,
           indication: {
             code: HealthIndicationCode.ProbableIssue,
-          }
+          },
         },
       ],
     },


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
Best viewed commit by commit.

**This PR refactors health indicators:**
- Renames `ParticipantStats` to `HealthStats`
   I think it is simpler data flow wise if we aren't trying to get everything in one stats object.
- Renames `ExperimentHealthIndicators` to `ExperimentParticipantStatsHealthIndicator`
   This allows adding additional functions that have different dependencies.
- Turns `HealthIndication` from enum into an object
   Allows extensions to the indication, such as `severity`, `reason` and `recommendedAction`.
- Refactors the indicationBracket code, allowing it for use in other indicators.
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Part of #436 #419 and #493

See also pbmo2S-Ii-p2#comment-1788

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
