### PR TITLE
Change the early monitoring query to count uniques

### DIFF
--- a/src/components/experiments/single-view/results/ActualExperimentResults.tsx
+++ b/src/components/experiments/single-view/results/ActualExperimentResults.tsx
@@ -463,8 +463,8 @@ export default function ActualExperimentResults({
               {/* (Using a javasript string automatically replaces special characters with html entities.) */}
               {`with tracks_counts as (
   select
-    a8c.get_json_object(eventprops, '$.experiment_variation_id') as experiment_variation_id,
-    count(*) as raw_number_of_assignments
+    cast(a8c.get_json_object(eventprops, '$.experiment_variation_id') as bigint) as experiment_variation_id,
+    count(distinct userid) as unique_users
   from tracks.etl_events
   where
     eventname = 'wpcom_experiment_variation_assigned' and
@@ -473,10 +473,10 @@ export default function ActualExperimentResults({
 )
 
 select
-  wpcom.experiment_variations.name as variation_name,
-  raw_number_of_assignments
+  experiment_variations.name as variation_name,
+  unique_users
 from tracks_counts
-inner join wpcom.experiment_variations on cast(tracks_counts.experiment_variation_id as bigint) = wpcom.experiment_variations.experiment_variation_id`}
+inner join wpcom.experiment_variations using (experiment_variation_id)`}
             </code>
           </pre>
         </AccordionDetails>

--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -117,8 +117,8 @@ exports[`renders an appropriate message with no analyses 1`] = `
                     <code>
                       with tracks_counts as (
   select
-    a8c.get_json_object(eventprops, '$.experiment_variation_id') as experiment_variation_id,
-    count(*) as raw_number_of_assignments
+    cast(a8c.get_json_object(eventprops, '$.experiment_variation_id') as bigint) as experiment_variation_id,
+    count(distinct userid) as unique_users
   from tracks.etl_events
   where
     eventname = 'wpcom_experiment_variation_assigned' and
@@ -127,10 +127,10 @@ exports[`renders an appropriate message with no analyses 1`] = `
 )
 
 select
-  wpcom.experiment_variations.name as variation_name,
-  raw_number_of_assignments
+  experiment_variations.name as variation_name,
+  unique_users
 from tracks_counts
-inner join wpcom.experiment_variations on cast(tracks_counts.experiment_variation_id as bigint) = wpcom.experiment_variations.experiment_variation_id
+inner join wpcom.experiment_variations using (experiment_variation_id)
                     </code>
                   </pre>
                 </div>
@@ -1091,8 +1091,8 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                   <code>
                     with tracks_counts as (
   select
-    a8c.get_json_object(eventprops, '$.experiment_variation_id') as experiment_variation_id,
-    count(*) as raw_number_of_assignments
+    cast(a8c.get_json_object(eventprops, '$.experiment_variation_id') as bigint) as experiment_variation_id,
+    count(distinct userid) as unique_users
   from tracks.etl_events
   where
     eventname = 'wpcom_experiment_variation_assigned' and
@@ -1101,10 +1101,10 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
 )
 
 select
-  wpcom.experiment_variations.name as variation_name,
-  raw_number_of_assignments
+  experiment_variations.name as variation_name,
+  unique_users
 from tracks_counts
-inner join wpcom.experiment_variations on cast(tracks_counts.experiment_variation_id as bigint) = wpcom.experiment_variations.experiment_variation_id
+inner join wpcom.experiment_variations using (experiment_variation_id)
                   </code>
                 </pre>
               </div>
@@ -2487,8 +2487,8 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                   <code>
                     with tracks_counts as (
   select
-    a8c.get_json_object(eventprops, '$.experiment_variation_id') as experiment_variation_id,
-    count(*) as raw_number_of_assignments
+    cast(a8c.get_json_object(eventprops, '$.experiment_variation_id') as bigint) as experiment_variation_id,
+    count(distinct userid) as unique_users
   from tracks.etl_events
   where
     eventname = 'wpcom_experiment_variation_assigned' and
@@ -2497,10 +2497,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
 )
 
 select
-  wpcom.experiment_variations.name as variation_name,
-  raw_number_of_assignments
+  experiment_variations.name as variation_name,
+  unique_users
 from tracks_counts
-inner join wpcom.experiment_variations on cast(tracks_counts.experiment_variation_id as bigint) = wpcom.experiment_variations.experiment_variation_id
+inner join wpcom.experiment_variations using (experiment_variation_id)
                   </code>
                 </pre>
               </div>
@@ -4297,8 +4297,8 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                   <code>
                     with tracks_counts as (
   select
-    a8c.get_json_object(eventprops, '$.experiment_variation_id') as experiment_variation_id,
-    count(*) as raw_number_of_assignments
+    cast(a8c.get_json_object(eventprops, '$.experiment_variation_id') as bigint) as experiment_variation_id,
+    count(distinct userid) as unique_users
   from tracks.etl_events
   where
     eventname = 'wpcom_experiment_variation_assigned' and
@@ -4307,10 +4307,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
 )
 
 select
-  wpcom.experiment_variations.name as variation_name,
-  raw_number_of_assignments
+  experiment_variations.name as variation_name,
+  unique_users
 from tracks_counts
-inner join wpcom.experiment_variations on cast(tracks_counts.experiment_variation_id as bigint) = wpcom.experiment_variations.experiment_variation_id
+inner join wpcom.experiment_variations using (experiment_variation_id)
                   </code>
                 </pre>
               </div>


### PR DESCRIPTION
Following the confusion overnight, change the early monitoring query to count unique users so that we don't get false alarms on duplicate assignment events. Also tweak the query a bit to make it less wide. :slightly_smiling_face: 

## How has this been tested?

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
- Additional manual testing instructions: Ran the query on a couple of different experiments to verify that the results make sense
