### PR TITLE
Streamline metric assignment results

### DIFF
--- a/src/components/experiments/single-view/results/ActualExperimentResults.tsx
+++ b/src/components/experiments/single-view/results/ActualExperimentResults.tsx
@@ -12,6 +12,7 @@ import {
   Paper,
   Select,
   Theme,
+  Tooltip,
   Typography,
   useTheme,
 } from '@material-ui/core'
@@ -244,7 +245,9 @@ export default function ActualExperimentResults({
       title: 'Metric',
       render: ({ metric, metricAssignment }: { metric: MetricBare; metricAssignment: MetricAssignment }) => (
         <>
-          {metric.name}{' '}
+          <Tooltip title={metric.description}>
+            <span>{metric.name}</span>
+          </Tooltip>{' '}
           {metricAssignment.isPrimary && (
             <Chip label='Primary' variant='outlined' disabled className={classes.primaryChip} />
           )}

--- a/src/components/experiments/single-view/results/MetricAssignmentResults.tsx
+++ b/src/components/experiments/single-view/results/MetricAssignmentResults.tsx
@@ -221,12 +221,14 @@ export default function MetricAssignmentResults({
   return (
     <TableContainer className={clsx(classes.root, 'analysis-detail-panel')}>
       <Table>
-        <TableRow>
-          <TableCell component='th' scope='row' variant='head' className={classes.headerCell}>
-            Metric Description
-          </TableCell>
-          <TableCell className={classes.metricDescription}>{metric.description}</TableCell>
-        </TableRow>
+        <TableBody>
+          <TableRow>
+            <TableCell component='th' scope='row' variant='head' className={classes.headerCell}>
+              Metric Description
+            </TableCell>
+            <TableCell className={classes.metricDescription}>{metric.description}</TableCell>
+          </TableRow>
+        </TableBody>
       </Table>
       <div className={classes.dataTable}>
         <div className={classes.latestEstimates}>

--- a/src/components/experiments/single-view/results/MetricAssignmentResults.tsx
+++ b/src/components/experiments/single-view/results/MetricAssignmentResults.tsx
@@ -7,6 +7,7 @@ import {
   TableContainer,
   TableRow,
   Theme,
+  Tooltip,
   Typography,
 } from '@material-ui/core'
 import clsx from 'clsx'
@@ -17,7 +18,7 @@ import Plot from 'react-plotly.js'
 
 import DatetimeText from 'src/components/general/DatetimeText'
 import MetricValue from 'src/components/general/MetricValue'
-import { AnalysisStrategyToHuman, RecommendationWarningToHuman } from 'src/lib/analyses'
+import { AnalysisStrategyToHuman } from 'src/lib/analyses'
 import {
   Analysis,
   AnalysisStrategy,
@@ -67,6 +68,11 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     rowHeader: {
       verticalAlign: 'top',
+    },
+    tooltipped: {
+      borderBottomWidth: 1,
+      borderBottomStyle: 'dashed',
+      borderBottomColor: theme.palette.grey[500],
     },
   }),
 )
@@ -243,36 +249,43 @@ export default function MetricAssignmentResults({
                   Difference
                 </TableCell>
                 <TableCell className={classes.monospace}>
-                  [
-                  <MetricValue
-                    value={latestEstimates.diff.bottom}
-                    metricParameterType={metric.parameterType}
-                    isDifference={true}
-                  />
-                  ,&nbsp;
-                  <MetricValue
-                    value={latestEstimates.diff.top}
-                    metricParameterType={metric.parameterType}
-                    isDifference={true}
-                  />
-                  ]
-                  <br />
-                  <br />
-                  <strong>Interpretation:</strong>
-                  <br />
-                  There is a 95% probability that the difference between variations is between{' '}
-                  <MetricValue
-                    value={latestEstimates.diff.bottom}
-                    metricParameterType={metric.parameterType}
-                    isDifference={true}
-                  />{' '}
-                  and{' '}
-                  <MetricValue
-                    value={latestEstimates.diff.top}
-                    metricParameterType={metric.parameterType}
-                    isDifference={true}
-                  />
-                  .
+                  <Tooltip
+                    title={
+                      <>
+                        <strong>Interpretation:</strong>
+                        <br />
+                        There is a 95% probability that the difference between variations is between{' '}
+                        <MetricValue
+                          value={latestEstimates.diff.bottom}
+                          metricParameterType={metric.parameterType}
+                          isDifference={true}
+                        />{' '}
+                        and{' '}
+                        <MetricValue
+                          value={latestEstimates.diff.top}
+                          metricParameterType={metric.parameterType}
+                          isDifference={true}
+                        />
+                        .
+                      </>
+                    }
+                  >
+                    <span className={classes.tooltipped}>
+                      [
+                      <MetricValue
+                        value={latestEstimates.diff.bottom}
+                        metricParameterType={metric.parameterType}
+                        isDifference={true}
+                      />
+                      ,&nbsp;
+                      <MetricValue
+                        value={latestEstimates.diff.top}
+                        metricParameterType={metric.parameterType}
+                        isDifference={true}
+                      />
+                      ] 95% CI
+                    </span>
+                  </Tooltip>
                 </TableCell>
               </TableRow>
             </>
@@ -290,51 +303,43 @@ export default function MetricAssignmentResults({
                   <span className={classes.monospace}>{variation.name}</span>
                 </TableCell>
                 <TableCell className={classes.monospace}>
-                  [
-                  <MetricValue
-                    value={latestEstimates[`variation_${variation.variationId}`].bottom}
-                    metricParameterType={metric.parameterType}
-                  />
-                  ,&nbsp;
-                  <MetricValue
-                    value={latestEstimates[`variation_${variation.variationId}`].top}
-                    metricParameterType={metric.parameterType}
-                  />
-                  ]
-                  <br />
-                  <br />
-                  <strong>Interpretation:</strong>
-                  <br />
-                  There is a 95% probability that the metric value for this variation is between{' '}
-                  <MetricValue
-                    value={latestEstimates[`variation_${variation.variationId}`].bottom}
-                    metricParameterType={metric.parameterType}
-                  />{' '}
-                  and{' '}
-                  <MetricValue
-                    value={latestEstimates[`variation_${variation.variationId}`].top}
-                    metricParameterType={metric.parameterType}
-                  />
-                  .
+                  <Tooltip
+                    title={
+                      <>
+                        <strong>Interpretation:</strong>
+                        <br />
+                        There is a 95% probability that the difference between variations is between{' '}
+                        <MetricValue
+                          value={latestEstimates[`variation_${variation.variationId}`].bottom}
+                          metricParameterType={metric.parameterType}
+                        />{' '}
+                        and{' '}
+                        <MetricValue
+                          value={latestEstimates[`variation_${variation.variationId}`].top}
+                          metricParameterType={metric.parameterType}
+                        />
+                        .
+                      </>
+                    }
+                  >
+                    <span className={classes.tooltipped}>
+                      [
+                      <MetricValue
+                        value={latestEstimates[`variation_${variation.variationId}`].bottom}
+                        metricParameterType={metric.parameterType}
+                      />
+                      ,&nbsp;
+                      <MetricValue
+                        value={latestEstimates[`variation_${variation.variationId}`].top}
+                        metricParameterType={metric.parameterType}
+                      />
+                      ] 95% CI
+                    </span>
+                  </Tooltip>
                 </TableCell>
               </TableRow>
             </React.Fragment>
           ))}
-          {latestAnalysis.recommendation && latestAnalysis.recommendation.warnings.length > 0 && (
-            <TableRow>
-              <TableCell component='th' scope='row' variant='head' className={classes.headerCell}>
-                <span role='img' aria-label=''>
-                  ⚠️
-                </span>{' '}
-                Warnings
-              </TableCell>
-              <TableCell className={classes.monospace}>
-                {latestAnalysis.recommendation.warnings.map((warning) => (
-                  <div key={warning}>{RecommendationWarningToHuman[warning]}</div>
-                ))}
-              </TableCell>
-            </TableRow>
-          )}
         </TableBody>
       </Table>
       <Typography variant='h4' className={classes.tableHeader}>

--- a/src/components/experiments/single-view/results/MetricAssignmentResults.tsx
+++ b/src/components/experiments/single-view/results/MetricAssignmentResults.tsx
@@ -74,6 +74,22 @@ const useStyles = makeStyles((theme: Theme) =>
       borderBottomStyle: 'dashed',
       borderBottomColor: theme.palette.grey[500],
     },
+    dataTable: {
+      display: 'grid',
+      gridTemplateColumns: '1fr 1fr',
+      gridColumnGap: theme.spacing(2),
+    },
+    latestEstimates: {},
+    metricAssignmentDetails: {},
+    metricDescription: {
+      opacity: 0.7,
+    },
+    analysisFinePrint: {
+      fontSize: '.8rem',
+      marginTop: '1rem',
+      fontStyle: 'italic',
+      opacity: 0.7,
+    },
   }),
 )
 
@@ -204,6 +220,149 @@ export default function MetricAssignmentResults({
 
   return (
     <TableContainer className={clsx(classes.root, 'analysis-detail-panel')}>
+      <Table>
+        <TableRow>
+          <TableCell component='th' scope='row' variant='head' className={classes.headerCell}>
+            Metric Description
+          </TableCell>
+          <TableCell className={classes.metricDescription}>{metric.description}</TableCell>
+        </TableRow>
+      </Table>
+      <div className={classes.dataTable}>
+        <div className={classes.latestEstimates}>
+          <Table>
+            <TableBody>
+              {latestAnalysis.recommendation && (
+                <>
+                  <TableRow>
+                    <TableCell
+                      component='th'
+                      scope='row'
+                      variant='head'
+                      className={clsx(classes.rowHeader, classes.headerCell)}
+                    >
+                      Difference
+                    </TableCell>
+                    <TableCell className={classes.monospace}>
+                      <Tooltip
+                        title={
+                          <>
+                            <strong>Interpretation:</strong>
+                            <br />
+                            There is a 95% probability that the difference between variations is between{' '}
+                            <MetricValue
+                              value={latestEstimates.diff.bottom}
+                              metricParameterType={metric.parameterType}
+                              isDifference={true}
+                            />{' '}
+                            and{' '}
+                            <MetricValue
+                              value={latestEstimates.diff.top}
+                              metricParameterType={metric.parameterType}
+                              isDifference={true}
+                            />
+                            .
+                          </>
+                        }
+                      >
+                        <span className={classes.tooltipped}>
+                          [
+                          <MetricValue
+                            value={latestEstimates.diff.bottom}
+                            metricParameterType={metric.parameterType}
+                            isDifference={true}
+                          />
+                          ,&nbsp;
+                          <MetricValue
+                            value={latestEstimates.diff.top}
+                            metricParameterType={metric.parameterType}
+                            isDifference={true}
+                          />
+                          ] 95% CI
+                        </span>
+                      </Tooltip>
+                    </TableCell>
+                  </TableRow>
+                </>
+              )}
+              {experiment.variations.map((variation) => (
+                <React.Fragment key={variation.variationId}>
+                  <TableRow>
+                    <TableCell
+                      component='th'
+                      scope='row'
+                      variant='head'
+                      valign='top'
+                      className={clsx(classes.rowHeader, classes.headerCell)}
+                    >
+                      <span className={classes.monospace}>{variation.name}</span>
+                    </TableCell>
+                    <TableCell className={classes.monospace}>
+                      <Tooltip
+                        title={
+                          <>
+                            <strong>Interpretation:</strong>
+                            <br />
+                            There is a 95% probability that the difference between variations is between{' '}
+                            <MetricValue
+                              value={latestEstimates[`variation_${variation.variationId}`].bottom}
+                              metricParameterType={metric.parameterType}
+                            />{' '}
+                            and{' '}
+                            <MetricValue
+                              value={latestEstimates[`variation_${variation.variationId}`].top}
+                              metricParameterType={metric.parameterType}
+                            />
+                            .
+                          </>
+                        }
+                      >
+                        <span className={classes.tooltipped}>
+                          [
+                          <MetricValue
+                            value={latestEstimates[`variation_${variation.variationId}`].bottom}
+                            metricParameterType={metric.parameterType}
+                          />
+                          ,&nbsp;
+                          <MetricValue
+                            value={latestEstimates[`variation_${variation.variationId}`].top}
+                            metricParameterType={metric.parameterType}
+                          />
+                          ] 95% CI
+                        </span>
+                      </Tooltip>
+                    </TableCell>
+                  </TableRow>
+                </React.Fragment>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+        <div className={classes.metricAssignmentDetails}>
+          <Table>
+            <TableBody>
+              <TableRow>
+                <TableCell component='th' scope='row' variant='head' className={classes.headerCell}>
+                  Minimum Practical Difference
+                </TableCell>
+                <TableCell className={classes.monospace}>
+                  <MetricValue
+                    value={metricAssignment.minDifference}
+                    metricParameterType={metric.parameterType}
+                    isDifference={true}
+                  />
+                </TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell component='th' scope='row' variant='head' className={classes.headerCell}>
+                  Change Expected
+                </TableCell>
+                <TableCell className={classes.monospace}>{formatBoolean(metricAssignment.changeExpected)}</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </div>
+      </div>
       {dates.length > 1 ? (
         <div className={classes.metricEstimatePlots}>
           <Plot
@@ -232,186 +391,18 @@ export default function MetricAssignmentResults({
           Past values will be plotted once we have more than one day of results.
         </Typography>
       )}
-      <Typography variant='h4' className={classes.tableHeader}>
-        Latest Estimates
+      <Typography className={classes.analysisFinePrint}>
+        <strong>Last analyzed:</strong> <DatetimeText datetime={latestAnalysis.analysisDatetime} excludeTime={true} />.{' '}
+        <strong>Analysis Strategy:</strong> {AnalysisStrategyToHuman[latestAnalysis.analysisStrategy]}.{' '}
+        <strong>Participants:</strong> {latestAnalysis.participantStats.total} (
+        {_.join(
+          Variations.sort(experiment.variations).map(
+            ({ variationId, name }) => `${latestAnalysis.participantStats[`variation_${variationId}`]} in ${name}`,
+          ),
+          '; ',
+        )}
+        )
       </Typography>
-      <Table>
-        <TableBody>
-          {latestAnalysis.recommendation && (
-            <>
-              <TableRow>
-                <TableCell
-                  component='th'
-                  scope='row'
-                  variant='head'
-                  className={clsx(classes.rowHeader, classes.headerCell)}
-                >
-                  Difference
-                </TableCell>
-                <TableCell className={classes.monospace}>
-                  <Tooltip
-                    title={
-                      <>
-                        <strong>Interpretation:</strong>
-                        <br />
-                        There is a 95% probability that the difference between variations is between{' '}
-                        <MetricValue
-                          value={latestEstimates.diff.bottom}
-                          metricParameterType={metric.parameterType}
-                          isDifference={true}
-                        />{' '}
-                        and{' '}
-                        <MetricValue
-                          value={latestEstimates.diff.top}
-                          metricParameterType={metric.parameterType}
-                          isDifference={true}
-                        />
-                        .
-                      </>
-                    }
-                  >
-                    <span className={classes.tooltipped}>
-                      [
-                      <MetricValue
-                        value={latestEstimates.diff.bottom}
-                        metricParameterType={metric.parameterType}
-                        isDifference={true}
-                      />
-                      ,&nbsp;
-                      <MetricValue
-                        value={latestEstimates.diff.top}
-                        metricParameterType={metric.parameterType}
-                        isDifference={true}
-                      />
-                      ] 95% CI
-                    </span>
-                  </Tooltip>
-                </TableCell>
-              </TableRow>
-            </>
-          )}
-          {experiment.variations.map((variation) => (
-            <React.Fragment key={variation.variationId}>
-              <TableRow>
-                <TableCell
-                  component='th'
-                  scope='row'
-                  variant='head'
-                  valign='top'
-                  className={clsx(classes.rowHeader, classes.headerCell)}
-                >
-                  <span className={classes.monospace}>{variation.name}</span>
-                </TableCell>
-                <TableCell className={classes.monospace}>
-                  <Tooltip
-                    title={
-                      <>
-                        <strong>Interpretation:</strong>
-                        <br />
-                        There is a 95% probability that the difference between variations is between{' '}
-                        <MetricValue
-                          value={latestEstimates[`variation_${variation.variationId}`].bottom}
-                          metricParameterType={metric.parameterType}
-                        />{' '}
-                        and{' '}
-                        <MetricValue
-                          value={latestEstimates[`variation_${variation.variationId}`].top}
-                          metricParameterType={metric.parameterType}
-                        />
-                        .
-                      </>
-                    }
-                  >
-                    <span className={classes.tooltipped}>
-                      [
-                      <MetricValue
-                        value={latestEstimates[`variation_${variation.variationId}`].bottom}
-                        metricParameterType={metric.parameterType}
-                      />
-                      ,&nbsp;
-                      <MetricValue
-                        value={latestEstimates[`variation_${variation.variationId}`].top}
-                        metricParameterType={metric.parameterType}
-                      />
-                      ] 95% CI
-                    </span>
-                  </Tooltip>
-                </TableCell>
-              </TableRow>
-            </React.Fragment>
-          ))}
-        </TableBody>
-      </Table>
-      <Typography variant='h4' className={classes.tableHeader}>
-        Metric Assignment Details
-      </Typography>
-      <Table>
-        <TableBody>
-          <TableRow>
-            <TableCell component='th' scope='row' variant='head' className={classes.headerCell}>
-              Metric Description
-            </TableCell>
-            <TableCell className={classes.monospace}>{metric.description}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component='th' scope='row' variant='head' className={classes.headerCell}>
-              Minimum Practical Difference
-            </TableCell>
-            <TableCell className={classes.monospace}>
-              <MetricValue
-                value={metricAssignment.minDifference}
-                metricParameterType={metric.parameterType}
-                isDifference={true}
-              />
-            </TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component='th' scope='row' variant='head' className={classes.headerCell}>
-              Change Expected
-            </TableCell>
-            <TableCell className={classes.monospace}>{formatBoolean(metricAssignment.changeExpected)}</TableCell>
-          </TableRow>
-        </TableBody>
-      </Table>
-      <Typography variant='h4' className={classes.tableHeader}>
-        Analysis Fine Print
-      </Typography>
-      <Table>
-        <TableBody>
-          <TableRow>
-            <TableCell component='th' scope='row' variant='head' className={classes.headerCell}>
-              Last analyzed
-            </TableCell>
-            <TableCell>
-              <DatetimeText datetime={latestAnalysis.analysisDatetime} excludeTime={true} />
-            </TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component='th' scope='row' variant='head' className={classes.headerCell}>
-              Analysis strategy
-            </TableCell>
-            <TableCell className={classes.monospace}>
-              {AnalysisStrategyToHuman[latestAnalysis.analysisStrategy]}
-            </TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component='th' scope='row' variant='head' className={classes.headerCell}>
-              Analyzed participants
-            </TableCell>
-            <TableCell className={classes.monospace}>
-              {latestAnalysis.participantStats.total} (
-              {_.join(
-                Variations.sort(experiment.variations).map(
-                  ({ variationId, name }) =>
-                    `${latestAnalysis.participantStats[`variation_${variationId}`]} in ${name}`,
-                ),
-                '; ',
-              )}
-              )
-            </TableCell>
-          </TableRow>
-        </TableBody>
-      </Table>
     </TableContainer>
   )
 }

--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -327,7 +327,12 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
-                      metric_1
+                      <span
+                        class=""
+                        title="This is metric 1"
+                      >
+                        metric_1
+                      </span>
                        
                       <div
                         aria-disabled="true"
@@ -393,7 +398,12 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
-                      metric_2
+                      <span
+                        class=""
+                        title="This is metric 2"
+                      >
+                        metric_2
+                      </span>
                        
                     </td>
                     <td
@@ -448,7 +458,12 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
-                      metric_2
+                      <span
+                        class=""
+                        title="This is metric 2"
+                      >
+                        metric_2
+                      </span>
                        
                     </td>
                     <td
@@ -503,7 +518,12 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
-                      metric_3
+                      <span
+                        class=""
+                        title="This is metric 3"
+                      >
+                        metric_3
+                      </span>
                        
                     </td>
                     <td
@@ -1121,213 +1141,6 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
 <div
   class="MuiTableContainer-root makeStyles-root-57 analysis-detail-panel"
 >
-  <p
-    class="MuiTypography-root makeStyles-noPlotMessage-63 MuiTypography-body1"
-  >
-    Past values will be plotted once we have more than one day of results.
-  </p>
-  <h4
-    class="MuiTypography-root makeStyles-tableHeader-64 MuiTypography-h4"
-  >
-    Latest Estimates
-  </h4>
-  <table
-    class="MuiTable-root"
-  >
-    <tbody
-      class="MuiTableBody-root"
-    >
-      <tr
-        class="MuiTableRow-root"
-      >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-65 makeStyles-headerCell-58"
-          role="cell"
-          scope="row"
-        >
-          Difference
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
-        >
-          [
-          
-          -1
-          <span
-            class="makeStyles-root-66"
-            title="Percentage points."
-          >
-            pp
-          </span>
-          , 
-          
-          1
-          <span
-            class="makeStyles-root-66"
-            title="Percentage points."
-          >
-            pp
-          </span>
-          ]
-          <br />
-          <br />
-          <strong>
-            Interpretation:
-          </strong>
-          <br />
-          There is a 95% probability that the difference between variations is between
-           
-          
-          -1
-          <span
-            class="makeStyles-root-66"
-            title="Percentage points."
-          >
-            pp
-          </span>
-           
-          and
-           
-          
-          1
-          <span
-            class="makeStyles-root-66"
-            title="Percentage points."
-          >
-            pp
-          </span>
-          .
-        </td>
-      </tr>
-      <tr
-        class="MuiTableRow-root"
-      >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-65 makeStyles-headerCell-58"
-          role="cell"
-          scope="row"
-          valign="top"
-        >
-          <span
-            class="makeStyles-monospace-59"
-          >
-            test
-          </span>
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
-        >
-          [
-          
-          -112.3
-          %
-          , 
-          
-          100
-          %
-          ]
-          <br />
-          <br />
-          <strong>
-            Interpretation:
-          </strong>
-          <br />
-          There is a 95% probability that the metric value for this variation is between
-           
-          
-          -112.3
-          %
-           
-          and
-           
-          
-          100
-          %
-          .
-        </td>
-      </tr>
-      <tr
-        class="MuiTableRow-root"
-      >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-65 makeStyles-headerCell-58"
-          role="cell"
-          scope="row"
-          valign="top"
-        >
-          <span
-            class="makeStyles-monospace-59"
-          >
-            control
-          </span>
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
-        >
-          [
-          
-          0
-          %
-          , 
-          
-          1000
-          %
-          ]
-          <br />
-          <br />
-          <strong>
-            Interpretation:
-          </strong>
-          <br />
-          There is a 95% probability that the metric value for this variation is between
-           
-          
-          0
-          %
-           
-          and
-           
-          
-          1000
-          %
-          .
-        </td>
-      </tr>
-      <tr
-        class="MuiTableRow-root"
-      >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-58"
-          role="cell"
-          scope="row"
-        >
-          <span
-            aria-label=""
-            role="img"
-          >
-            ⚠️
-          </span>
-           
-          Warnings
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
-        >
-          <div>
-            Experiment period is too short. Wait a few days to be safer.
-          </div>
-          <div>
-            The CI is too wide in comparison to the ROPE. Collect more data to be safer.
-          </div>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-  <h4
-    class="MuiTypography-root makeStyles-tableHeader-64 MuiTypography-h4"
-  >
-    Metric Assignment Details
-  </h4>
   <table
     class="MuiTable-root"
   >
@@ -1345,121 +1158,220 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
           Metric Description
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-metricDescription-70"
         >
           This is metric 1
         </td>
       </tr>
-      <tr
-        class="MuiTableRow-root"
-      >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-58"
-          role="cell"
-          scope="row"
-        >
-          Minimum Practical Difference
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
-        >
-          
-          10
-          <span
-            class="makeStyles-root-66"
-            title="Percentage points."
-          >
-            pp
-          </span>
-        </td>
-      </tr>
-      <tr
-        class="MuiTableRow-root"
-      >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-58"
-          role="cell"
-          scope="row"
-        >
-          Change Expected
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
-        >
-          Yes
-        </td>
-      </tr>
     </tbody>
   </table>
-  <h4
-    class="MuiTypography-root makeStyles-tableHeader-64 MuiTypography-h4"
+  <div
+    class="makeStyles-dataTable-67"
   >
-    Analysis Fine Print
-  </h4>
-  <table
-    class="MuiTable-root"
-  >
-    <tbody
-      class="MuiTableBody-root"
+    <div
+      class="makeStyles-latestEstimates-68"
     >
-      <tr
-        class="MuiTableRow-root"
+      <table
+        class="MuiTable-root"
       >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-58"
-          role="cell"
-          scope="row"
+        <tbody
+          class="MuiTableBody-root"
         >
-          Last analyzed
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body"
-        >
-          <span
-            class="makeStyles-root-67"
-            title="09/05/2020, 20:00:00"
+          <tr
+            class="MuiTableRow-root"
           >
-            2020-05-10
-          </span>
-        </td>
-      </tr>
-      <tr
-        class="MuiTableRow-root"
+            <th
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-65 makeStyles-headerCell-58"
+              role="cell"
+              scope="row"
+            >
+              Difference
+            </th>
+            <td
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
+            >
+              <span
+                class="makeStyles-tooltipped-66"
+              >
+                [
+                
+                -1
+                <span
+                  class="makeStyles-root-72"
+                  title="Percentage points."
+                >
+                  pp
+                </span>
+                , 
+                
+                1
+                <span
+                  class="makeStyles-root-72"
+                  title="Percentage points."
+                >
+                  pp
+                </span>
+                ] 95% CI
+              </span>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root"
+          >
+            <th
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-65 makeStyles-headerCell-58"
+              role="cell"
+              scope="row"
+              valign="top"
+            >
+              <span
+                class="makeStyles-monospace-59"
+              >
+                test
+              </span>
+            </th>
+            <td
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
+            >
+              <span
+                class="makeStyles-tooltipped-66"
+              >
+                [
+                
+                -112.3
+                %
+                , 
+                
+                100
+                %
+                ] 95% CI
+              </span>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root"
+          >
+            <th
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-65 makeStyles-headerCell-58"
+              role="cell"
+              scope="row"
+              valign="top"
+            >
+              <span
+                class="makeStyles-monospace-59"
+              >
+                control
+              </span>
+            </th>
+            <td
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
+            >
+              <span
+                class="makeStyles-tooltipped-66"
+              >
+                [
+                
+                0
+                %
+                , 
+                
+                1000
+                %
+                ] 95% CI
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div
+      class="makeStyles-metricAssignmentDetails-69"
+    >
+      <table
+        class="MuiTable-root"
       >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-58"
-          role="cell"
-          scope="row"
+        <tbody
+          class="MuiTableBody-root"
         >
-          Analysis strategy
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
-        >
-          Exposed without crossovers and spammers
-        </td>
-      </tr>
-      <tr
-        class="MuiTableRow-root"
-      >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-58"
-          role="cell"
-          scope="row"
-        >
-          Analyzed participants
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
-        >
-          1000
-           (
-          600 in control; 400 in test
-          )
-        </td>
-      </tr>
-    </tbody>
-  </table>
+          <tr
+            class="MuiTableRow-root"
+          >
+            <th
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-58"
+              role="cell"
+              scope="row"
+            >
+              Minimum Practical Difference
+            </th>
+            <td
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
+            >
+              
+              10
+              <span
+                class="makeStyles-root-72"
+                title="Percentage points."
+              >
+                pp
+              </span>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root"
+          >
+            <th
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-58"
+              role="cell"
+              scope="row"
+            >
+              Change Expected
+            </th>
+            <td
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-59"
+            >
+              Yes
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <p
+    class="MuiTypography-root makeStyles-noPlotMessage-63 MuiTypography-body1"
+  >
+    Past values will be plotted once we have more than one day of results.
+  </p>
+  <p
+    class="MuiTypography-root makeStyles-analysisFinePrint-71 MuiTypography-body1"
+  >
+    <strong>
+      Last analyzed:
+    </strong>
+     
+    <span
+      class="makeStyles-root-73"
+      title="09/05/2020, 20:00:00"
+    >
+      2020-05-10
+    </span>
+    .
+     
+    <strong>
+      Analysis Strategy:
+    </strong>
+     
+    Exposed without crossovers and spammers
+    .
+     
+    <strong>
+      Participants:
+    </strong>
+     
+    1000
+     (
+    600 in control; 400 in test
+    )
+  </p>
 </div>
 `;
 
@@ -1536,13 +1448,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-68"
+    class="makeStyles-root-74"
   >
     <div
-      class="makeStyles-summary-70"
+      class="makeStyles-summary-76"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-81 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-87 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -1551,16 +1463,16 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-72"
+        class="makeStyles-summaryColumn-78"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-73 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-79 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-74"
+            class="makeStyles-summaryStatsPart-80"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-76 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-82 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               700
             </h3>
@@ -1576,10 +1488,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-74"
+            class="makeStyles-summaryStatsPart-80"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-76 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-82 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Deploy 
               test
@@ -1595,12 +1507,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-77 makeStyles-indicationSeverityError-80 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-83 makeStyles-indicationSeverityError-86 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-76 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-82 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Serious issues
             </h3>
@@ -1617,7 +1529,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-83 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-89 MuiTypography-h3"
     >
       Metric Assignment Results
     </h3>
@@ -1626,7 +1538,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-93"
+        class="Component-horizontalScrollContainer-99"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -1645,26 +1557,26 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-94 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-100 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-94 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-100 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-94 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-100 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Attribution window
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-94 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-100 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -1714,11 +1626,16 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
-                      metric_1
+                      <span
+                        class=""
+                        title="This is metric 1"
+                      >
+                        metric_1
+                      </span>
                        
                       <div
                         aria-disabled="true"
-                        class="MuiChip-root makeStyles-primaryChip-69 MuiChip-outlined Mui-disabled"
+                        class="MuiChip-root makeStyles-primaryChip-75 MuiChip-outlined Mui-disabled"
                       >
                         <span
                           class="MuiChip-label"
@@ -1780,7 +1697,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
-                      metric_2
+                      <span
+                        class=""
+                        title="This is metric 2"
+                      >
+                        metric_2
+                      </span>
                        
                     </td>
                     <td
@@ -1835,7 +1757,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
-                      metric_2
+                      <span
+                        class=""
+                        title="This is metric 2"
+                      >
+                        metric_2
+                      </span>
                        
                     </td>
                     <td
@@ -1890,7 +1817,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
-                      metric_3
+                      <span
+                        class=""
+                        title="This is metric 3"
+                      >
+                        metric_3
+                      </span>
                        
                     </td>
                     <td
@@ -1915,7 +1847,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-83 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-89 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -1997,18 +1929,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 makeStyles-deemphasized-103 makeStyles-nowrap-104"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-103"
+                  class="makeStyles-tooltip-109"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 makeStyles-deemphasized-103 makeStyles-nowrap-104"
                 scope="row"
               >
                 1.0000
@@ -2020,7 +1952,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-99 makeStyles-indicationSeverityOk-100 makeStyles-monospace-96 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-105 makeStyles-indicationSeverityOk-106 makeStyles-monospace-102 makeStyles-nowrap-104"
                 scope="row"
               >
                 <span>
@@ -2028,13 +1960,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 makeStyles-deemphasized-103 makeStyles-nowrap-104"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-97"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-103"
                 scope="row"
               >
                 <p
@@ -2058,18 +1990,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 makeStyles-deemphasized-103 makeStyles-nowrap-104"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-103"
+                  class="makeStyles-tooltip-109"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 makeStyles-deemphasized-103 makeStyles-nowrap-104"
                 scope="row"
               >
                 1.0000
@@ -2081,7 +2013,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-99 makeStyles-indicationSeverityOk-100 makeStyles-monospace-96 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-105 makeStyles-indicationSeverityOk-106 makeStyles-monospace-102 makeStyles-nowrap-104"
                 scope="row"
               >
                 <span>
@@ -2089,13 +2021,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 makeStyles-deemphasized-103 makeStyles-nowrap-104"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-97"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-103"
                 scope="row"
               >
                 <p
@@ -2119,18 +2051,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 makeStyles-deemphasized-103 makeStyles-nowrap-104"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-103"
+                  class="makeStyles-tooltip-109"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 makeStyles-deemphasized-103 makeStyles-nowrap-104"
                 scope="row"
               >
                 1.0000
@@ -2142,7 +2074,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-99 makeStyles-indicationSeverityOk-100 makeStyles-monospace-96 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-105 makeStyles-indicationSeverityOk-106 makeStyles-monospace-102 makeStyles-nowrap-104"
                 scope="row"
               >
                 <span>
@@ -2150,13 +2082,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 makeStyles-deemphasized-103 makeStyles-nowrap-104"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-97"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-103"
                 scope="row"
               >
                 <p
@@ -2180,7 +2112,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 makeStyles-deemphasized-103 makeStyles-nowrap-104"
                 scope="row"
               >
                 <span>
@@ -2188,7 +2120,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 makeStyles-deemphasized-103 makeStyles-nowrap-104"
                 scope="row"
               >
                 0.1000
@@ -2202,7 +2134,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-99 makeStyles-indicationSeverityError-102 makeStyles-monospace-96 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-105 makeStyles-indicationSeverityError-108 makeStyles-monospace-102 makeStyles-nowrap-104"
                 scope="row"
               >
                 <span>
@@ -2210,13 +2142,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 makeStyles-deemphasized-103 makeStyles-nowrap-104"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-97"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-103"
                 scope="row"
               >
                 <p
@@ -2242,7 +2174,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 makeStyles-deemphasized-103 makeStyles-nowrap-104"
                 scope="row"
               >
                 <span>
@@ -2250,7 +2182,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 makeStyles-deemphasized-103 makeStyles-nowrap-104"
                 scope="row"
               >
                 0.1500
@@ -2264,7 +2196,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-99 makeStyles-indicationSeverityWarning-101 makeStyles-monospace-96 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-105 makeStyles-indicationSeverityWarning-107 makeStyles-monospace-102 makeStyles-nowrap-104"
                 scope="row"
               >
                 <span>
@@ -2272,13 +2204,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 makeStyles-deemphasized-103 makeStyles-nowrap-104"
                 scope="row"
               >
                 0.1 &lt; x ≤ 0.4
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-97"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-103"
                 scope="row"
               >
                 <p
@@ -2304,7 +2236,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 makeStyles-deemphasized-103 makeStyles-nowrap-104"
                 scope="row"
               >
                 <span>
@@ -2312,7 +2244,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 makeStyles-deemphasized-103 makeStyles-nowrap-104"
                 scope="row"
               >
                 0.1000
@@ -2324,7 +2256,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-99 makeStyles-indicationSeverityOk-100 makeStyles-monospace-96 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-105 makeStyles-indicationSeverityOk-106 makeStyles-monospace-102 makeStyles-nowrap-104"
                 scope="row"
               >
                 <span>
@@ -2332,13 +2264,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 makeStyles-deemphasized-103 makeStyles-nowrap-104"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.8
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-97"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-103"
                 scope="row"
               >
                 <p
@@ -2362,7 +2294,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 makeStyles-deemphasized-103 makeStyles-nowrap-104"
                 scope="row"
               >
                 <span>
@@ -2370,7 +2302,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 makeStyles-deemphasized-103 makeStyles-nowrap-104"
                 scope="row"
               >
                 0.0000
@@ -2384,7 +2316,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-99 makeStyles-indicationSeverityWarning-101 makeStyles-monospace-96 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-105 makeStyles-indicationSeverityWarning-107 makeStyles-monospace-102 makeStyles-nowrap-104"
                 scope="row"
               >
                 <span>
@@ -2392,13 +2324,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-96 makeStyles-deemphasized-97 makeStyles-nowrap-98"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 makeStyles-deemphasized-103 makeStyles-nowrap-104"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-97"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-103"
                 scope="row"
               >
                 <p
@@ -2413,7 +2345,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-84 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-90 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         aria-disabled="false"
@@ -2469,7 +2401,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               role="region"
             >
               <div
-                class="MuiAccordionDetails-root makeStyles-accordionDetails-85"
+                class="MuiAccordionDetails-root makeStyles-accordionDetails-91"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -2482,7 +2414,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                   This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                 </p>
                 <pre
-                  class="makeStyles-pre-87"
+                  class="makeStyles-pre-93"
                 >
                   <code>
                     with tracks_counts as (
@@ -2515,16 +2447,8 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders the condensed table with some analyses in non-debug mode for a Conversion Metric 2`] = `
 <div
-  class="MuiTableContainer-root makeStyles-root-104 analysis-detail-panel"
+  class="MuiTableContainer-root makeStyles-root-110 analysis-detail-panel"
 >
-  <div
-    class="makeStyles-metricEstimatePlots-107"
-  />
-  <h4
-    class="MuiTypography-root makeStyles-tableHeader-111 MuiTypography-h4"
-  >
-    Latest Estimates
-  </h4>
   <table
     class="MuiTable-root"
   >
@@ -2535,325 +2459,225 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-112 makeStyles-headerCell-105"
-          role="cell"
-          scope="row"
-        >
-          Difference
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106"
-        >
-          [
-          
-          -1
-          <span
-            class="makeStyles-root-113"
-            title="Percentage points."
-          >
-            pp
-          </span>
-          , 
-          
-          1
-          <span
-            class="makeStyles-root-113"
-            title="Percentage points."
-          >
-            pp
-          </span>
-          ]
-          <br />
-          <br />
-          <strong>
-            Interpretation:
-          </strong>
-          <br />
-          There is a 95% probability that the difference between variations is between
-           
-          
-          -1
-          <span
-            class="makeStyles-root-113"
-            title="Percentage points."
-          >
-            pp
-          </span>
-           
-          and
-           
-          
-          1
-          <span
-            class="makeStyles-root-113"
-            title="Percentage points."
-          >
-            pp
-          </span>
-          .
-        </td>
-      </tr>
-      <tr
-        class="MuiTableRow-root"
-      >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-112 makeStyles-headerCell-105"
-          role="cell"
-          scope="row"
-          valign="top"
-        >
-          <span
-            class="makeStyles-monospace-106"
-          >
-            test
-          </span>
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106"
-        >
-          [
-          
-          -112.3
-          %
-          , 
-          
-          100
-          %
-          ]
-          <br />
-          <br />
-          <strong>
-            Interpretation:
-          </strong>
-          <br />
-          There is a 95% probability that the metric value for this variation is between
-           
-          
-          -112.3
-          %
-           
-          and
-           
-          
-          100
-          %
-          .
-        </td>
-      </tr>
-      <tr
-        class="MuiTableRow-root"
-      >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-112 makeStyles-headerCell-105"
-          role="cell"
-          scope="row"
-          valign="top"
-        >
-          <span
-            class="makeStyles-monospace-106"
-          >
-            control
-          </span>
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106"
-        >
-          [
-          
-          0
-          %
-          , 
-          
-          1000
-          %
-          ]
-          <br />
-          <br />
-          <strong>
-            Interpretation:
-          </strong>
-          <br />
-          There is a 95% probability that the metric value for this variation is between
-           
-          
-          0
-          %
-           
-          and
-           
-          
-          1000
-          %
-          .
-        </td>
-      </tr>
-      <tr
-        class="MuiTableRow-root"
-      >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-105"
-          role="cell"
-          scope="row"
-        >
-          <span
-            aria-label=""
-            role="img"
-          >
-            ⚠️
-          </span>
-           
-          Warnings
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106"
-        >
-          <div>
-            Experiment period is too short. Wait a few days to be safer.
-          </div>
-          <div>
-            The CI is too wide in comparison to the ROPE. Collect more data to be safer.
-          </div>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-  <h4
-    class="MuiTypography-root makeStyles-tableHeader-111 MuiTypography-h4"
-  >
-    Metric Assignment Details
-  </h4>
-  <table
-    class="MuiTable-root"
-  >
-    <tbody
-      class="MuiTableBody-root"
-    >
-      <tr
-        class="MuiTableRow-root"
-      >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-105"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-111"
           role="cell"
           scope="row"
         >
           Metric Description
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-metricDescription-123"
         >
           This is metric 1
         </td>
       </tr>
-      <tr
-        class="MuiTableRow-root"
-      >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-105"
-          role="cell"
-          scope="row"
-        >
-          Minimum Practical Difference
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106"
-        >
-          
-          10
-          <span
-            class="makeStyles-root-113"
-            title="Percentage points."
-          >
-            pp
-          </span>
-        </td>
-      </tr>
-      <tr
-        class="MuiTableRow-root"
-      >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-105"
-          role="cell"
-          scope="row"
-        >
-          Change Expected
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106"
-        >
-          Yes
-        </td>
-      </tr>
     </tbody>
   </table>
-  <h4
-    class="MuiTypography-root makeStyles-tableHeader-111 MuiTypography-h4"
+  <div
+    class="makeStyles-dataTable-120"
   >
-    Analysis Fine Print
-  </h4>
-  <table
-    class="MuiTable-root"
-  >
-    <tbody
-      class="MuiTableBody-root"
+    <div
+      class="makeStyles-latestEstimates-121"
     >
-      <tr
-        class="MuiTableRow-root"
+      <table
+        class="MuiTable-root"
       >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-105"
-          role="cell"
-          scope="row"
+        <tbody
+          class="MuiTableBody-root"
         >
-          Last analyzed
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body"
-        >
-          <span
-            class="makeStyles-root-114"
-            title="09/05/2020, 20:00:00"
+          <tr
+            class="MuiTableRow-root"
           >
-            2020-05-10
-          </span>
-        </td>
-      </tr>
-      <tr
-        class="MuiTableRow-root"
+            <th
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-118 makeStyles-headerCell-111"
+              role="cell"
+              scope="row"
+            >
+              Difference
+            </th>
+            <td
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-112"
+            >
+              <span
+                class="makeStyles-tooltipped-119"
+              >
+                [
+                
+                -1
+                <span
+                  class="makeStyles-root-125"
+                  title="Percentage points."
+                >
+                  pp
+                </span>
+                , 
+                
+                1
+                <span
+                  class="makeStyles-root-125"
+                  title="Percentage points."
+                >
+                  pp
+                </span>
+                ] 95% CI
+              </span>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root"
+          >
+            <th
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-118 makeStyles-headerCell-111"
+              role="cell"
+              scope="row"
+              valign="top"
+            >
+              <span
+                class="makeStyles-monospace-112"
+              >
+                test
+              </span>
+            </th>
+            <td
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-112"
+            >
+              <span
+                class="makeStyles-tooltipped-119"
+              >
+                [
+                
+                -112.3
+                %
+                , 
+                
+                100
+                %
+                ] 95% CI
+              </span>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root"
+          >
+            <th
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-118 makeStyles-headerCell-111"
+              role="cell"
+              scope="row"
+              valign="top"
+            >
+              <span
+                class="makeStyles-monospace-112"
+              >
+                control
+              </span>
+            </th>
+            <td
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-112"
+            >
+              <span
+                class="makeStyles-tooltipped-119"
+              >
+                [
+                
+                0
+                %
+                , 
+                
+                1000
+                %
+                ] 95% CI
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div
+      class="makeStyles-metricAssignmentDetails-122"
+    >
+      <table
+        class="MuiTable-root"
       >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-105"
-          role="cell"
-          scope="row"
+        <tbody
+          class="MuiTableBody-root"
         >
-          Analysis strategy
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106"
-        >
-          Exposed without crossovers and spammers
-        </td>
-      </tr>
-      <tr
-        class="MuiTableRow-root"
-      >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-105"
-          role="cell"
-          scope="row"
-        >
-          Analyzed participants
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106"
-        >
-          700
-           (
-          420 in control; 280 in test
-          )
-        </td>
-      </tr>
-    </tbody>
-  </table>
+          <tr
+            class="MuiTableRow-root"
+          >
+            <th
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-111"
+              role="cell"
+              scope="row"
+            >
+              Minimum Practical Difference
+            </th>
+            <td
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-112"
+            >
+              
+              10
+              <span
+                class="makeStyles-root-125"
+                title="Percentage points."
+              >
+                pp
+              </span>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root"
+          >
+            <th
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-111"
+              role="cell"
+              scope="row"
+            >
+              Change Expected
+            </th>
+            <td
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-112"
+            >
+              Yes
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div
+    class="makeStyles-metricEstimatePlots-113"
+  />
+  <p
+    class="MuiTypography-root makeStyles-analysisFinePrint-124 MuiTypography-body1"
+  >
+    <strong>
+      Last analyzed:
+    </strong>
+     
+    <span
+      class="makeStyles-root-126"
+      title="09/05/2020, 20:00:00"
+    >
+      2020-05-10
+    </span>
+    .
+     
+    <strong>
+      Analysis Strategy:
+    </strong>
+     
+    Exposed without crossovers and spammers
+    .
+     
+    <strong>
+      Participants:
+    </strong>
+     
+    700
+     (
+    420 in control; 280 in test
+    )
+  </p>
 </div>
 `;
 
@@ -2862,7 +2686,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-82",
+        "className": "makeStyles-participantsPlot-88",
         "data": Array [
           Object {
             "line": Object {
@@ -2921,7 +2745,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-108",
+        "className": "makeStyles-metricEstimatePlot-114",
         "data": Array [
           Object {
             "line": Object {
@@ -3017,7 +2841,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-108",
+        "className": "makeStyles-metricEstimatePlot-114",
         "data": Array [
           Object {
             "line": Object {
@@ -3119,7 +2943,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-108",
+        "className": "makeStyles-metricEstimatePlot-114",
         "data": Array [
           Object {
             "line": Object {
@@ -3215,7 +3039,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-108",
+        "className": "makeStyles-metricEstimatePlot-114",
         "data": Array [
           Object {
             "line": Object {
@@ -3346,13 +3170,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-115"
+    class="makeStyles-root-127"
   >
     <div
-      class="makeStyles-summary-117"
+      class="makeStyles-summary-129"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-128 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-140 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -3361,16 +3185,16 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-119"
+        class="makeStyles-summaryColumn-131"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-120 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-132 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-121"
+            class="makeStyles-summaryStatsPart-133"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-123 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-135 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               700
             </h3>
@@ -3386,10 +3210,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-121"
+            class="makeStyles-summaryStatsPart-133"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-123 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-135 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Deploy 
               test
@@ -3405,12 +3229,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-124 makeStyles-indicationSeverityError-127 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-136 makeStyles-indicationSeverityError-139 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-123 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-135 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Serious issues
             </h3>
@@ -3427,7 +3251,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-130 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-142 MuiTypography-h3"
     >
       Metric Assignment Results
     </h3>
@@ -3436,7 +3260,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-140"
+        class="Component-horizontalScrollContainer-152"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -3455,26 +3279,26 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-141 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-153 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-141 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-153 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-141 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-153 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Attribution window
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-141 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-153 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -3524,11 +3348,16 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
-                      metric_1
+                      <span
+                        class=""
+                        title="This is metric 1"
+                      >
+                        metric_1
+                      </span>
                        
                       <div
                         aria-disabled="true"
-                        class="MuiChip-root makeStyles-primaryChip-116 MuiChip-outlined Mui-disabled"
+                        class="MuiChip-root makeStyles-primaryChip-128 MuiChip-outlined Mui-disabled"
                       >
                         <span
                           class="MuiChip-label"
@@ -3590,7 +3419,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
-                      metric_2
+                      <span
+                        class=""
+                        title="This is metric 2"
+                      >
+                        metric_2
+                      </span>
                        
                     </td>
                     <td
@@ -3645,7 +3479,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
-                      metric_2
+                      <span
+                        class=""
+                        title="This is metric 2"
+                      >
+                        metric_2
+                      </span>
                        
                     </td>
                     <td
@@ -3700,7 +3539,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
-                      metric_3
+                      <span
+                        class=""
+                        title="This is metric 3"
+                      >
+                        metric_3
+                      </span>
                        
                     </td>
                     <td
@@ -3725,7 +3569,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-130 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-142 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -3807,18 +3651,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-155 makeStyles-deemphasized-156 makeStyles-nowrap-157"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-150"
+                  class="makeStyles-tooltip-162"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-155 makeStyles-deemphasized-156 makeStyles-nowrap-157"
                 scope="row"
               >
                 1.0000
@@ -3830,7 +3674,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-146 makeStyles-indicationSeverityOk-147 makeStyles-monospace-143 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-158 makeStyles-indicationSeverityOk-159 makeStyles-monospace-155 makeStyles-nowrap-157"
                 scope="row"
               >
                 <span>
@@ -3838,13 +3682,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-155 makeStyles-deemphasized-156 makeStyles-nowrap-157"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-144"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-156"
                 scope="row"
               >
                 <p
@@ -3868,18 +3712,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-155 makeStyles-deemphasized-156 makeStyles-nowrap-157"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-150"
+                  class="makeStyles-tooltip-162"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-155 makeStyles-deemphasized-156 makeStyles-nowrap-157"
                 scope="row"
               >
                 1.0000
@@ -3891,7 +3735,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-146 makeStyles-indicationSeverityOk-147 makeStyles-monospace-143 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-158 makeStyles-indicationSeverityOk-159 makeStyles-monospace-155 makeStyles-nowrap-157"
                 scope="row"
               >
                 <span>
@@ -3899,13 +3743,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-155 makeStyles-deemphasized-156 makeStyles-nowrap-157"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-144"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-156"
                 scope="row"
               >
                 <p
@@ -3929,18 +3773,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-155 makeStyles-deemphasized-156 makeStyles-nowrap-157"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-150"
+                  class="makeStyles-tooltip-162"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-155 makeStyles-deemphasized-156 makeStyles-nowrap-157"
                 scope="row"
               >
                 1.0000
@@ -3952,7 +3796,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-146 makeStyles-indicationSeverityOk-147 makeStyles-monospace-143 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-158 makeStyles-indicationSeverityOk-159 makeStyles-monospace-155 makeStyles-nowrap-157"
                 scope="row"
               >
                 <span>
@@ -3960,13 +3804,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-155 makeStyles-deemphasized-156 makeStyles-nowrap-157"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-144"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-156"
                 scope="row"
               >
                 <p
@@ -3990,7 +3834,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-155 makeStyles-deemphasized-156 makeStyles-nowrap-157"
                 scope="row"
               >
                 <span>
@@ -3998,7 +3842,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-155 makeStyles-deemphasized-156 makeStyles-nowrap-157"
                 scope="row"
               >
                 0.1000
@@ -4012,7 +3856,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-146 makeStyles-indicationSeverityError-149 makeStyles-monospace-143 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-158 makeStyles-indicationSeverityError-161 makeStyles-monospace-155 makeStyles-nowrap-157"
                 scope="row"
               >
                 <span>
@@ -4020,13 +3864,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-155 makeStyles-deemphasized-156 makeStyles-nowrap-157"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-144"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-156"
                 scope="row"
               >
                 <p
@@ -4052,7 +3896,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-155 makeStyles-deemphasized-156 makeStyles-nowrap-157"
                 scope="row"
               >
                 <span>
@@ -4060,7 +3904,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-155 makeStyles-deemphasized-156 makeStyles-nowrap-157"
                 scope="row"
               >
                 0.1500
@@ -4074,7 +3918,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-146 makeStyles-indicationSeverityWarning-148 makeStyles-monospace-143 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-158 makeStyles-indicationSeverityWarning-160 makeStyles-monospace-155 makeStyles-nowrap-157"
                 scope="row"
               >
                 <span>
@@ -4082,13 +3926,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-155 makeStyles-deemphasized-156 makeStyles-nowrap-157"
                 scope="row"
               >
                 0.1 &lt; x ≤ 0.4
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-144"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-156"
                 scope="row"
               >
                 <p
@@ -4114,7 +3958,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-155 makeStyles-deemphasized-156 makeStyles-nowrap-157"
                 scope="row"
               >
                 <span>
@@ -4122,7 +3966,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-155 makeStyles-deemphasized-156 makeStyles-nowrap-157"
                 scope="row"
               >
                 0.1000
@@ -4134,7 +3978,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-146 makeStyles-indicationSeverityOk-147 makeStyles-monospace-143 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-158 makeStyles-indicationSeverityOk-159 makeStyles-monospace-155 makeStyles-nowrap-157"
                 scope="row"
               >
                 <span>
@@ -4142,13 +3986,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-155 makeStyles-deemphasized-156 makeStyles-nowrap-157"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.8
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-144"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-156"
                 scope="row"
               >
                 <p
@@ -4172,7 +4016,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-155 makeStyles-deemphasized-156 makeStyles-nowrap-157"
                 scope="row"
               >
                 <span>
@@ -4180,7 +4024,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-155 makeStyles-deemphasized-156 makeStyles-nowrap-157"
                 scope="row"
               >
                 0.0000
@@ -4194,7 +4038,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-146 makeStyles-indicationSeverityWarning-148 makeStyles-monospace-143 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-158 makeStyles-indicationSeverityWarning-160 makeStyles-monospace-155 makeStyles-nowrap-157"
                 scope="row"
               >
                 <span>
@@ -4202,13 +4046,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-143 makeStyles-deemphasized-144 makeStyles-nowrap-145"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-155 makeStyles-deemphasized-156 makeStyles-nowrap-157"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-144"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-156"
                 scope="row"
               >
                 <p
@@ -4223,7 +4067,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-131 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-143 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         aria-disabled="false"
@@ -4279,7 +4123,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               role="region"
             >
               <div
-                class="MuiAccordionDetails-root makeStyles-accordionDetails-132"
+                class="MuiAccordionDetails-root makeStyles-accordionDetails-144"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4292,7 +4136,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                   This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                 </p>
                 <pre
-                  class="makeStyles-pre-134"
+                  class="makeStyles-pre-146"
                 >
                   <code>
                     with tracks_counts as (
@@ -4325,16 +4169,8 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders the condensed table with some analyses in non-debug mode for a Revenue Metric 2`] = `
 <div
-  class="MuiTableContainer-root makeStyles-root-151 analysis-detail-panel"
+  class="MuiTableContainer-root makeStyles-root-163 analysis-detail-panel"
 >
-  <div
-    class="makeStyles-metricEstimatePlots-154"
-  />
-  <h4
-    class="MuiTypography-root makeStyles-tableHeader-158 MuiTypography-h4"
-  >
-    Latest Estimates
-  </h4>
   <table
     class="MuiTable-root"
   >
@@ -4345,300 +4181,210 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-159 makeStyles-headerCell-152"
-          role="cell"
-          scope="row"
-        >
-          Difference
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-153"
-        >
-          [
-          USD 
-          -0.01
-          
-          , 
-          USD 
-          0.01
-          
-          ]
-          <br />
-          <br />
-          <strong>
-            Interpretation:
-          </strong>
-          <br />
-          There is a 95% probability that the difference between variations is between
-           
-          USD 
-          -0.01
-          
-           
-          and
-           
-          USD 
-          0.01
-          
-          .
-        </td>
-      </tr>
-      <tr
-        class="MuiTableRow-root"
-      >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-159 makeStyles-headerCell-152"
-          role="cell"
-          scope="row"
-          valign="top"
-        >
-          <span
-            class="makeStyles-monospace-153"
-          >
-            test
-          </span>
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-153"
-        >
-          [
-          USD 
-          -1.12
-          
-          , 
-          USD 
-          1
-          
-          ]
-          <br />
-          <br />
-          <strong>
-            Interpretation:
-          </strong>
-          <br />
-          There is a 95% probability that the metric value for this variation is between
-           
-          USD 
-          -1.12
-          
-           
-          and
-           
-          USD 
-          1
-          
-          .
-        </td>
-      </tr>
-      <tr
-        class="MuiTableRow-root"
-      >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-159 makeStyles-headerCell-152"
-          role="cell"
-          scope="row"
-          valign="top"
-        >
-          <span
-            class="makeStyles-monospace-153"
-          >
-            control
-          </span>
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-153"
-        >
-          [
-          USD 
-          0
-          
-          , 
-          USD 
-          10
-          
-          ]
-          <br />
-          <br />
-          <strong>
-            Interpretation:
-          </strong>
-          <br />
-          There is a 95% probability that the metric value for this variation is between
-           
-          USD 
-          0
-          
-           
-          and
-           
-          USD 
-          10
-          
-          .
-        </td>
-      </tr>
-      <tr
-        class="MuiTableRow-root"
-      >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-152"
-          role="cell"
-          scope="row"
-        >
-          <span
-            aria-label=""
-            role="img"
-          >
-            ⚠️
-          </span>
-           
-          Warnings
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-153"
-        >
-          <div>
-            Experiment period is too short. Wait a few days to be safer.
-          </div>
-          <div>
-            The CI is too wide in comparison to the ROPE. Collect more data to be safer.
-          </div>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-  <h4
-    class="MuiTypography-root makeStyles-tableHeader-158 MuiTypography-h4"
-  >
-    Metric Assignment Details
-  </h4>
-  <table
-    class="MuiTable-root"
-  >
-    <tbody
-      class="MuiTableBody-root"
-    >
-      <tr
-        class="MuiTableRow-root"
-      >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-152"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-164"
           role="cell"
           scope="row"
         >
           Metric Description
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-153"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-metricDescription-176"
         >
           This is metric 1
         </td>
       </tr>
-      <tr
-        class="MuiTableRow-root"
-      >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-152"
-          role="cell"
-          scope="row"
-        >
-          Minimum Practical Difference
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-153"
-        >
-          USD 
-          0.1
-          
-        </td>
-      </tr>
-      <tr
-        class="MuiTableRow-root"
-      >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-152"
-          role="cell"
-          scope="row"
-        >
-          Change Expected
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-153"
-        >
-          Yes
-        </td>
-      </tr>
     </tbody>
   </table>
-  <h4
-    class="MuiTypography-root makeStyles-tableHeader-158 MuiTypography-h4"
+  <div
+    class="makeStyles-dataTable-173"
   >
-    Analysis Fine Print
-  </h4>
-  <table
-    class="MuiTable-root"
-  >
-    <tbody
-      class="MuiTableBody-root"
+    <div
+      class="makeStyles-latestEstimates-174"
     >
-      <tr
-        class="MuiTableRow-root"
+      <table
+        class="MuiTable-root"
       >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-152"
-          role="cell"
-          scope="row"
+        <tbody
+          class="MuiTableBody-root"
         >
-          Last analyzed
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body"
-        >
-          <span
-            class="makeStyles-root-160"
-            title="09/05/2020, 20:00:00"
+          <tr
+            class="MuiTableRow-root"
           >
-            2020-05-10
-          </span>
-        </td>
-      </tr>
-      <tr
-        class="MuiTableRow-root"
+            <th
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-171 makeStyles-headerCell-164"
+              role="cell"
+              scope="row"
+            >
+              Difference
+            </th>
+            <td
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-165"
+            >
+              <span
+                class="makeStyles-tooltipped-172"
+              >
+                [
+                USD 
+                -0.01
+                
+                , 
+                USD 
+                0.01
+                
+                ] 95% CI
+              </span>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root"
+          >
+            <th
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-171 makeStyles-headerCell-164"
+              role="cell"
+              scope="row"
+              valign="top"
+            >
+              <span
+                class="makeStyles-monospace-165"
+              >
+                test
+              </span>
+            </th>
+            <td
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-165"
+            >
+              <span
+                class="makeStyles-tooltipped-172"
+              >
+                [
+                USD 
+                -1.12
+                
+                , 
+                USD 
+                1
+                
+                ] 95% CI
+              </span>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root"
+          >
+            <th
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-171 makeStyles-headerCell-164"
+              role="cell"
+              scope="row"
+              valign="top"
+            >
+              <span
+                class="makeStyles-monospace-165"
+              >
+                control
+              </span>
+            </th>
+            <td
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-165"
+            >
+              <span
+                class="makeStyles-tooltipped-172"
+              >
+                [
+                USD 
+                0
+                
+                , 
+                USD 
+                10
+                
+                ] 95% CI
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div
+      class="makeStyles-metricAssignmentDetails-175"
+    >
+      <table
+        class="MuiTable-root"
       >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-152"
-          role="cell"
-          scope="row"
+        <tbody
+          class="MuiTableBody-root"
         >
-          Analysis strategy
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-153"
-        >
-          Exposed without crossovers and spammers
-        </td>
-      </tr>
-      <tr
-        class="MuiTableRow-root"
-      >
-        <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-152"
-          role="cell"
-          scope="row"
-        >
-          Analyzed participants
-        </th>
-        <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-153"
-        >
-          700
-           (
-          420 in control; 280 in test
-          )
-        </td>
-      </tr>
-    </tbody>
-  </table>
+          <tr
+            class="MuiTableRow-root"
+          >
+            <th
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-164"
+              role="cell"
+              scope="row"
+            >
+              Minimum Practical Difference
+            </th>
+            <td
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-165"
+            >
+              USD 
+              0.1
+              
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root"
+          >
+            <th
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-164"
+              role="cell"
+              scope="row"
+            >
+              Change Expected
+            </th>
+            <td
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-165"
+            >
+              Yes
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div
+    class="makeStyles-metricEstimatePlots-166"
+  />
+  <p
+    class="MuiTypography-root makeStyles-analysisFinePrint-177 MuiTypography-body1"
+  >
+    <strong>
+      Last analyzed:
+    </strong>
+     
+    <span
+      class="makeStyles-root-178"
+      title="09/05/2020, 20:00:00"
+    >
+      2020-05-10
+    </span>
+    .
+     
+    <strong>
+      Analysis Strategy:
+    </strong>
+     
+    Exposed without crossovers and spammers
+    .
+     
+    <strong>
+      Participants:
+    </strong>
+     
+    700
+     (
+    420 in control; 280 in test
+    )
+  </p>
 </div>
 `;
 
@@ -4647,7 +4393,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-129",
+        "className": "makeStyles-participantsPlot-141",
         "data": Array [
           Object {
             "line": Object {
@@ -4706,7 +4452,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-155",
+        "className": "makeStyles-metricEstimatePlot-167",
         "data": Array [
           Object {
             "line": Object {
@@ -4802,7 +4548,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-155",
+        "className": "makeStyles-metricEstimatePlot-167",
         "data": Array [
           Object {
             "line": Object {
@@ -4904,7 +4650,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-155",
+        "className": "makeStyles-metricEstimatePlot-167",
         "data": Array [
           Object {
             "line": Object {
@@ -5000,7 +4746,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-155",
+        "className": "makeStyles-metricEstimatePlot-167",
         "data": Array [
           Object {
             "line": Object {

--- a/src/components/experiments/single-view/results/__snapshots__/MetricAssignmentResults.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/MetricAssignmentResults.test.tsx.snap
@@ -8,7 +8,9 @@ exports[`renders an appropriate message with no analyses 1`] = `
     <h5
       class="MuiTypography-root MuiTypography-h5 MuiTypography-gutterBottom"
     >
-       No Analysis Data Found 
+       
+      No Analysis Data Found
+       
     </h5>
     <p
       class="MuiTypography-root MuiTypography-body1"


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR condenses and streamlines metric assignment results:**
- Use tooltips for showing CI interpretations
- Remove warnings (To be replaced by a health report)
- Add metric description tooltip to the metric assignment
- Reform the data in two columns, gives extra emphasis to metric description, metric assignment details.
- Remove unnecessary headers
- Make fine-print actual fine print

Screenshot to be posted in slack.

**Future PRs:**
- Seems like we are using whitespace for formatting metric descriptions, I could add it to a pre tag, needs some tweaking though.
- Add a metricAssignment level health report
- Seems like it is not too hard to add a box plot visualisation of the CIs [using D3](https://www.d3-graph-gallery.com/graph/boxplot_basic.html), could add it with the row level lift and diff
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
