### PR TITLE
Add early monitoring and improve empty results page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6174,22 +6174,29 @@
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
     },
     "@material-ui/core": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.10.0.tgz",
-      "integrity": "sha512-yVlHe4b8AaoiTHhCOZeszHZ+T2iHU5DncdMGeNcQaaaO+q/Qrq0hxP3iFzTbgjRWnWwftEVQL668GRxcPJVRaQ==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.4.tgz",
+      "integrity": "sha512-oqb+lJ2Dl9HXI9orc6/aN8ZIAMkeThufA5iZELf2LQeBn2NtjVilF5D2w7e9RpntAzDb4jK5DsVhkfOvFY/8fg==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/styles": "^4.10.0",
-        "@material-ui/system": "^4.9.14",
-        "@material-ui/types": "^5.1.0",
-        "@material-ui/utils": "^4.9.12",
+        "@material-ui/styles": "^4.11.4",
+        "@material-ui/system": "^4.11.3",
+        "@material-ui/types": "5.1.0",
+        "@material-ui/utils": "^4.11.2",
         "@types/react-transition-group": "^4.2.0",
         "clsx": "^1.0.4",
         "hoist-non-react-statics": "^3.3.2",
-        "popper.js": "^1.16.1-lts",
+        "popper.js": "1.16.1-lts",
         "prop-types": "^15.7.2",
-        "react-is": "^16.8.0",
+        "react-is": "^16.8.0 || ^17.0.0",
         "react-transition-group": "^4.4.0"
+      },
+      "dependencies": {
+        "popper.js": {
+          "version": "1.16.1-lts",
+          "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
+          "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA=="
+        }
       }
     },
     "@material-ui/icons": {
@@ -6238,35 +6245,35 @@
       }
     },
     "@material-ui/styles": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.10.0.tgz",
-      "integrity": "sha512-XPwiVTpd3rlnbfrgtEJ1eJJdFCXZkHxy8TrdieaTvwxNYj42VnnCyFzxYeNW9Lhj4V1oD8YtQ6S5Gie7bZDf7Q==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.4.tgz",
+      "integrity": "sha512-KNTIZcnj/zprG5LW0Sao7zw+yG3O35pviHzejMdcSGCdWbiO8qzRgOYL8JAxAsWBKOKYwVZxXtHWaB5T2Kvxew==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@emotion/hash": "^0.8.0",
-        "@material-ui/types": "^5.1.0",
-        "@material-ui/utils": "^4.9.6",
+        "@material-ui/types": "5.1.0",
+        "@material-ui/utils": "^4.11.2",
         "clsx": "^1.0.4",
         "csstype": "^2.5.2",
         "hoist-non-react-statics": "^3.3.2",
-        "jss": "^10.0.3",
-        "jss-plugin-camel-case": "^10.0.3",
-        "jss-plugin-default-unit": "^10.0.3",
-        "jss-plugin-global": "^10.0.3",
-        "jss-plugin-nested": "^10.0.3",
-        "jss-plugin-props-sort": "^10.0.3",
-        "jss-plugin-rule-value-function": "^10.0.3",
-        "jss-plugin-vendor-prefixer": "^10.0.3",
+        "jss": "^10.5.1",
+        "jss-plugin-camel-case": "^10.5.1",
+        "jss-plugin-default-unit": "^10.5.1",
+        "jss-plugin-global": "^10.5.1",
+        "jss-plugin-nested": "^10.5.1",
+        "jss-plugin-props-sort": "^10.5.1",
+        "jss-plugin-rule-value-function": "^10.5.1",
+        "jss-plugin-vendor-prefixer": "^10.5.1",
         "prop-types": "^15.7.2"
       }
     },
     "@material-ui/system": {
-      "version": "4.9.14",
-      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.9.14.tgz",
-      "integrity": "sha512-oQbaqfSnNlEkXEziDcJDDIy8pbvwUmZXWNqlmIwDqr/ZdCK8FuV3f4nxikUh7hvClKV2gnQ9djh5CZFTHkZj3w==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.11.3.tgz",
+      "integrity": "sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/utils": "^4.9.6",
+        "@material-ui/utils": "^4.11.2",
         "csstype": "^2.5.2",
         "prop-types": "^15.7.2"
       }
@@ -6277,13 +6284,13 @@
       "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
     },
     "@material-ui/utils": {
-      "version": "4.9.12",
-      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.9.12.tgz",
-      "integrity": "sha512-/0rgZPEOcZq5CFA4+4n6Q6zk7fi8skHhH2Bcra8R3epoJEYy5PL55LuMazPtPH1oKeRausDV/Omz4BbgFsn1HQ==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
+      "integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "prop-types": "^15.7.2",
-        "react-is": "^16.8.0"
+        "react-is": "^16.8.0 || ^17.0.0"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -10082,9 +10089,9 @@
       }
     },
     "@types/react-transition-group": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
-      "integrity": "sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-vIo69qKKcYoJ8wKCJjwSgCTM+z3chw3g18dkrDfVX665tMH7tmbDxEAnPdey4gTlwZz5QuHGzd+hul0OVZDqqQ==",
       "requires": {
         "@types/react": "*"
       }
@@ -14837,9 +14844,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
-          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "version": "7.14.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -19673,9 +19680,9 @@
       }
     },
     "hyphenate-style-name": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
-      "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -19778,6 +19785,14 @@
       "requires": {
         "robust-orientation": "^1.1.2",
         "simplicial-complex": "^1.0.0"
+      }
+    },
+    "indefinite-observable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/indefinite-observable/-/indefinite-observable-2.0.1.tgz",
+      "integrity": "sha512-G8vgmork+6H9S8lUAg1gtXEj2JxIQTo0g2PbFiYOdjkziSI0F7UYBiVwhZRuixhBCNGczAls34+5HJPyZysvxQ==",
+      "requires": {
+        "symbol-observable": "1.2.0"
       }
     },
     "indent-string": {
@@ -24396,171 +24411,89 @@
       }
     },
     "jss": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/jss/-/jss-10.1.1.tgz",
-      "integrity": "sha512-Xz3qgRUFlxbWk1czCZibUJqhVPObrZHxY3FPsjCXhDld4NOj1BgM14Ir5hVm+Qr6OLqVljjGvoMcCdXNOAbdkQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.6.0.tgz",
+      "integrity": "sha512-n7SHdCozmxnzYGXBHe0NsO0eUf9TvsHVq2MXvi4JmTn3x5raynodDVE/9VQmBdWFyyj9HpHZ2B4xNZ7MMy7lkw==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "csstype": "^2.6.5",
+        "csstype": "^3.0.2",
+        "indefinite-observable": "^2.0.1",
         "is-in-browser": "^1.1.3",
         "tiny-warning": "^1.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+          "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
+        }
       }
     },
     "jss-plugin-camel-case": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.1.1.tgz",
-      "integrity": "sha512-MDIaw8FeD5uFz1seQBKz4pnvDLnj5vIKV5hXSVdMaAVq13xR6SVTVWkIV/keyTs5txxTvzGJ9hXoxgd1WTUlBw==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.6.0.tgz",
+      "integrity": "sha512-JdLpA3aI/npwj3nDMKk308pvnhoSzkW3PXlbgHAzfx0yHWnPPVUjPhXFtLJzgKZge8lsfkUxvYSQ3X2OYIFU6A==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "hyphenate-style-name": "^1.0.3",
-        "jss": "10.1.1"
+        "jss": "10.6.0"
       }
     },
     "jss-plugin-default-unit": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.1.1.tgz",
-      "integrity": "sha512-UkeVCA/b3QEA4k0nIKS4uWXDCNmV73WLHdh2oDGZZc3GsQtlOCuiH3EkB/qI60v2MiCq356/SYWsDXt21yjwdg==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.6.0.tgz",
+      "integrity": "sha512-7y4cAScMHAxvslBK2JRK37ES9UT0YfTIXWgzUWD5euvR+JR3q+o8sQKzBw7GmkQRfZijrRJKNTiSt1PBsLI9/w==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.1.1"
+        "jss": "10.6.0"
       }
     },
     "jss-plugin-global": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.4.0.tgz",
-      "integrity": "sha512-b8IHMJUmv29cidt3nI4bUI1+Mo5RZE37kqthaFpmxf5K7r2aAegGliAw4hXvA70ca6ckAoXMUl4SN/zxiRcRag==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.6.0.tgz",
+      "integrity": "sha512-I3w7ji/UXPi3VuWrTCbHG9rVCgB4yoBQLehGDTmsnDfXQb3r1l3WIdcO8JFp9m0YMmyy2CU7UOV6oPI7/Tmu+w==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.4.0"
-      },
-      "dependencies": {
-        "csstype": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
-          "integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
-        },
-        "jss": {
-          "version": "10.4.0",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.4.0.tgz",
-          "integrity": "sha512-l7EwdwhsDishXzqTc3lbsbyZ83tlUl5L/Hb16pHCvZliA9lRDdNBZmHzeJHP0sxqD0t1mrMmMR8XroR12JBYzw==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "csstype": "^3.0.2",
-            "is-in-browser": "^1.1.3",
-            "tiny-warning": "^1.0.2"
-          }
-        }
+        "jss": "10.6.0"
       }
     },
     "jss-plugin-nested": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.4.0.tgz",
-      "integrity": "sha512-cKgpeHIxAP0ygeWh+drpLbrxFiak6zzJ2toVRi/NmHbpkNaLjTLgePmOz5+67ln3qzJiPdXXJB1tbOyYKAP4Pw==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.6.0.tgz",
+      "integrity": "sha512-fOFQWgd98H89E6aJSNkEh2fAXquC9aZcAVjSw4q4RoQ9gU++emg18encR4AT4OOIFl4lQwt5nEyBBRn9V1Rk8g==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.4.0",
+        "jss": "10.6.0",
         "tiny-warning": "^1.0.2"
-      },
-      "dependencies": {
-        "csstype": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
-          "integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
-        },
-        "jss": {
-          "version": "10.4.0",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.4.0.tgz",
-          "integrity": "sha512-l7EwdwhsDishXzqTc3lbsbyZ83tlUl5L/Hb16pHCvZliA9lRDdNBZmHzeJHP0sxqD0t1mrMmMR8XroR12JBYzw==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "csstype": "^3.0.2",
-            "is-in-browser": "^1.1.3",
-            "tiny-warning": "^1.0.2"
-          }
-        }
       }
     },
     "jss-plugin-props-sort": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.4.0.tgz",
-      "integrity": "sha512-j/t0R40/2fp+Nzt6GgHeUFnHVY2kPGF5drUVlgkcwYoHCgtBDOhTTsOfdaQFW6sHWfoQYgnGV4CXdjlPiRrzwA==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.6.0.tgz",
+      "integrity": "sha512-oMCe7hgho2FllNc60d9VAfdtMrZPo9n1Iu6RNa+3p9n0Bkvnv/XX5San8fTPujrTBScPqv9mOE0nWVvIaohNuw==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.4.0"
-      },
-      "dependencies": {
-        "csstype": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
-          "integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
-        },
-        "jss": {
-          "version": "10.4.0",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.4.0.tgz",
-          "integrity": "sha512-l7EwdwhsDishXzqTc3lbsbyZ83tlUl5L/Hb16pHCvZliA9lRDdNBZmHzeJHP0sxqD0t1mrMmMR8XroR12JBYzw==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "csstype": "^3.0.2",
-            "is-in-browser": "^1.1.3",
-            "tiny-warning": "^1.0.2"
-          }
-        }
+        "jss": "10.6.0"
       }
     },
     "jss-plugin-rule-value-function": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.4.0.tgz",
-      "integrity": "sha512-w8504Cdfu66+0SJoLkr6GUQlEb8keHg8ymtJXdVHWh0YvFxDG2l/nS93SI5Gfx0fV29dO6yUugXnKzDFJxrdFQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.6.0.tgz",
+      "integrity": "sha512-TKFqhRTDHN1QrPTMYRlIQUOC2FFQb271+AbnetURKlGvRl/eWLswcgHQajwuxI464uZk91sPiTtdGi7r7XaWfA==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.4.0",
+        "jss": "10.6.0",
         "tiny-warning": "^1.0.2"
-      },
-      "dependencies": {
-        "csstype": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
-          "integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
-        },
-        "jss": {
-          "version": "10.4.0",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.4.0.tgz",
-          "integrity": "sha512-l7EwdwhsDishXzqTc3lbsbyZ83tlUl5L/Hb16pHCvZliA9lRDdNBZmHzeJHP0sxqD0t1mrMmMR8XroR12JBYzw==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "csstype": "^3.0.2",
-            "is-in-browser": "^1.1.3",
-            "tiny-warning": "^1.0.2"
-          }
-        }
       }
     },
     "jss-plugin-vendor-prefixer": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.4.0.tgz",
-      "integrity": "sha512-DpF+/a+GU8hMh/948sBGnKSNfKkoHg2p9aRFUmyoyxgKjOeH9n74Ht3Yt8lOgdZsuWNJbPrvaa3U4PXKwxVpTQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.6.0.tgz",
+      "integrity": "sha512-doJ7MouBXT1lypLLctCwb4nJ6lDYqrTfVS3LtXgox42Xz0gXusXIIDboeh6UwnSmox90QpVnub7au8ybrb0krQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "css-vendor": "^2.0.8",
-        "jss": "10.4.0"
-      },
-      "dependencies": {
-        "csstype": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
-          "integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
-        },
-        "jss": {
-          "version": "10.4.0",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.4.0.tgz",
-          "integrity": "sha512-l7EwdwhsDishXzqTc3lbsbyZ83tlUl5L/Hb16pHCvZliA9lRDdNBZmHzeJHP0sxqD0t1mrMmMR8XroR12JBYzw==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "csstype": "^3.0.2",
-            "is-in-browser": "^1.1.3",
-            "tiny-warning": "^1.0.2"
-          }
-        }
+        "jss": "10.6.0"
       }
     },
     "jsx-ast-utils": {
@@ -27285,7 +27218,8 @@
     "popper.js": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "dev": true
     },
     "portfinder": {
       "version": "1.0.28",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">=10.18.1"
   },
   "dependencies": {
-    "@material-ui/core": "^4.10.0",
+    "@material-ui/core": "^4.11.1",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.56",
     "@rehooks/component-size": "^1.0.3",

--- a/src/components/experiments/single-view/results/ActualExperimentResults.tsx
+++ b/src/components/experiments/single-view/results/ActualExperimentResults.tsx
@@ -1,5 +1,8 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Chip,
   createStyles,
   FormControl,
@@ -12,6 +15,7 @@ import {
   Typography,
   useTheme,
 } from '@material-ui/core'
+import { ExpandMore as ExpandMoreIcon } from '@material-ui/icons'
 import clsx from 'clsx'
 import _ from 'lodash'
 import MaterialTable from 'material-table'
@@ -108,6 +112,17 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     tableTitle: {
       margin: theme.spacing(4, 2, 2),
+    },
+    accordion: {
+      margin: theme.spacing(2, 0),
+    },
+    accordionDetails: {
+      flexDirection: 'column',
+    },
+    pre: {
+      background: '#f5f5f5',
+      padding: theme.spacing(3),
+      overflow: 'scroll',
     },
   }),
 )
@@ -398,6 +413,39 @@ export default function ActualExperimentResults({
       <Paper id='health-report'>
         <HealthIndicatorTable indicators={experimentHealthIndicators} />
       </Paper>
+
+      <Accordion className={classes.accordion}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Typography variant='h5'>Early Monitoring - Live Assignment Count</Typography>
+        </AccordionSummary>
+        <AccordionDetails className={classes.accordionDetails}>
+          <Typography variant='body1'>
+            For early monitoring, you can run this query in Hue to retrieve raw unfiltered assignment counts from
+            Tracks.
+          </Typography>
+          <pre className={classes.pre}>
+            <code>
+              {/* (Using a javasript string automatically replaces special characters with html entities.) */}
+              {`with tracks_counts as (
+  select
+    a8c.get_json_object(eventprops, '$.experiment_variation_id') as experiment_variation_id,
+    count(*) as raw_number_of_assignments
+  from tracks.etl_events
+  where
+    eventname = 'wpcom_experiment_variation_assigned' and
+    eventprops like '%"experiment_id":"${experiment.experimentId}"%'
+  group by experiment_variation_id
+)
+
+select
+  experiment_variations.name as variation_name,
+  raw_number_of_assignments
+from tracks_counts
+inner join experiment_variations on cast(tracks_counts.experiment_variation_id as bigint) = experiment_variations.experiment_variation_id`}
+            </code>
+          </pre>
+        </AccordionDetails>
+      </Accordion>
     </div>
   )
 }

--- a/src/components/experiments/single-view/results/ActualExperimentResults.tsx
+++ b/src/components/experiments/single-view/results/ActualExperimentResults.tsx
@@ -432,8 +432,8 @@ export default function ActualExperimentResults({
           <Typography variant='body1'>No results are available at the moment, this can be due to:</Typography>
           <ul>
             <Typography component='li'>
-              <strong> An experiment being new. </strong> Due to Tracks and ExPlat processing it can take 24-48 hours
-              for results to come available. Usually released at 06:00 UTC daily.
+              <strong> An experiment being new. </strong> ExPlat can take 24-48 hours for results to process and become
+              available. Updates are usually released at 06:00 UTC daily.
             </Typography>
             <Typography component='li'>
               <strong> No assignments occuring. </strong> Check the &quot;Early Monitoring&quot; section below to ensure
@@ -445,12 +445,18 @@ export default function ActualExperimentResults({
 
       <Accordion className={classes.accordion}>
         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-          <Typography variant='h5'>Early Monitoring - Live Assignment Count</Typography>
+          <Typography variant='h5'>Early Monitoring - Live Assignment Event Flow</Typography>
         </AccordionSummary>
         <AccordionDetails className={classes.accordionDetails}>
           <Typography variant='body1'>
-            For early monitoring, you can run this query in Hue to retrieve raw unfiltered assignment counts from
-            Tracks.
+            For early monitoring, you can run this query in Hue to retrieve unfiltered assignment counts from the
+            unprocessed tracks queue.
+          </Typography>
+
+          <Typography variant='body1'>
+            This query should only be used to monitor event flow. The best way to use it is to run it multiple times and
+            ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are
+            moved to prod_events every day.
           </Typography>
           <pre className={classes.pre}>
             <code>
@@ -467,10 +473,10 @@ export default function ActualExperimentResults({
 )
 
 select
-  experiment_variations.name as variation_name,
+  wpcom.experiment_variations.name as variation_name,
   raw_number_of_assignments
 from tracks_counts
-inner join experiment_variations on cast(tracks_counts.experiment_variation_id as bigint) = experiment_variations.experiment_variation_id`}
+inner join wpcom.experiment_variations on cast(tracks_counts.experiment_variation_id as bigint) = wpcom.experiment_variations.experiment_variation_id`}
             </code>
           </pre>
         </AccordionDetails>

--- a/src/components/experiments/single-view/results/ActualExperimentResults.tsx
+++ b/src/components/experiments/single-view/results/ActualExperimentResults.tsx
@@ -425,19 +425,17 @@ export default function ActualExperimentResults({
         </>
       ) : (
         <Paper className={classes.noAnalysesPaper}>
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             {' '}
-            No results available
+            No Results{' '}
           </Typography>
-          <Typography variant='body1'>No results are available for this experiment, this can be due to:</Typography>
+          <Typography variant='body1'>No results are available at the moment, this can be due to:</Typography>
           <ul>
             <Typography component='li'>
-              {' '}
               <strong> An experiment being new. </strong> Due to Tracks and ExPlat processing it can take 24-48 hours
               for results to come available. Usually released at 06:00 UTC daily.
             </Typography>
             <Typography component='li'>
-              {' '}
               <strong> No assignments occuring. </strong> Check the &quot;Early Monitoring&quot; section below to ensure
               that assignments are occuring.
             </Typography>

--- a/src/components/experiments/single-view/results/ExperimentResults.test.tsx
+++ b/src/components/experiments/single-view/results/ExperimentResults.test.tsx
@@ -20,9 +20,7 @@ const analyses = Fixtures.createAnalyses()
 
 test('renders an appropriate message with no analyses', () => {
   const { container } = render(<ExperimentResults analyses={[]} experiment={experiment} metrics={metrics} />)
-  expect(container).toHaveTextContent('No analyses yet for experiment_1.')
-
-  expect(mockedPlot).toMatchInlineSnapshot(`[MockFunction]`)
+  expect(container).toMatchSnapshot()
 })
 
 test('renders correctly for 1 analysis datapoint', async () => {

--- a/src/components/experiments/single-view/results/ExperimentResults.tsx
+++ b/src/components/experiments/single-view/results/ExperimentResults.tsx
@@ -42,10 +42,6 @@ export default function ExperimentResults({
     }
   })
 
-  if (analyses.length === 0) {
-    return <p>No analyses yet for {experiment.name}.</p>
-  }
-
   return (
     <div className='analysis-latest-results'>
       <ActualExperimentResults

--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -11,21 +11,20 @@ exports[`renders an appropriate message with no analyses 1`] = `
       <div
         class="MuiPaper-root makeStyles-noAnalysesPaper-19 MuiPaper-elevation1 MuiPaper-rounded"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
+        <h3
+          class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
         >
-           No results available
-        </h4>
+           No Results 
+        </h3>
         <p
           class="MuiTypography-root MuiTypography-body1"
         >
-          No results are available for this experiment, this can be due to:
+          No results are available at the moment, this can be due to:
         </p>
         <ul>
           <li
             class="MuiTypography-root MuiTypography-body1"
           >
-             
             <strong>
                An experiment being new. 
             </strong>
@@ -34,7 +33,6 @@ exports[`renders an appropriate message with no analyses 1`] = `
           <li
             class="MuiTypography-root MuiTypography-body1"
           >
-             
             <strong>
                No assignments occuring. 
             </strong>

--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -14,7 +14,9 @@ exports[`renders an appropriate message with no analyses 1`] = `
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
         >
-           No Results 
+           
+          No Results
+           
         </h3>
         <p
           class="MuiTypography-root MuiTypography-body1"
@@ -28,7 +30,7 @@ exports[`renders an appropriate message with no analyses 1`] = `
             <strong>
                An experiment being new. 
             </strong>
-             Due to Tracks and ExPlat processing it can take 24-48 hours for results to come available. Usually released at 06:00 UTC daily.
+             ExPlat can take 24-48 hours for results to process and become available. Updates are usually released at 06:00 UTC daily.
           </li>
           <li
             class="MuiTypography-root MuiTypography-body1"
@@ -56,7 +58,7 @@ exports[`renders an appropriate message with no analyses 1`] = `
             <h5
               class="MuiTypography-root MuiTypography-h5"
             >
-              Early Monitoring - Live Assignment Count
+              Early Monitoring - Live Assignment Event Flow
             </h5>
           </div>
           <div
@@ -102,7 +104,12 @@ exports[`renders an appropriate message with no analyses 1`] = `
                   <p
                     class="MuiTypography-root MuiTypography-body1"
                   >
-                    For early monitoring, you can run this query in Hue to retrieve raw unfiltered assignment counts from Tracks.
+                    For early monitoring, you can run this query in Hue to retrieve unfiltered assignment counts from the unprocessed tracks queue.
+                  </p>
+                  <p
+                    class="MuiTypography-root MuiTypography-body1"
+                  >
+                    This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                   </p>
                   <pre
                     class="makeStyles-pre-20"
@@ -120,10 +127,10 @@ exports[`renders an appropriate message with no analyses 1`] = `
 )
 
 select
-  experiment_variations.name as variation_name,
+  wpcom.experiment_variations.name as variation_name,
   raw_number_of_assignments
 from tracks_counts
-inner join experiment_variations on cast(tracks_counts.experiment_variation_id as bigint) = experiment_variations.experiment_variation_id
+inner join wpcom.experiment_variations on cast(tracks_counts.experiment_variation_id as bigint) = wpcom.experiment_variations.experiment_variation_id
                     </code>
                   </pre>
                 </div>
@@ -1025,7 +1032,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
           <h5
             class="MuiTypography-root MuiTypography-h5"
           >
-            Early Monitoring - Live Assignment Count
+            Early Monitoring - Live Assignment Event Flow
           </h5>
         </div>
         <div
@@ -1071,7 +1078,12 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 <p
                   class="MuiTypography-root MuiTypography-body1"
                 >
-                  For early monitoring, you can run this query in Hue to retrieve raw unfiltered assignment counts from Tracks.
+                  For early monitoring, you can run this query in Hue to retrieve unfiltered assignment counts from the unprocessed tracks queue.
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1"
+                >
+                  This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                 </p>
                 <pre
                   class="makeStyles-pre-40"
@@ -1089,10 +1101,10 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
 )
 
 select
-  experiment_variations.name as variation_name,
+  wpcom.experiment_variations.name as variation_name,
   raw_number_of_assignments
 from tracks_counts
-inner join experiment_variations on cast(tracks_counts.experiment_variation_id as bigint) = experiment_variations.experiment_variation_id
+inner join wpcom.experiment_variations on cast(tracks_counts.experiment_variation_id as bigint) = wpcom.experiment_variations.experiment_variation_id
                   </code>
                 </pre>
               </div>
@@ -2422,7 +2434,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           <h5
             class="MuiTypography-root MuiTypography-h5"
           >
-            Early Monitoring - Live Assignment Count
+            Early Monitoring - Live Assignment Event Flow
           </h5>
         </div>
         <div
@@ -2468,7 +2480,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <p
                   class="MuiTypography-root MuiTypography-body1"
                 >
-                  For early monitoring, you can run this query in Hue to retrieve raw unfiltered assignment counts from Tracks.
+                  For early monitoring, you can run this query in Hue to retrieve unfiltered assignment counts from the unprocessed tracks queue.
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1"
+                >
+                  This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                 </p>
                 <pre
                   class="makeStyles-pre-87"
@@ -2486,10 +2503,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
 )
 
 select
-  experiment_variations.name as variation_name,
+  wpcom.experiment_variations.name as variation_name,
   raw_number_of_assignments
 from tracks_counts
-inner join experiment_variations on cast(tracks_counts.experiment_variation_id as bigint) = experiment_variations.experiment_variation_id
+inner join wpcom.experiment_variations on cast(tracks_counts.experiment_variation_id as bigint) = wpcom.experiment_variations.experiment_variation_id
                   </code>
                 </pre>
               </div>
@@ -4027,7 +4044,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           <h5
             class="MuiTypography-root MuiTypography-h5"
           >
-            Early Monitoring - Live Assignment Count
+            Early Monitoring - Live Assignment Event Flow
           </h5>
         </div>
         <div
@@ -4073,7 +4090,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <p
                   class="MuiTypography-root MuiTypography-body1"
                 >
-                  For early monitoring, you can run this query in Hue to retrieve raw unfiltered assignment counts from Tracks.
+                  For early monitoring, you can run this query in Hue to retrieve unfiltered assignment counts from the unprocessed tracks queue.
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1"
+                >
+                  This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                 </p>
                 <pre
                   class="makeStyles-pre-134"
@@ -4091,10 +4113,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
 )
 
 select
-  experiment_variations.name as variation_name,
+  wpcom.experiment_variations.name as variation_name,
   raw_number_of_assignments
 from tracks_counts
-inner join experiment_variations on cast(tracks_counts.experiment_variation_id as bigint) = experiment_variations.experiment_variation_id
+inner join wpcom.experiment_variations on cast(tracks_counts.experiment_variation_id as bigint) = wpcom.experiment_variations.experiment_variation_id
                   </code>
                 </pre>
               </div>

--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -1,17 +1,156 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders an appropriate message with no analyses 1`] = `
+<div>
+  <div
+    class="analysis-latest-results"
+  >
+    <div
+      class="makeStyles-root-1"
+    >
+      <div
+        class="MuiPaper-root makeStyles-noAnalysesPaper-19 MuiPaper-elevation1 MuiPaper-rounded"
+      >
+        <h4
+          class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
+        >
+           No results available
+        </h4>
+        <p
+          class="MuiTypography-root MuiTypography-body1"
+        >
+          No results are available for this experiment, this can be due to:
+        </p>
+        <ul>
+          <li
+            class="MuiTypography-root MuiTypography-body1"
+          >
+             
+            <strong>
+               An experiment being new. 
+            </strong>
+             Due to Tracks and ExPlat processing it can take 24-48 hours for results to come available. Usually released at 06:00 UTC daily.
+          </li>
+          <li
+            class="MuiTypography-root MuiTypography-body1"
+          >
+             
+            <strong>
+               No assignments occuring. 
+            </strong>
+             Check the "Early Monitoring" section below to ensure that assignments are occuring.
+          </li>
+        </ul>
+      </div>
+      <div
+        class="MuiPaper-root MuiAccordion-root makeStyles-accordion-17 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+      >
+        <div
+          aria-disabled="false"
+          aria-expanded="false"
+          class="MuiButtonBase-root MuiAccordionSummary-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiAccordionSummary-content"
+          >
+            <h5
+              class="MuiTypography-root MuiTypography-h5"
+            >
+              Early Monitoring - Live Assignment Count
+            </h5>
+          </div>
+          <div
+            aria-disabled="false"
+            aria-hidden="true"
+            class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </div>
+        </div>
+        <div
+          class="MuiCollapse-container MuiCollapse-hidden"
+          style="min-height: 0px;"
+        >
+          <div
+            class="MuiCollapse-wrapper"
+          >
+            <div
+              class="MuiCollapse-wrapperInner"
+            >
+              <div
+                role="region"
+              >
+                <div
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-18"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1"
+                  >
+                    For early monitoring, you can run this query in Hue to retrieve raw unfiltered assignment counts from Tracks.
+                  </p>
+                  <pre
+                    class="makeStyles-pre-20"
+                  >
+                    <code>
+                      with tracks_counts as (
+  select
+    a8c.get_json_object(eventprops, '$.experiment_variation_id') as experiment_variation_id,
+    count(*) as raw_number_of_assignments
+  from tracks.etl_events
+  where
+    eventname = 'wpcom_experiment_variation_assigned' and
+    eventprops like '%"experiment_id":"1"%'
+  group by experiment_variation_id
+)
+
+select
+  experiment_variations.name as variation_name,
+  raw_number_of_assignments
+from tracks_counts
+inner join experiment_variations on cast(tracks_counts.experiment_variation_id as bigint) = experiment_variations.experiment_variation_id
+                    </code>
+                  </pre>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders correctly for 1 analysis datapoint 1`] = `
 <div
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-1"
+    class="makeStyles-root-21"
   >
     <div
-      class="makeStyles-summary-3"
+      class="makeStyles-summary-23"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-14 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-34 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -20,16 +159,16 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-5"
+        class="makeStyles-summaryColumn-25"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-6 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-26 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-7"
+            class="makeStyles-summaryStatsPart-27"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-9 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-29 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               1,000
             </h3>
@@ -45,10 +184,10 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-7"
+            class="makeStyles-summaryStatsPart-27"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-9 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-29 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Deploy 
               test
@@ -64,12 +203,12 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-10 makeStyles-indicationSeverityWarning-12 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-30 makeStyles-indicationSeverityWarning-32 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-9 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-29 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Potential issues
             </h3>
@@ -86,7 +225,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-16 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-36 MuiTypography-h3"
     >
       Metric Assignment Results
     </h3>
@@ -95,7 +234,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-22"
+        class="Component-horizontalScrollContainer-46"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -114,26 +253,26 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-23 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-47 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-23 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-47 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-23 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-47 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Attribution window
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-23 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-47 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -187,7 +326,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                        
                       <div
                         aria-disabled="true"
-                        class="MuiChip-root makeStyles-primaryChip-2 MuiChip-outlined Mui-disabled"
+                        class="MuiChip-root makeStyles-primaryChip-22 MuiChip-outlined Mui-disabled"
                       >
                         <span
                           class="MuiChip-label"
@@ -383,7 +522,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-16 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-36 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -465,18 +604,18 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49 makeStyles-deemphasized-50 makeStyles-nowrap-51"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-32"
+                  class="makeStyles-tooltip-56"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49 makeStyles-deemphasized-50 makeStyles-nowrap-51"
                 scope="row"
               >
                 1.0000
@@ -488,7 +627,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-28 makeStyles-indicationSeverityOk-29 makeStyles-monospace-25 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-52 makeStyles-indicationSeverityOk-53 makeStyles-monospace-49 makeStyles-nowrap-51"
                 scope="row"
               >
                 <span>
@@ -496,13 +635,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49 makeStyles-deemphasized-50 makeStyles-nowrap-51"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-26"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-50"
                 scope="row"
               >
                 <p
@@ -526,18 +665,18 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49 makeStyles-deemphasized-50 makeStyles-nowrap-51"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-32"
+                  class="makeStyles-tooltip-56"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49 makeStyles-deemphasized-50 makeStyles-nowrap-51"
                 scope="row"
               >
                 1.0000
@@ -549,7 +688,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-28 makeStyles-indicationSeverityOk-29 makeStyles-monospace-25 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-52 makeStyles-indicationSeverityOk-53 makeStyles-monospace-49 makeStyles-nowrap-51"
                 scope="row"
               >
                 <span>
@@ -557,13 +696,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49 makeStyles-deemphasized-50 makeStyles-nowrap-51"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-26"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-50"
                 scope="row"
               >
                 <p
@@ -587,18 +726,18 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49 makeStyles-deemphasized-50 makeStyles-nowrap-51"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-32"
+                  class="makeStyles-tooltip-56"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49 makeStyles-deemphasized-50 makeStyles-nowrap-51"
                 scope="row"
               >
                 1.0000
@@ -610,7 +749,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-28 makeStyles-indicationSeverityOk-29 makeStyles-monospace-25 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-52 makeStyles-indicationSeverityOk-53 makeStyles-monospace-49 makeStyles-nowrap-51"
                 scope="row"
               >
                 <span>
@@ -618,13 +757,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49 makeStyles-deemphasized-50 makeStyles-nowrap-51"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-26"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-50"
                 scope="row"
               >
                 <p
@@ -648,7 +787,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49 makeStyles-deemphasized-50 makeStyles-nowrap-51"
                 scope="row"
               >
                 <span>
@@ -656,7 +795,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49 makeStyles-deemphasized-50 makeStyles-nowrap-51"
                 scope="row"
               >
                 0.0000
@@ -668,7 +807,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-28 makeStyles-indicationSeverityOk-29 makeStyles-monospace-25 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-52 makeStyles-indicationSeverityOk-53 makeStyles-monospace-49 makeStyles-nowrap-51"
                 scope="row"
               >
                 <span>
@@ -676,13 +815,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49 makeStyles-deemphasized-50 makeStyles-nowrap-51"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.01
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-26"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-50"
                 scope="row"
               >
                 <p
@@ -706,7 +845,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49 makeStyles-deemphasized-50 makeStyles-nowrap-51"
                 scope="row"
               >
                 <span>
@@ -714,7 +853,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49 makeStyles-deemphasized-50 makeStyles-nowrap-51"
                 scope="row"
               >
                 0.0000
@@ -726,7 +865,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-28 makeStyles-indicationSeverityOk-29 makeStyles-monospace-25 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-52 makeStyles-indicationSeverityOk-53 makeStyles-monospace-49 makeStyles-nowrap-51"
                 scope="row"
               >
                 <span>
@@ -734,13 +873,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49 makeStyles-deemphasized-50 makeStyles-nowrap-51"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-26"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-50"
                 scope="row"
               >
                 <p
@@ -764,7 +903,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49 makeStyles-deemphasized-50 makeStyles-nowrap-51"
                 scope="row"
               >
                 <span>
@@ -772,7 +911,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49 makeStyles-deemphasized-50 makeStyles-nowrap-51"
                 scope="row"
               >
                 0.1000
@@ -784,7 +923,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-28 makeStyles-indicationSeverityOk-29 makeStyles-monospace-25 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-52 makeStyles-indicationSeverityOk-53 makeStyles-monospace-49 makeStyles-nowrap-51"
                 scope="row"
               >
                 <span>
@@ -792,13 +931,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49 makeStyles-deemphasized-50 makeStyles-nowrap-51"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.8
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-26"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-50"
                 scope="row"
               >
                 <p
@@ -822,7 +961,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49 makeStyles-deemphasized-50 makeStyles-nowrap-51"
                 scope="row"
               >
                 <span>
@@ -830,7 +969,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49 makeStyles-deemphasized-50 makeStyles-nowrap-51"
                 scope="row"
               >
                 0.0000
@@ -844,7 +983,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-28 makeStyles-indicationSeverityWarning-30 makeStyles-monospace-25 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-52 makeStyles-indicationSeverityWarning-54 makeStyles-monospace-49 makeStyles-nowrap-51"
                 scope="row"
               >
                 <span>
@@ -852,13 +991,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25 makeStyles-deemphasized-26 makeStyles-nowrap-27"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-49 makeStyles-deemphasized-50 makeStyles-nowrap-51"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-26"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-50"
                 scope="row"
               >
                 <p
@@ -872,21 +1011,113 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
         </table>
       </div>
     </div>
+    <div
+      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-37 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="false"
+        class="MuiButtonBase-root MuiAccordionSummary-root"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="MuiAccordionSummary-content"
+        >
+          <h5
+            class="MuiTypography-root MuiTypography-h5"
+          >
+            Early Monitoring - Live Assignment Count
+          </h5>
+        </div>
+        <div
+          aria-disabled="false"
+          aria-hidden="true"
+          class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
+        >
+          <span
+            class="MuiIconButton-label"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+              />
+            </svg>
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </div>
+      </div>
+      <div
+        class="MuiCollapse-container MuiCollapse-hidden"
+        style="min-height: 0px;"
+      >
+        <div
+          class="MuiCollapse-wrapper"
+        >
+          <div
+            class="MuiCollapse-wrapperInner"
+          >
+            <div
+              role="region"
+            >
+              <div
+                class="MuiAccordionDetails-root makeStyles-accordionDetails-38"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1"
+                >
+                  For early monitoring, you can run this query in Hue to retrieve raw unfiltered assignment counts from Tracks.
+                </p>
+                <pre
+                  class="makeStyles-pre-40"
+                >
+                  <code>
+                    with tracks_counts as (
+  select
+    a8c.get_json_object(eventprops, '$.experiment_variation_id') as experiment_variation_id,
+    count(*) as raw_number_of_assignments
+  from tracks.etl_events
+  where
+    eventname = 'wpcom_experiment_variation_assigned' and
+    eventprops like '%"experiment_id":"1"%'
+  group by experiment_variation_id
+)
+
+select
+  experiment_variations.name as variation_name,
+  raw_number_of_assignments
+from tracks_counts
+inner join experiment_variations on cast(tracks_counts.experiment_variation_id as bigint) = experiment_variations.experiment_variation_id
+                  </code>
+                </pre>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;
 
 exports[`renders correctly for 1 analysis datapoint 2`] = `
 <div
-  class="MuiTableContainer-root makeStyles-root-33 analysis-detail-panel"
+  class="MuiTableContainer-root makeStyles-root-57 analysis-detail-panel"
 >
   <p
-    class="MuiTypography-root makeStyles-noPlotMessage-39 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-noPlotMessage-63 MuiTypography-body1"
   >
     Past values will be plotted once we have more than one day of results.
   </p>
   <h4
-    class="MuiTypography-root makeStyles-tableHeader-40 MuiTypography-h4"
+    class="MuiTypography-root makeStyles-tableHeader-64 MuiTypography-h4"
   >
     Latest Estimates
   </h4>
@@ -900,20 +1131,20 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-41 makeStyles-headerCell-34"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-65 makeStyles-headerCell-58"
           role="cell"
           scope="row"
         >
           Difference
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-35"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
         >
           [
           
           -1
           <span
-            class="makeStyles-root-42"
+            class="makeStyles-root-66"
             title="Percentage points."
           >
             pp
@@ -922,7 +1153,7 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
           
           1
           <span
-            class="makeStyles-root-42"
+            class="makeStyles-root-66"
             title="Percentage points."
           >
             pp
@@ -939,7 +1170,7 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
           
           -1
           <span
-            class="makeStyles-root-42"
+            class="makeStyles-root-66"
             title="Percentage points."
           >
             pp
@@ -950,7 +1181,7 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
           
           1
           <span
-            class="makeStyles-root-42"
+            class="makeStyles-root-66"
             title="Percentage points."
           >
             pp
@@ -962,19 +1193,19 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-41 makeStyles-headerCell-34"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-65 makeStyles-headerCell-58"
           role="cell"
           scope="row"
           valign="top"
         >
           <span
-            class="makeStyles-monospace-35"
+            class="makeStyles-monospace-59"
           >
             test
           </span>
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-35"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
         >
           [
           
@@ -1009,19 +1240,19 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-41 makeStyles-headerCell-34"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-65 makeStyles-headerCell-58"
           role="cell"
           scope="row"
           valign="top"
         >
           <span
-            class="makeStyles-monospace-35"
+            class="makeStyles-monospace-59"
           >
             control
           </span>
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-35"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
         >
           [
           
@@ -1056,7 +1287,7 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-34"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-58"
           role="cell"
           scope="row"
         >
@@ -1070,7 +1301,7 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
           Warnings
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-35"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
         >
           <div>
             Experiment period is too short. Wait a few days to be safer.
@@ -1083,7 +1314,7 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
     </tbody>
   </table>
   <h4
-    class="MuiTypography-root makeStyles-tableHeader-40 MuiTypography-h4"
+    class="MuiTypography-root makeStyles-tableHeader-64 MuiTypography-h4"
   >
     Metric Assignment Details
   </h4>
@@ -1097,14 +1328,14 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-34"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-58"
           role="cell"
           scope="row"
         >
           Metric Description
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-35"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
         >
           This is metric 1
         </td>
@@ -1113,19 +1344,19 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-34"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-58"
           role="cell"
           scope="row"
         >
           Minimum Practical Difference
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-35"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
         >
           
           10
           <span
-            class="makeStyles-root-42"
+            class="makeStyles-root-66"
             title="Percentage points."
           >
             pp
@@ -1136,14 +1367,14 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-34"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-58"
           role="cell"
           scope="row"
         >
           Change Expected
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-35"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
         >
           Yes
         </td>
@@ -1151,7 +1382,7 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
     </tbody>
   </table>
   <h4
-    class="MuiTypography-root makeStyles-tableHeader-40 MuiTypography-h4"
+    class="MuiTypography-root makeStyles-tableHeader-64 MuiTypography-h4"
   >
     Analysis Fine Print
   </h4>
@@ -1165,7 +1396,7 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-34"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-58"
           role="cell"
           scope="row"
         >
@@ -1175,7 +1406,7 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
           class="MuiTableCell-root MuiTableCell-body"
         >
           <span
-            class="makeStyles-root-43"
+            class="makeStyles-root-67"
             title="09/05/2020, 20:00:00"
           >
             2020-05-10
@@ -1186,14 +1417,14 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-34"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-58"
           role="cell"
           scope="row"
         >
           Analysis strategy
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-35"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
         >
           Exposed without crossovers and spammers
         </td>
@@ -1202,14 +1433,14 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-34"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-58"
           role="cell"
           scope="row"
         >
           Analyzed participants
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-35"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
         >
           1000
            (
@@ -1227,7 +1458,7 @@ exports[`renders correctly for 1 analysis datapoint 3`] = `
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-15",
+        "className": "makeStyles-participantsPlot-35",
         "data": Array [
           Object {
             "line": Object {
@@ -1295,13 +1526,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-44"
+    class="makeStyles-root-68"
   >
     <div
-      class="makeStyles-summary-46"
+      class="makeStyles-summary-70"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-57 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-81 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -1310,16 +1541,16 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-48"
+        class="makeStyles-summaryColumn-72"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-49 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-73 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-50"
+            class="makeStyles-summaryStatsPart-74"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-52 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-76 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               700
             </h3>
@@ -1335,13 +1566,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-50"
+            class="makeStyles-summaryStatsPart-74"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-52 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-76 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               <span
-                class="makeStyles-tooltipped-60"
+                class="makeStyles-tooltipped-88"
                 title="Contact @experimentation-review on #a8c-experiments"
               >
                 Manual analysis required
@@ -1358,12 +1589,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-53 makeStyles-indicationSeverityError-56 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-77 makeStyles-indicationSeverityError-80 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-52 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-76 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Serious issues
             </h3>
@@ -1380,7 +1611,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-59 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-83 MuiTypography-h3"
     >
       Metric Assignment Results
     </h3>
@@ -1389,7 +1620,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-65"
+        class="Component-horizontalScrollContainer-93"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -1408,26 +1639,26 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-66 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-94 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-66 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-94 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-66 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-94 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Attribution window
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-66 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-94 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -1479,7 +1710,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                        
                       <div
                         aria-disabled="true"
-                        class="MuiChip-root makeStyles-primaryChip-45 MuiChip-outlined Mui-disabled"
+                        class="MuiChip-root makeStyles-primaryChip-69 MuiChip-outlined Mui-disabled"
                       >
                         <span
                           class="MuiChip-label"
@@ -1499,7 +1730,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
                       <span
-                        class="makeStyles-tooltipped-60"
+                        class="makeStyles-tooltipped-88"
                         title="Contact @experimentation-review on #a8c-experiments"
                       >
                         Manual analysis required
@@ -1680,7 +1911,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-59 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-83 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -1762,18 +1993,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-75"
+                  class="makeStyles-tooltip-103"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
                 scope="row"
               >
                 1.0000
@@ -1785,7 +2016,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-71 makeStyles-indicationSeverityOk-72 makeStyles-monospace-68 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-99 makeStyles-indicationSeverityOk-100 makeStyles-monospace-96 makeStyles-nowrap-98"
                 scope="row"
               >
                 <span>
@@ -1793,13 +2024,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-69"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-97"
                 scope="row"
               >
                 <p
@@ -1823,18 +2054,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-75"
+                  class="makeStyles-tooltip-103"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
                 scope="row"
               >
                 1.0000
@@ -1846,7 +2077,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-71 makeStyles-indicationSeverityOk-72 makeStyles-monospace-68 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-99 makeStyles-indicationSeverityOk-100 makeStyles-monospace-96 makeStyles-nowrap-98"
                 scope="row"
               >
                 <span>
@@ -1854,13 +2085,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-69"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-97"
                 scope="row"
               >
                 <p
@@ -1884,18 +2115,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-75"
+                  class="makeStyles-tooltip-103"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
                 scope="row"
               >
                 1.0000
@@ -1907,7 +2138,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-71 makeStyles-indicationSeverityOk-72 makeStyles-monospace-68 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-99 makeStyles-indicationSeverityOk-100 makeStyles-monospace-96 makeStyles-nowrap-98"
                 scope="row"
               >
                 <span>
@@ -1915,13 +2146,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-69"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-97"
                 scope="row"
               >
                 <p
@@ -1945,7 +2176,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
                 scope="row"
               >
                 <span>
@@ -1953,7 +2184,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
                 scope="row"
               >
                 0.1000
@@ -1967,7 +2198,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-71 makeStyles-indicationSeverityError-74 makeStyles-monospace-68 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-99 makeStyles-indicationSeverityError-102 makeStyles-monospace-96 makeStyles-nowrap-98"
                 scope="row"
               >
                 <span>
@@ -1975,13 +2206,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-69"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-97"
                 scope="row"
               >
                 <p
@@ -2007,7 +2238,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
                 scope="row"
               >
                 <span>
@@ -2015,7 +2246,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
                 scope="row"
               >
                 0.1500
@@ -2029,7 +2260,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-71 makeStyles-indicationSeverityWarning-73 makeStyles-monospace-68 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-99 makeStyles-indicationSeverityWarning-101 makeStyles-monospace-96 makeStyles-nowrap-98"
                 scope="row"
               >
                 <span>
@@ -2037,13 +2268,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
                 scope="row"
               >
                 0.1 &lt; x ≤ 0.4
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-69"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-97"
                 scope="row"
               >
                 <p
@@ -2069,7 +2300,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
                 scope="row"
               >
                 <span>
@@ -2077,7 +2308,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
                 scope="row"
               >
                 0.1000
@@ -2089,7 +2320,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-71 makeStyles-indicationSeverityOk-72 makeStyles-monospace-68 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-99 makeStyles-indicationSeverityOk-100 makeStyles-monospace-96 makeStyles-nowrap-98"
                 scope="row"
               >
                 <span>
@@ -2097,13 +2328,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.8
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-69"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-97"
                 scope="row"
               >
                 <p
@@ -2127,7 +2358,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
                 scope="row"
               >
                 <span>
@@ -2135,7 +2366,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
                 scope="row"
               >
                 0.0000
@@ -2149,7 +2380,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-71 makeStyles-indicationSeverityWarning-73 makeStyles-monospace-68 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-99 makeStyles-indicationSeverityWarning-101 makeStyles-monospace-96 makeStyles-nowrap-98"
                 scope="row"
               >
                 <span>
@@ -2157,13 +2388,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68 makeStyles-deemphasized-69 makeStyles-nowrap-70"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-69"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-97"
                 scope="row"
               >
                 <p
@@ -2177,19 +2408,111 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         </table>
       </div>
     </div>
+    <div
+      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-84 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="false"
+        class="MuiButtonBase-root MuiAccordionSummary-root"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="MuiAccordionSummary-content"
+        >
+          <h5
+            class="MuiTypography-root MuiTypography-h5"
+          >
+            Early Monitoring - Live Assignment Count
+          </h5>
+        </div>
+        <div
+          aria-disabled="false"
+          aria-hidden="true"
+          class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
+        >
+          <span
+            class="MuiIconButton-label"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+              />
+            </svg>
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </div>
+      </div>
+      <div
+        class="MuiCollapse-container MuiCollapse-hidden"
+        style="min-height: 0px;"
+      >
+        <div
+          class="MuiCollapse-wrapper"
+        >
+          <div
+            class="MuiCollapse-wrapperInner"
+          >
+            <div
+              role="region"
+            >
+              <div
+                class="MuiAccordionDetails-root makeStyles-accordionDetails-85"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1"
+                >
+                  For early monitoring, you can run this query in Hue to retrieve raw unfiltered assignment counts from Tracks.
+                </p>
+                <pre
+                  class="makeStyles-pre-87"
+                >
+                  <code>
+                    with tracks_counts as (
+  select
+    a8c.get_json_object(eventprops, '$.experiment_variation_id') as experiment_variation_id,
+    count(*) as raw_number_of_assignments
+  from tracks.etl_events
+  where
+    eventname = 'wpcom_experiment_variation_assigned' and
+    eventprops like '%"experiment_id":"1"%'
+  group by experiment_variation_id
+)
+
+select
+  experiment_variations.name as variation_name,
+  raw_number_of_assignments
+from tracks_counts
+inner join experiment_variations on cast(tracks_counts.experiment_variation_id as bigint) = experiment_variations.experiment_variation_id
+                  </code>
+                </pre>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;
 
 exports[`renders the condensed table with some analyses in non-debug mode for a Conversion Metric 2`] = `
 <div
-  class="MuiTableContainer-root makeStyles-root-76 analysis-detail-panel"
+  class="MuiTableContainer-root makeStyles-root-104 analysis-detail-panel"
 >
   <div
-    class="makeStyles-metricEstimatePlots-79"
+    class="makeStyles-metricEstimatePlots-107"
   />
   <h4
-    class="MuiTypography-root makeStyles-tableHeader-83 MuiTypography-h4"
+    class="MuiTypography-root makeStyles-tableHeader-111 MuiTypography-h4"
   >
     Latest Estimates
   </h4>
@@ -2203,20 +2526,20 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-84 makeStyles-headerCell-77"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-112 makeStyles-headerCell-105"
           role="cell"
           scope="row"
         >
           Difference
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-78"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106"
         >
           [
           
           -1
           <span
-            class="makeStyles-root-85"
+            class="makeStyles-root-113"
             title="Percentage points."
           >
             pp
@@ -2225,7 +2548,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           
           1
           <span
-            class="makeStyles-root-85"
+            class="makeStyles-root-113"
             title="Percentage points."
           >
             pp
@@ -2242,7 +2565,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           
           -1
           <span
-            class="makeStyles-root-85"
+            class="makeStyles-root-113"
             title="Percentage points."
           >
             pp
@@ -2253,7 +2576,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           
           1
           <span
-            class="makeStyles-root-85"
+            class="makeStyles-root-113"
             title="Percentage points."
           >
             pp
@@ -2265,19 +2588,19 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-84 makeStyles-headerCell-77"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-112 makeStyles-headerCell-105"
           role="cell"
           scope="row"
           valign="top"
         >
           <span
-            class="makeStyles-monospace-78"
+            class="makeStyles-monospace-106"
           >
             test
           </span>
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-78"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106"
         >
           [
           
@@ -2312,19 +2635,19 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-84 makeStyles-headerCell-77"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-112 makeStyles-headerCell-105"
           role="cell"
           scope="row"
           valign="top"
         >
           <span
-            class="makeStyles-monospace-78"
+            class="makeStyles-monospace-106"
           >
             control
           </span>
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-78"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106"
         >
           [
           
@@ -2359,7 +2682,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-77"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-105"
           role="cell"
           scope="row"
         >
@@ -2373,7 +2696,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           Warnings
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-78"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106"
         >
           <div>
             Experiment period is too short. Wait a few days to be safer.
@@ -2386,7 +2709,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </tbody>
   </table>
   <h4
-    class="MuiTypography-root makeStyles-tableHeader-83 MuiTypography-h4"
+    class="MuiTypography-root makeStyles-tableHeader-111 MuiTypography-h4"
   >
     Metric Assignment Details
   </h4>
@@ -2400,14 +2723,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-77"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-105"
           role="cell"
           scope="row"
         >
           Metric Description
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-78"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106"
         >
           This is metric 3
         </td>
@@ -2416,19 +2739,19 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-77"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-105"
           role="cell"
           scope="row"
         >
           Minimum Practical Difference
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-78"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106"
         >
           
           1200
           <span
-            class="makeStyles-root-85"
+            class="makeStyles-root-113"
             title="Percentage points."
           >
             pp
@@ -2439,14 +2762,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-77"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-105"
           role="cell"
           scope="row"
         >
           Change Expected
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-78"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106"
         >
           Yes
         </td>
@@ -2454,7 +2777,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </tbody>
   </table>
   <h4
-    class="MuiTypography-root makeStyles-tableHeader-83 MuiTypography-h4"
+    class="MuiTypography-root makeStyles-tableHeader-111 MuiTypography-h4"
   >
     Analysis Fine Print
   </h4>
@@ -2468,7 +2791,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-77"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-105"
           role="cell"
           scope="row"
         >
@@ -2478,7 +2801,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           class="MuiTableCell-root MuiTableCell-body"
         >
           <span
-            class="makeStyles-root-86"
+            class="makeStyles-root-114"
             title="10/06/2020, 20:00:00"
           >
             2020-06-11
@@ -2489,14 +2812,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-77"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-105"
           role="cell"
           scope="row"
         >
           Analysis strategy
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-78"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106"
         >
           Exposed without crossovers and spammers
         </td>
@@ -2505,14 +2828,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-77"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-105"
           role="cell"
           scope="row"
         >
           Analyzed participants
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-78"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106"
         >
           1200
            (
@@ -2530,7 +2853,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-58",
+        "className": "makeStyles-participantsPlot-82",
         "data": Array [
           Object {
             "line": Object {
@@ -2589,7 +2912,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-80",
+        "className": "makeStyles-metricEstimatePlot-108",
         "data": Array [
           Object {
             "line": Object {
@@ -2685,7 +3008,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-80",
+        "className": "makeStyles-metricEstimatePlot-108",
         "data": Array [
           Object {
             "line": Object {
@@ -2808,13 +3131,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-87"
+    class="makeStyles-root-115"
   >
     <div
-      class="makeStyles-summary-89"
+      class="makeStyles-summary-117"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-100 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-128 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -2823,16 +3146,16 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-91"
+        class="makeStyles-summaryColumn-119"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-92 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-120 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-93"
+            class="makeStyles-summaryStatsPart-121"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-95 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-123 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               700
             </h3>
@@ -2848,13 +3171,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-93"
+            class="makeStyles-summaryStatsPart-121"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-95 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-123 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               <span
-                class="makeStyles-tooltipped-103"
+                class="makeStyles-tooltipped-135"
                 title="Contact @experimentation-review on #a8c-experiments"
               >
                 Manual analysis required
@@ -2871,12 +3194,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-96 makeStyles-indicationSeverityError-99 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-124 makeStyles-indicationSeverityError-127 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-95 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-123 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Serious issues
             </h3>
@@ -2893,7 +3216,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-102 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-130 MuiTypography-h3"
     >
       Metric Assignment Results
     </h3>
@@ -2902,7 +3225,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-108"
+        class="Component-horizontalScrollContainer-140"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -2921,26 +3244,26 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-109 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-141 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-109 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-141 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-109 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-141 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Attribution window
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-109 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-141 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -2992,7 +3315,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                        
                       <div
                         aria-disabled="true"
-                        class="MuiChip-root makeStyles-primaryChip-88 MuiChip-outlined Mui-disabled"
+                        class="MuiChip-root makeStyles-primaryChip-116 MuiChip-outlined Mui-disabled"
                       >
                         <span
                           class="MuiChip-label"
@@ -3012,7 +3335,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
                       <span
-                        class="makeStyles-tooltipped-103"
+                        class="makeStyles-tooltipped-135"
                         title="Contact @experimentation-review on #a8c-experiments"
                       >
                         Manual analysis required
@@ -3193,7 +3516,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-102 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-130 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -3275,18 +3598,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-118"
+                  class="makeStyles-tooltip-150"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
                 scope="row"
               >
                 1.0000
@@ -3298,7 +3621,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-114 makeStyles-indicationSeverityOk-115 makeStyles-monospace-111 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-146 makeStyles-indicationSeverityOk-147 makeStyles-monospace-143 makeStyles-nowrap-145"
                 scope="row"
               >
                 <span>
@@ -3306,13 +3629,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-112"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-144"
                 scope="row"
               >
                 <p
@@ -3336,18 +3659,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-118"
+                  class="makeStyles-tooltip-150"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
                 scope="row"
               >
                 1.0000
@@ -3359,7 +3682,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-114 makeStyles-indicationSeverityOk-115 makeStyles-monospace-111 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-146 makeStyles-indicationSeverityOk-147 makeStyles-monospace-143 makeStyles-nowrap-145"
                 scope="row"
               >
                 <span>
@@ -3367,13 +3690,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-112"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-144"
                 scope="row"
               >
                 <p
@@ -3397,18 +3720,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-118"
+                  class="makeStyles-tooltip-150"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
                 scope="row"
               >
                 1.0000
@@ -3420,7 +3743,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-114 makeStyles-indicationSeverityOk-115 makeStyles-monospace-111 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-146 makeStyles-indicationSeverityOk-147 makeStyles-monospace-143 makeStyles-nowrap-145"
                 scope="row"
               >
                 <span>
@@ -3428,13 +3751,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-112"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-144"
                 scope="row"
               >
                 <p
@@ -3458,7 +3781,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
                 scope="row"
               >
                 <span>
@@ -3466,7 +3789,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
                 scope="row"
               >
                 0.1000
@@ -3480,7 +3803,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-114 makeStyles-indicationSeverityError-117 makeStyles-monospace-111 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-146 makeStyles-indicationSeverityError-149 makeStyles-monospace-143 makeStyles-nowrap-145"
                 scope="row"
               >
                 <span>
@@ -3488,13 +3811,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-112"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-144"
                 scope="row"
               >
                 <p
@@ -3520,7 +3843,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
                 scope="row"
               >
                 <span>
@@ -3528,7 +3851,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
                 scope="row"
               >
                 0.1500
@@ -3542,7 +3865,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-114 makeStyles-indicationSeverityWarning-116 makeStyles-monospace-111 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-146 makeStyles-indicationSeverityWarning-148 makeStyles-monospace-143 makeStyles-nowrap-145"
                 scope="row"
               >
                 <span>
@@ -3550,13 +3873,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
                 scope="row"
               >
                 0.1 &lt; x ≤ 0.4
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-112"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-144"
                 scope="row"
               >
                 <p
@@ -3582,7 +3905,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
                 scope="row"
               >
                 <span>
@@ -3590,7 +3913,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
                 scope="row"
               >
                 0.1000
@@ -3602,7 +3925,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-114 makeStyles-indicationSeverityOk-115 makeStyles-monospace-111 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-146 makeStyles-indicationSeverityOk-147 makeStyles-monospace-143 makeStyles-nowrap-145"
                 scope="row"
               >
                 <span>
@@ -3610,13 +3933,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.8
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-112"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-144"
                 scope="row"
               >
                 <p
@@ -3640,7 +3963,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
                 scope="row"
               >
                 <span>
@@ -3648,7 +3971,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
                 scope="row"
               >
                 0.0000
@@ -3662,7 +3985,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-114 makeStyles-indicationSeverityWarning-116 makeStyles-monospace-111 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-146 makeStyles-indicationSeverityWarning-148 makeStyles-monospace-143 makeStyles-nowrap-145"
                 scope="row"
               >
                 <span>
@@ -3670,13 +3993,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 makeStyles-deemphasized-112 makeStyles-nowrap-113"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-112"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-144"
                 scope="row"
               >
                 <p
@@ -3690,19 +4013,111 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         </table>
       </div>
     </div>
+    <div
+      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-131 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="false"
+        class="MuiButtonBase-root MuiAccordionSummary-root"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="MuiAccordionSummary-content"
+        >
+          <h5
+            class="MuiTypography-root MuiTypography-h5"
+          >
+            Early Monitoring - Live Assignment Count
+          </h5>
+        </div>
+        <div
+          aria-disabled="false"
+          aria-hidden="true"
+          class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
+        >
+          <span
+            class="MuiIconButton-label"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+              />
+            </svg>
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </div>
+      </div>
+      <div
+        class="MuiCollapse-container MuiCollapse-hidden"
+        style="min-height: 0px;"
+      >
+        <div
+          class="MuiCollapse-wrapper"
+        >
+          <div
+            class="MuiCollapse-wrapperInner"
+          >
+            <div
+              role="region"
+            >
+              <div
+                class="MuiAccordionDetails-root makeStyles-accordionDetails-132"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1"
+                >
+                  For early monitoring, you can run this query in Hue to retrieve raw unfiltered assignment counts from Tracks.
+                </p>
+                <pre
+                  class="makeStyles-pre-134"
+                >
+                  <code>
+                    with tracks_counts as (
+  select
+    a8c.get_json_object(eventprops, '$.experiment_variation_id') as experiment_variation_id,
+    count(*) as raw_number_of_assignments
+  from tracks.etl_events
+  where
+    eventname = 'wpcom_experiment_variation_assigned' and
+    eventprops like '%"experiment_id":"1"%'
+  group by experiment_variation_id
+)
+
+select
+  experiment_variations.name as variation_name,
+  raw_number_of_assignments
+from tracks_counts
+inner join experiment_variations on cast(tracks_counts.experiment_variation_id as bigint) = experiment_variations.experiment_variation_id
+                  </code>
+                </pre>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;
 
 exports[`renders the condensed table with some analyses in non-debug mode for a Revenue Metric 2`] = `
 <div
-  class="MuiTableContainer-root makeStyles-root-119 analysis-detail-panel"
+  class="MuiTableContainer-root makeStyles-root-151 analysis-detail-panel"
 >
   <div
-    class="makeStyles-metricEstimatePlots-122"
+    class="makeStyles-metricEstimatePlots-154"
   />
   <h4
-    class="MuiTypography-root makeStyles-tableHeader-126 MuiTypography-h4"
+    class="MuiTypography-root makeStyles-tableHeader-158 MuiTypography-h4"
   >
     Latest Estimates
   </h4>
@@ -3716,14 +4131,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-127 makeStyles-headerCell-120"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-159 makeStyles-headerCell-152"
           role="cell"
           scope="row"
         >
           Difference
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-153"
         >
           [
           USD 
@@ -3758,19 +4173,19 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-127 makeStyles-headerCell-120"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-159 makeStyles-headerCell-152"
           role="cell"
           scope="row"
           valign="top"
         >
           <span
-            class="makeStyles-monospace-121"
+            class="makeStyles-monospace-153"
           >
             test
           </span>
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-153"
         >
           [
           USD 
@@ -3805,19 +4220,19 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-127 makeStyles-headerCell-120"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-159 makeStyles-headerCell-152"
           role="cell"
           scope="row"
           valign="top"
         >
           <span
-            class="makeStyles-monospace-121"
+            class="makeStyles-monospace-153"
           >
             control
           </span>
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-153"
         >
           [
           USD 
@@ -3852,7 +4267,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-120"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-152"
           role="cell"
           scope="row"
         >
@@ -3866,7 +4281,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           Warnings
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-153"
         >
           <div>
             Experiment period is too short. Wait a few days to be safer.
@@ -3879,7 +4294,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </tbody>
   </table>
   <h4
-    class="MuiTypography-root makeStyles-tableHeader-126 MuiTypography-h4"
+    class="MuiTypography-root makeStyles-tableHeader-158 MuiTypography-h4"
   >
     Metric Assignment Details
   </h4>
@@ -3893,14 +4308,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-120"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-152"
           role="cell"
           scope="row"
         >
           Metric Description
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-153"
         >
           This is metric 3
         </td>
@@ -3909,14 +4324,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-120"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-152"
           role="cell"
           scope="row"
         >
           Minimum Practical Difference
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-153"
         >
           USD 
           12
@@ -3927,14 +4342,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-120"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-152"
           role="cell"
           scope="row"
         >
           Change Expected
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-153"
         >
           Yes
         </td>
@@ -3942,7 +4357,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </tbody>
   </table>
   <h4
-    class="MuiTypography-root makeStyles-tableHeader-126 MuiTypography-h4"
+    class="MuiTypography-root makeStyles-tableHeader-158 MuiTypography-h4"
   >
     Analysis Fine Print
   </h4>
@@ -3956,7 +4371,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-120"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-152"
           role="cell"
           scope="row"
         >
@@ -3966,7 +4381,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           class="MuiTableCell-root MuiTableCell-body"
         >
           <span
-            class="makeStyles-root-128"
+            class="makeStyles-root-160"
             title="10/06/2020, 20:00:00"
           >
             2020-06-11
@@ -3977,14 +4392,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-120"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-152"
           role="cell"
           scope="row"
         >
           Analysis strategy
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-153"
         >
           Exposed without crossovers and spammers
         </td>
@@ -3993,14 +4408,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-120"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-152"
           role="cell"
           scope="row"
         >
           Analyzed participants
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-121"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-153"
         >
           1200
            (
@@ -4018,7 +4433,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-101",
+        "className": "makeStyles-participantsPlot-129",
         "data": Array [
           Object {
             "line": Object {
@@ -4077,7 +4492,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-123",
+        "className": "makeStyles-metricEstimatePlot-155",
         "data": Array [
           Object {
             "line": Object {
@@ -4173,7 +4588,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-123",
+        "className": "makeStyles-metricEstimatePlot-155",
         "data": Array [
           Object {
             "line": Object {

--- a/src/components/experiments/wizard/__snapshots__/Audience.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/Audience.test.tsx.snap
@@ -42,8 +42,10 @@ exports[`renders as expected 1`] = `
             Select a Platform
           </div>
           <input
+            aria-hidden="true"
+            class="MuiSelect-nativeInput"
             name="experiment.platform"
-            type="hidden"
+            tabindex="-1"
             value=""
           />
           <svg
@@ -739,8 +741,10 @@ exports[`renders as expected 2`] = `
             Select a Platform
           </div>
           <input
+            aria-hidden="true"
+            class="MuiSelect-nativeInput"
             name="experiment.platform"
-            type="hidden"
+            tabindex="-1"
             value=""
           />
           <svg

--- a/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
@@ -2249,7 +2249,9 @@ exports[`sections should be browsable by the section buttons 4`] = `
                       </span>
                     </div>
                     <input
-                      type="hidden"
+                      aria-hidden="true"
+                      class="MuiSelect-nativeInput"
+                      tabindex="-1"
                       value=""
                     />
                     <svg

--- a/src/components/experiments/wizard/__snapshots__/Metrics.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/Metrics.test.tsx.snap
@@ -106,7 +106,9 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
             </span>
           </div>
           <input
-            type="hidden"
+            aria-hidden="true"
+            class="MuiSelect-nativeInput"
+            tabindex="-1"
             value=""
           />
           <svg
@@ -391,7 +393,9 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
             </span>
           </div>
           <input
-            type="hidden"
+            aria-hidden="true"
+            class="MuiSelect-nativeInput"
+            tabindex="-1"
             value=""
           />
           <svg
@@ -662,8 +666,10 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                   -
                 </div>
                 <input
+                  aria-hidden="true"
+                  class="MuiSelect-nativeInput"
                   name="experiment.metricAssignments[0].attributionWindowSeconds"
-                  type="hidden"
+                  tabindex="-1"
                   value=""
                 />
                 <svg
@@ -843,7 +849,9 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
             </span>
           </div>
           <input
-            type="hidden"
+            aria-hidden="true"
+            class="MuiSelect-nativeInput"
+            tabindex="-1"
             value=""
           />
           <svg
@@ -1116,8 +1124,10 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                   -
                 </div>
                 <input
+                  aria-hidden="true"
+                  class="MuiSelect-nativeInput"
                   name="experiment.metricAssignments[0].attributionWindowSeconds"
-                  type="hidden"
+                  tabindex="-1"
                   value=""
                 />
                 <svg
@@ -1297,7 +1307,9 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
             </span>
           </div>
           <input
-            type="hidden"
+            aria-hidden="true"
+            class="MuiSelect-nativeInput"
+            tabindex="-1"
             value=""
           />
           <svg
@@ -1568,8 +1580,10 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                   -
                 </div>
                 <input
+                  aria-hidden="true"
+                  class="MuiSelect-nativeInput"
                   name="experiment.metricAssignments[0].attributionWindowSeconds"
-                  type="hidden"
+                  tabindex="-1"
                   value=""
                 />
                 <svg
@@ -1749,7 +1763,9 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
             </span>
           </div>
           <input
-            type="hidden"
+            aria-hidden="true"
+            class="MuiSelect-nativeInput"
+            tabindex="-1"
             value=""
           />
           <svg
@@ -2034,7 +2050,9 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
             </span>
           </div>
           <input
-            type="hidden"
+            aria-hidden="true"
+            class="MuiSelect-nativeInput"
+            tabindex="-1"
             value=""
           />
           <svg
@@ -2305,8 +2323,10 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                   -
                 </div>
                 <input
+                  aria-hidden="true"
+                  class="MuiSelect-nativeInput"
                   name="experiment.metricAssignments[0].attributionWindowSeconds"
-                  type="hidden"
+                  tabindex="-1"
                   value=""
                 />
                 <svg
@@ -2488,7 +2508,9 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
             </span>
           </div>
           <input
-            type="hidden"
+            aria-hidden="true"
+            class="MuiSelect-nativeInput"
+            tabindex="-1"
             value=""
           />
           <svg
@@ -2773,7 +2795,9 @@ exports[`renders as expected 1`] = `
             </span>
           </div>
           <input
-            type="hidden"
+            aria-hidden="true"
+            class="MuiSelect-nativeInput"
+            tabindex="-1"
             value=""
           />
           <svg


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR:**
- Adds early monitoring query
- Improves no results information

<img width="1273" alt="Screen Shot 2021-05-04 at 4 28 57 pm" src="https://user-images.githubusercontent.com/971886/116978102-db3b6580-acf5-11eb-8222-3fb5ebd96269.png">
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Resolves 534-gh-Automattic/experimentation-platform

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
