### PR TITLE
Hide top level issue display when primary analyses are missing

### DIFF
--- a/src/components/experiments/single-view/results/ActualExperimentResults.tsx
+++ b/src/components/experiments/single-view/results/ActualExperimentResults.tsx
@@ -223,13 +223,16 @@ export default function ActualExperimentResults({
     ...Analyses.getExperimentHealthIndicators(experiment),
   ]
 
-  const maxIndicationSeverity = experimentHealthIndicators
-    .map(({ indication: { severity } }) => severity)
-    .sort(
-      (severityA, severityB) =>
-        Analyses.healthIndicationSeverityOrder.indexOf(severityB) -
-        Analyses.healthIndicationSeverityOrder.indexOf(severityA),
-    )[0]
+  const maxIndicationSeverity =
+    primaryMetricAggregateRecommendation.decision === Analyses.AggregateRecommendationDecision.MissingAnalysis
+      ? Analyses.HealthIndicationSeverity.Ok
+      : experimentHealthIndicators
+          .map(({ indication: { severity } }) => severity)
+          .sort(
+            (severityA, severityB) =>
+              Analyses.healthIndicationSeverityOrder.indexOf(severityB) -
+              Analyses.healthIndicationSeverityOrder.indexOf(severityA),
+          )[0]
 
   const maxIndicationSeverityMessage = {
     [Analyses.HealthIndicationSeverity.Ok]: 'No issues detected',


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR hides top level issues when analyses are missing** 

In the future we can look into conditionally displaying the indicators as a more long term fix.

From p1620396357160000-slack-C7HH3V5AS
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
