### PR TITLE
Fix health report issues and tweak messaging

### DIFF
--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -757,10 +757,10 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
               >
                 <a
                   class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#kruschke-precision"
+                  href="https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#kruschke-uncertainty"
                   target="_blank"
                 >
-                  Kruschke precision (CI to ROPE ratio)
+                  Kruschke uncertainty (CI to ROPE ratio)
                 </a>
               </td>
               <td
@@ -864,7 +864,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 <p
                   class="MuiTypography-root MuiTypography-body1"
                 >
-                  Experiments should generally run at least 7 days before drawing conclusions.
+                  Experiments should generally run for at least a week before drawing conclusions.
                 </p>
               </td>
             </tr>
@@ -1987,7 +1987,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <p
                   class="MuiTypography-root MuiTypography-body1"
                 >
-                  Contact @experimentation-review-guild
+                  Contact @experiment-review.
                 </p>
               </td>
             </tr>
@@ -2049,7 +2049,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <p
                   class="MuiTypography-root MuiTypography-body1"
                 >
-                  Spammers don't affect experiments, but high numbers could indicate other problems.
+                  Spammers are filtered out of the displayed metrics, but high numbers may be indicative of problems.
                 </p>
               </td>
             </tr>
@@ -2062,10 +2062,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               >
                 <a
                   class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#kruschke-precision"
+                  href="https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#kruschke-uncertainty"
                   target="_blank"
                 >
-                  Kruschke precision (CI to ROPE ratio)
+                  Kruschke uncertainty (CI to ROPE ratio)
                 </a>
               </td>
               <td
@@ -2169,7 +2169,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <p
                   class="MuiTypography-root MuiTypography-body1"
                 >
-                  Experiments should generally run at least 7 days before drawing conclusions.
+                  Experiments should generally run for at least a week before drawing conclusions.
                 </p>
               </td>
             </tr>
@@ -3500,7 +3500,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <p
                   class="MuiTypography-root MuiTypography-body1"
                 >
-                  Contact @experimentation-review-guild
+                  Contact @experiment-review.
                 </p>
               </td>
             </tr>
@@ -3562,7 +3562,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <p
                   class="MuiTypography-root MuiTypography-body1"
                 >
-                  Spammers don't affect experiments, but high numbers could indicate other problems.
+                  Spammers are filtered out of the displayed metrics, but high numbers may be indicative of problems.
                 </p>
               </td>
             </tr>
@@ -3575,10 +3575,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               >
                 <a
                   class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-                  href="https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#kruschke-precision"
+                  href="https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#kruschke-uncertainty"
                   target="_blank"
                 >
-                  Kruschke precision (CI to ROPE ratio)
+                  Kruschke uncertainty (CI to ROPE ratio)
                 </a>
               </td>
               <td
@@ -3682,7 +3682,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <p
                   class="MuiTypography-root MuiTypography-body1"
                 >
-                  Experiments should generally run at least 7 days before drawing conclusions.
+                  Experiments should generally run for at least a week before drawing conclusions.
                 </p>
               </td>
             </tr>

--- a/src/lib/analyses.test.ts
+++ b/src/lib/analyses.test.ts
@@ -478,13 +478,11 @@ describe('getExperimentParticipantStats', () => {
             "1": Object {
               "assignedDistributionMatchingAllocated": 0.000011583130623216142,
               "assignedNoSpammersNoCrossoversDistributionMatchingAllocated": 0.19670560245894686,
-              "assignedSpammersDistributionMatchingAllocated": 1.970346108493004e-11,
               "exposedDistributionMatchingAllocated": 0.11384629800665802,
             },
             "2": Object {
               "assignedDistributionMatchingAllocated": 0.3804551252503884,
               "assignedNoSpammersNoCrossoversDistributionMatchingAllocated": 0.19670560245894686,
-              "assignedSpammersDistributionMatchingAllocated": 0.4560565402502559,
               "exposedDistributionMatchingAllocated": 0.026856695507524453,
             },
           },
@@ -580,7 +578,7 @@ describe('getExperimentParticipantStatHealthIndicators', () => {
           "indication": Object {
             "code": "probable issue",
             "reason": "−∞ < x ≤ 0.001",
-            "recommendation": "Contact @experimentation-review-guild",
+            "recommendation": "Contact @experiment-review.",
             "severity": "Error",
           },
           "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#assignment-distribution-matching-allocated",
@@ -590,21 +588,20 @@ describe('getExperimentParticipantStatHealthIndicators', () => {
         },
         Object {
           "indication": Object {
-            "code": "probable issue",
-            "reason": "−∞ < x ≤ 0.001",
-            "recommendation": "Contact @experimentation-review-guild",
-            "severity": "Error",
+            "code": "nominal",
+            "reason": "0.05 < x ≤ 1",
+            "severity": "Ok",
           },
           "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#assigned-no-spammers-no-crossovers-distribution-matching-allocated",
           "name": "Assignment distribution without crossovers and spammers",
           "unit": "p-value",
-          "value": 0.000011583130623216142,
+          "value": 0.19670560245894686,
         },
         Object {
           "indication": Object {
             "code": "possible issue",
             "reason": "0.001 < x ≤ 0.05",
-            "recommendation": "If not in combination with other distribution issues, exposure event being fired is linked to variation causing bias. Choose a different exposure event or use assignment analysis (contact @experiment-review-guild to do so).",
+            "recommendation": "If not in combination with other distribution issues, exposure event being fired is linked to variation causing bias. Choose a different exposure event or use assignment analysis (contact @experiment-review to do so).",
             "severity": "Warning",
           },
           "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#exposure-event-distribution-matching-allocated-sample-ratio-mismatch",
@@ -616,7 +613,7 @@ describe('getExperimentParticipantStatHealthIndicators', () => {
           "indication": Object {
             "code": "very high",
             "reason": "0.05 < x ≤ 1",
-            "recommendation": "Contact @experimentation-review-guild",
+            "recommendation": "Contact @experiment-review.",
             "severity": "Error",
           },
           "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#total-crossovers",
@@ -628,7 +625,7 @@ describe('getExperimentParticipantStatHealthIndicators', () => {
           "indication": Object {
             "code": "high",
             "reason": "0.1 < x ≤ 0.4",
-            "recommendation": "Spammers don't affect experiments, but high numbers could indicate other problems.",
+            "recommendation": "Spammers are filtered out of the displayed metrics, but high numbers may be indicative of problems.",
             "severity": "Warning",
           },
           "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#total-spammers",
@@ -696,7 +693,7 @@ describe('getExperimentParticipantStatHealthIndicators', () => {
           "indication": Object {
             "code": "value error",
             "reason": "Unexpected value",
-            "recommendation": "Contact @experimentation-review-guild",
+            "recommendation": "Contact @experiment-review.",
             "severity": "Error",
           },
           "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#total-crossovers",
@@ -708,7 +705,7 @@ describe('getExperimentParticipantStatHealthIndicators', () => {
           "indication": Object {
             "code": "value error",
             "reason": "Unexpected value",
-            "recommendation": "Contact @experimentation-review-guild",
+            "recommendation": "Contact @experiment-review.",
             "severity": "Error",
           },
           "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#total-spammers",
@@ -759,11 +756,11 @@ describe('getExperimentAnalysesHealthIndicators', () => {
           "indication": Object {
             "code": "very high",
             "reason": "1.5 < x ≤ ∞",
-            "recommendation": "Results are very imprecise, be careful about drawing conclusions. Extend for more precision",
+            "recommendation": "Very high uncertainty. Be careful about drawing conclusions. Collect more data to reduce uncertainty.",
             "severity": "Warning",
           },
-          "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#kruschke-precision",
-          "name": "Kruschke precision (CI to ROPE ratio)",
+          "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#kruschke-uncertainty",
+          "name": "Kruschke uncertainty (CI to ROPE ratio)",
           "unit": "ratio",
           "value": 25,
         },
@@ -857,7 +854,7 @@ describe('getExperimentHealthIndicators', () => {
           "indication": Object {
             "code": "very low",
             "reason": "−∞ < x ≤ 3",
-            "recommendation": "Experiments should generally run at least 7 days before drawing conclusions.",
+            "recommendation": "Experiments should generally run for at least a week before drawing conclusions.",
             "severity": "Warning",
           },
           "link": "https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#experiment-run-time",


### PR DESCRIPTION
Fix a bunch of issues I noticed with the health report and messaging:

* Bug fix: Change `Assignment distribution without crossovers and spammers` to actually show that rather than the overall assignment distribution
* Replace `@experimentation-review-guild` and `@experiment-review-guild` with `@experiment-review` (the correct Slack group)
* Change "Kruschke precision" to "Kruschke uncertainty", as it aligns more with what it is (high number = high uncertainty), and change the recommendation wording accordingly. 
* Change the "high" experiment run time threshold from 31 to 42, as it's generally better to have measurements for whole weeks and 31 is too close to 28.
* Add periods at the end of recommendations (some had them and some didn't) and tweak some other phrasing.
* Remove `assignedSpammersDistributionMatchingAllocated` references and calculations since it doesn't get used.

## How has this been tested?

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
