### PR TITLE
Add experiment run time indicator

### DIFF
--- a/src/components/experiments/single-view/results/ActualExperimentResults.tsx
+++ b/src/components/experiments/single-view/results/ActualExperimentResults.tsx
@@ -201,6 +201,7 @@ export default function ActualExperimentResults({
   const experimentHealthIndicators = [
     ...Analyses.getExperimentParticipantHealthIndicators(experimentParticipantStats),
     ...Analyses.getExperimentAnalysesHealthIndicators(experiment, primaryMetricLatestAnalysesByStrategy, strategy),
+    ...Analyses.getExperimentHealthIndicators(experiment),
   ]
 
   const maxIndicationSeverity = experimentHealthIndicators

--- a/src/components/experiments/single-view/results/HealthIndicatorTable.tsx
+++ b/src/components/experiments/single-view/results/HealthIndicatorTable.tsx
@@ -90,7 +90,7 @@ export default function HealthIndicatorTable({
                     <span className={classes.tooltip}>p-value</span>
                   </Tooltip>
                 ) : (
-                  <span>ratio</span>
+                  <span>{indicator.unit}</span>
                 )}
               </TableCell>
               <TableCell scope='row' className={clsx(classes.monospace, classes.deemphasized)}>

--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -772,7 +772,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 scope="row"
               >
                 <span>
-                  ratio
+                  days
                 </span>
               </td>
               <td
@@ -2009,7 +2009,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 scope="row"
               >
                 <span>
-                  ratio
+                  days
                 </span>
               </td>
               <td
@@ -3454,7 +3454,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 scope="row"
               >
                 <span>
-                  ratio
+                  days
                 </span>
               </td>
               <td

--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -64,14 +64,14 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-10 makeStyles-indicationSeverityOk-11 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-10 makeStyles-indicationSeverityError-13 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
               class="MuiTypography-root makeStyles-summaryStatsStat-9 MuiTypography-h3 MuiTypography-colorPrimary"
             >
-              No issues detected
+              Serious issues
             </h3>
             <h6
               class="MuiTypography-root MuiTypography-subtitle1"
@@ -711,7 +711,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
               >
                 <a
                   class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#ci-width-to-rope-ratio"
+                  href="https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#kruschke-precision"
                   target="_blank"
                 >
                   Kruschke Precision (CI to ROPE ratio)
@@ -750,6 +750,58 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.8
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+                scope="row"
+              >
+                <a
+                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                  href="https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#experiment-run-time"
+                  target="_blank"
+                >
+                  Experiment Run Time
+                </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26"
+                scope="row"
+              >
+                <span>
+                  ratio
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26"
+                scope="row"
+              >
+                0.0000
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+                scope="row"
+              >
+                <span>
+                  🆘
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-27 makeStyles-indicationSeverityError-30 makeStyles-monospace-25"
+                scope="row"
+              >
+                <span>
+                  very low
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26"
+                scope="row"
+              >
+                −∞ &lt; x ≤ 3
               </td>
             </tr>
           </tbody>
@@ -1896,7 +1948,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               >
                 <a
                   class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#ci-width-to-rope-ratio"
+                  href="https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#kruschke-precision"
                   target="_blank"
                 >
                   Kruschke Precision (CI to ROPE ratio)
@@ -1935,6 +1987,58 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.8
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+                scope="row"
+              >
+                <a
+                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                  href="https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#experiment-run-time"
+                  target="_blank"
+                >
+                  Experiment Run Time
+                </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69"
+                scope="row"
+              >
+                <span>
+                  ratio
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69"
+                scope="row"
+              >
+                0.0000
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+                scope="row"
+              >
+                <span>
+                  🆘
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-70 makeStyles-indicationSeverityError-73 makeStyles-monospace-68"
+                scope="row"
+              >
+                <span>
+                  very low
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69"
+                scope="row"
+              >
+                −∞ &lt; x ≤ 3
               </td>
             </tr>
           </tbody>
@@ -3289,7 +3393,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               >
                 <a
                   class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#ci-width-to-rope-ratio"
+                  href="https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#kruschke-precision"
                   target="_blank"
                 >
                   Kruschke Precision (CI to ROPE ratio)
@@ -3328,6 +3432,58 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.8
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+                scope="row"
+              >
+                <a
+                  class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                  href="https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#experiment-run-time"
+                  target="_blank"
+                >
+                  Experiment Run Time
+                </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112"
+                scope="row"
+              >
+                <span>
+                  ratio
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112"
+                scope="row"
+              >
+                0.0000
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body"
+                scope="row"
+              >
+                <span>
+                  🆘
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-113 makeStyles-indicationSeverityError-116 makeStyles-monospace-111"
+                scope="row"
+              >
+                <span>
+                  very low
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112"
+                scope="row"
+              >
+                −∞ &lt; x ≤ 3
               </td>
             </tr>
           </tbody>

--- a/src/lib/analyses.test.ts
+++ b/src/lib/analyses.test.ts
@@ -754,7 +754,7 @@ describe('getExperimentAnalysesHealthIndicators', () => {
             "reason": "1.5 < x ≤ ∞",
             "severity": "Error",
           },
-          "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#ci-width-to-rope-ratio",
+          "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#kruschke-precision",
           "name": "Kruschke Precision (CI to ROPE ratio)",
           "unit": "Ratio",
           "value": 25,
@@ -829,5 +829,34 @@ describe('getExperimentAnalysesHealthIndicators', () => {
         AnalysisStrategy.PpNaive,
       ),
     ).toThrowErrorMatchingInlineSnapshot(`"Missing metricAssignment"`)
+  })
+})
+
+describe('getExperimentHealthIndicators', () => {
+  it('should work correctly', () => {
+    expect(
+      Analyses.getExperimentHealthIndicators(
+        Fixtures.createExperimentFull({
+          variations: [
+            { variationId: 1, allocatedPercentage: 50, isDefault: true, name: 'variation_name_1' },
+            { variationId: 2, allocatedPercentage: 50, isDefault: false, name: 'variation_name_2' },
+          ],
+        }),
+      ),
+    ).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "indication": Object {
+            "code": "very low",
+            "reason": "−∞ < x ≤ 3",
+            "severity": "Error",
+          },
+          "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#experiment-run-time",
+          "name": "Experiment Run Time",
+          "unit": "Days",
+          "value": 0,
+        },
+      ]
+    `)
   })
 })

--- a/src/lib/analyses.test.ts
+++ b/src/lib/analyses.test.ts
@@ -584,7 +584,7 @@ describe('getExperimentParticipantStatHealthIndicators', () => {
           },
           "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#assignment-distribution-matching-allocated",
           "name": "Assignment distribution",
-          "unit": "P-Value",
+          "unit": "p-value",
           "value": 0.000011583130623216142,
         },
         Object {
@@ -595,7 +595,7 @@ describe('getExperimentParticipantStatHealthIndicators', () => {
           },
           "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#assigned-no-spammers-no-crossovers-distribution-matching-allocated",
           "name": "Assignment distribution without crossovers and spammers",
-          "unit": "P-Value",
+          "unit": "p-value",
           "value": 0.000011583130623216142,
         },
         Object {
@@ -606,7 +606,7 @@ describe('getExperimentParticipantStatHealthIndicators', () => {
           },
           "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#exposure-event-distribution-matching-allocated-sample-ratio-mismatch",
           "name": "Assignment distribution of exposed participants",
-          "unit": "P-Value",
+          "unit": "p-value",
           "value": 0.026856695507524453,
         },
         Object {
@@ -617,7 +617,7 @@ describe('getExperimentParticipantStatHealthIndicators', () => {
           },
           "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#total-crossovers",
           "name": "Ratio of crossovers to assigned",
-          "unit": "Ratio",
+          "unit": "ratio",
           "value": 0.3076923076923077,
         },
         Object {
@@ -628,7 +628,7 @@ describe('getExperimentParticipantStatHealthIndicators', () => {
           },
           "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#total-spammers",
           "name": "Ratio of spammers to assigned",
-          "unit": "Ratio",
+          "unit": "ratio",
           "value": 0.34615384615384615,
         },
       ]
@@ -673,7 +673,7 @@ describe('getExperimentParticipantStatHealthIndicators', () => {
           },
           "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#assignment-distribution-matching-allocated",
           "name": "Assignment distribution",
-          "unit": "P-Value",
+          "unit": "p-value",
           "value": 1,
         },
         Object {
@@ -684,7 +684,7 @@ describe('getExperimentParticipantStatHealthIndicators', () => {
           },
           "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#assigned-no-spammers-no-crossovers-distribution-matching-allocated",
           "name": "Assignment distribution without crossovers and spammers",
-          "unit": "P-Value",
+          "unit": "p-value",
           "value": 1,
         },
         Object {
@@ -695,7 +695,7 @@ describe('getExperimentParticipantStatHealthIndicators', () => {
           },
           "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#total-crossovers",
           "name": "Ratio of crossovers to assigned",
-          "unit": "Ratio",
+          "unit": "ratio",
           "value": NaN,
         },
         Object {
@@ -706,7 +706,7 @@ describe('getExperimentParticipantStatHealthIndicators', () => {
           },
           "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#total-spammers",
           "name": "Ratio of spammers to assigned",
-          "unit": "Ratio",
+          "unit": "ratio",
           "value": NaN,
         },
       ]
@@ -756,7 +756,7 @@ describe('getExperimentAnalysesHealthIndicators', () => {
           },
           "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#kruschke-precision",
           "name": "Kruschke Precision (CI to ROPE ratio)",
-          "unit": "Ratio",
+          "unit": "ratio",
           "value": 25,
         },
       ]
@@ -853,7 +853,7 @@ describe('getExperimentHealthIndicators', () => {
           },
           "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#experiment-run-time",
           "name": "Experiment Run Time",
-          "unit": "Days",
+          "unit": "days",
           "value": 0,
         },
       ]

--- a/src/lib/analyses.ts
+++ b/src/lib/analyses.ts
@@ -2,6 +2,7 @@ import _ from 'lodash'
 
 import { binomialProbValue } from 'src/utils/math'
 
+import * as Experiments from './experiments'
 import { Analysis, AnalysisStrategy, ExperimentFull, RecommendationWarning } from './schemas'
 
 /**
@@ -288,6 +289,7 @@ interface HealthIndication {
 export enum HealthIndicatorUnit {
   Pvalue = 'P-Value',
   Ratio = 'Ratio',
+  Days = 'Days',
 }
 
 /**
@@ -560,7 +562,7 @@ export function getExperimentAnalysesHealthIndicators(
       name: 'Kruschke Precision (CI to ROPE ratio)',
       value: diffCiWidth / ropeWidth,
       unit: HealthIndicatorUnit.Ratio,
-      link: 'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#ci-width-to-rope-ratio',
+      link: 'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#kruschke-precision',
       indicationBrackets: [
         {
           max: 0.8,
@@ -571,6 +573,63 @@ export function getExperimentAnalysesHealthIndicators(
         },
         {
           max: 1.5,
+          indication: {
+            code: HealthIndicationCode.High,
+            severity: HealthIndicationSeverity.Warning,
+          },
+        },
+        {
+          max: Infinity,
+          indication: {
+            code: HealthIndicationCode.VeryHigh,
+            severity: HealthIndicationSeverity.Error,
+          },
+        },
+      ],
+    },
+  ]
+
+  return indicatorDefinitions.map(({ value, indicationBrackets, ...rest }) => ({
+    value,
+    indication: getIndicationFromBrackets(indicationBrackets, value),
+    ...rest,
+  }))
+}
+
+/**
+ * Get experiment health indicators for a experiment.
+ */
+export function getExperimentHealthIndicators(experiment: ExperimentFull): HealthIndicator[] {
+  const indicatorDefinitions = [
+    {
+      name: 'Experiment Run Time',
+      value: Experiments.getExperimentRunHours(experiment),
+      unit: HealthIndicatorUnit.Days,
+      link: 'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#experiment-run-time',
+      indicationBrackets: [
+        {
+          max: 3,
+          indication: {
+            code: HealthIndicationCode.VeryLow,
+            severity: HealthIndicationSeverity.Error,
+          },
+        },
+        {
+          max: 7,
+          indication: {
+            code: HealthIndicationCode.Low,
+            severity: HealthIndicationSeverity.Warning,
+          },
+        },
+        {
+          max: 28,
+          indication: {
+            code: HealthIndicationCode.Nominal,
+            severity: HealthIndicationSeverity.Ok,
+          },
+        },
+        {
+          max: 31,
           indication: {
             code: HealthIndicationCode.High,
             severity: HealthIndicationSeverity.Warning,

--- a/src/lib/analyses.ts
+++ b/src/lib/analyses.ts
@@ -287,9 +287,9 @@ interface HealthIndication {
 }
 
 export enum HealthIndicatorUnit {
-  Pvalue = 'P-Value',
-  Ratio = 'Ratio',
-  Days = 'Days',
+  Pvalue = 'p-value',
+  Ratio = 'ratio',
+  Days = 'days',
 }
 
 /**
@@ -603,7 +603,7 @@ export function getExperimentHealthIndicators(experiment: ExperimentFull): Healt
   const indicatorDefinitions = [
     {
       name: 'Experiment Run Time',
-      value: Experiments.getExperimentRunHours(experiment),
+      value: Experiments.getExperimentRunHours(experiment) / 24,
       unit: HealthIndicatorUnit.Days,
       link: 'https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#experiment-run-time',
       indicationBrackets: [


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR adds the experiment run time indicator:**

<img width="1251" alt="Screen Shot 2021-04-21 at 10 15 07 pm" src="https://user-images.githubusercontent.com/971886/115568611-0afa6e80-a2ef-11eb-883f-d79f18d0954c.png">

<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
