### PR TITLE
Reword the existing users only switch

### DIFF
--- a/src/components/experiments/single-view/overview/AudiencePanel.tsx
+++ b/src/components/experiments/single-view/overview/AudiencePanel.tsx
@@ -146,7 +146,7 @@ function AudiencePanel({
       label: 'User Type',
       value: (
         <span className={classes.monospace}>
-          {experiment.existingUsersAllowed ? 'All users (new + existing)' : 'New users only'}
+          {experiment.existingUsersAllowed ? 'All users (new + existing + anonymous)' : 'New logged-in users only'}
         </span>
       ),
     },

--- a/src/components/experiments/single-view/overview/__snapshots__/AudiencePanel.test.tsx.snap
+++ b/src/components/experiments/single-view/overview/__snapshots__/AudiencePanel.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`Empty array shows no exposure events 1`] = `
             <span
               class="makeStyles-monospace-62"
             >
-              New users only
+              New logged-in users only
             </span>
           </td>
         </tr>
@@ -350,7 +350,7 @@ exports[`Shows exposure events 1`] = `
             <span
               class="makeStyles-monospace-62"
             >
-              New users only
+              New logged-in users only
             </span>
           </td>
         </tr>
@@ -655,7 +655,7 @@ exports[`null shows no exposure events 1`] = `
             <span
               class="makeStyles-monospace-62"
             >
-              New users only
+              New logged-in users only
             </span>
           </td>
         </tr>
@@ -949,7 +949,7 @@ exports[`renders as expected with all segments resolvable 1`] = `
             <span
               class="makeStyles-monospace-47"
             >
-              New users only
+              New logged-in users only
             </span>
           </td>
         </tr>
@@ -1325,7 +1325,7 @@ exports[`renders as expected with existing users allowed 1`] = `
             <span
               class="makeStyles-monospace-32"
             >
-              All users (new + existing)
+              All users (new + existing + anonymous)
             </span>
           </td>
         </tr>
@@ -1653,7 +1653,7 @@ exports[`renders as expected with no exclusion groups 1`] = `
             <span
               class="makeStyles-monospace-17"
             >
-              New users only
+              New logged-in users only
             </span>
           </td>
         </tr>
@@ -1955,7 +1955,7 @@ exports[`renders as expected with no segment assignments 1`] = `
             <span
               class="makeStyles-monospace-2"
             >
-              New users only
+              New logged-in users only
             </span>
           </td>
         </tr>

--- a/src/components/experiments/single-view/overview/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/src/components/experiments/single-view/overview/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -488,7 +488,7 @@ exports[`renders as expected at large width 1`] = `
                 <span
                   class="makeStyles-monospace-22"
                 >
-                  New users only
+                  New logged-in users only
                 </span>
               </td>
             </tr>
@@ -1040,7 +1040,7 @@ exports[`renders as expected at small width 1`] = `
                     <span
                       class="makeStyles-monospace-57"
                     >
-                      New users only
+                      New logged-in users only
                     </span>
                   </td>
                 </tr>
@@ -1812,7 +1812,7 @@ exports[`renders as expected with conclusion data 1`] = `
                     <span
                       class="makeStyles-monospace-94"
                     >
-                      New users only
+                      New logged-in users only
                     </span>
                   </td>
                 </tr>
@@ -2688,7 +2688,7 @@ exports[`renders as expected without conclusion data 1`] = `
                     <span
                       class="makeStyles-monospace-129"
                     >
-                      New users only
+                      New logged-in users only
                     </span>
                   </td>
                 </tr>

--- a/src/components/experiments/wizard/Audience.tsx
+++ b/src/components/experiments/wizard/Audience.tsx
@@ -175,7 +175,7 @@ const Audience = ({
 
       <div className={classes.row}>
         <FormControl component='fieldset'>
-          <FormLabel required>User types</FormLabel>
+          <FormLabel required>User type</FormLabel>
           <FormHelperText>Types of users to include in experiment</FormHelperText>
 
           <Field component={FormikMuiRadioGroup} name='experiment.existingUsersAllowed' required>

--- a/src/components/experiments/wizard/Audience.tsx
+++ b/src/components/experiments/wizard/Audience.tsx
@@ -181,13 +181,13 @@ const Audience = ({
           <Field component={FormikMuiRadioGroup} name='experiment.existingUsersAllowed' required>
             <FormControlLabel
               value='false'
-              label='New users only'
+              label='New logged-in users only'
               control={<Radio disabled={formikProps.isSubmitting} />}
               disabled={formikProps.isSubmitting}
             />
             <FormControlLabel
               value='true'
-              label='All users (new + existing)'
+              label='All users (new + existing + anonymous)'
               control={<Radio disabled={formikProps.isSubmitting} />}
               disabled={formikProps.isSubmitting}
             />

--- a/src/components/experiments/wizard/__snapshots__/Audience.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/Audience.test.tsx.snap
@@ -135,7 +135,7 @@ exports[`renders as expected 1`] = `
             <span
               class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
             >
-              New users only
+              New logged-in users only
             </span>
           </label>
           <label
@@ -187,7 +187,7 @@ exports[`renders as expected 1`] = `
             <span
               class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
             >
-              All users (new + existing)
+              All users (new + existing + anonymous)
             </span>
           </label>
         </div>
@@ -832,7 +832,7 @@ exports[`renders as expected 2`] = `
             <span
               class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
             >
-              New users only
+              New logged-in users only
             </span>
           </label>
           <label
@@ -884,7 +884,7 @@ exports[`renders as expected 2`] = `
             <span
               class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
             >
-              All users (new + existing)
+              All users (new + existing + anonymous)
             </span>
           </label>
         </div>

--- a/src/components/experiments/wizard/__snapshots__/Audience.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/Audience.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`renders as expected 1`] = `
         <label
           class="MuiFormLabel-root Mui-required"
         >
-          User types
+          User type
           <span
             aria-hidden="true"
             class="MuiFormLabel-asterisk"
@@ -765,7 +765,7 @@ exports[`renders as expected 2`] = `
         <label
           class="MuiFormLabel-root Mui-required"
         >
-          User types
+          User type
           <span
             aria-hidden="true"
             class="MuiFormLabel-asterisk"


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR renames "existing user" terminology in the UI:**
- "New users only" becomes "New logged-in users only".
- Emphasise that all users includes anonymous participants.

<img width="552" alt="Screen Shot 2021-04-28 at 12 16 05 pm" src="https://user-images.githubusercontent.com/971886/116346086-17fded00-a81c-11eb-83f5-d79f62e1f245.png">
<img width="520" alt="Screen Shot 2021-04-28 at 12 15 18 pm" src="https://user-images.githubusercontent.com/971886/116346090-19c7b080-a81c-11eb-8021-26864d273b97.png">
<img width="521" alt="Screen Shot 2021-04-28 at 12 15 06 pm" src="https://user-images.githubusercontent.com/971886/116346097-1cc2a100-a81c-11eb-8f05-8be1dde03502.png">



Resolves 621-gh-Automattic/experimentation-platform
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
