### PR TITLE
Wizard: Improve metric input

### DIFF
--- a/src/components/experiments/wizard/BasicInfo.tsx
+++ b/src/components/experiments/wizard/BasicInfo.tsx
@@ -148,6 +148,7 @@ const BasicInfo = ({
           fullWidth
           options={userCompletionDataSource.data ?? []}
           loading={userCompletionDataSource.isLoading}
+          noOptionsText='No users found'
           renderInput={(params: AutocompleteRenderInputParams) => (
             <MuiTextField
               {...params}

--- a/src/components/experiments/wizard/ExperimentForm.test.tsx
+++ b/src/components/experiments/wizard/ExperimentForm.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/require-await,@typescript-eslint/ban-ts-comment */
 
-import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, getByRole, screen, waitFor } from '@testing-library/react'
 import { StatusCodes } from 'http-status-codes'
 import _ from 'lodash'
 import noop from 'lodash/noop'
@@ -431,14 +431,11 @@ test('form submits with valid fields', async () => {
 
   // ### Metrics
   screen.getByText(/Assign Metrics/)
-  const metricSearchField = screen.getByRole('button', { name: /Select a Metric/ })
+  const metricSearchField = screen.getByRole('combobox', { name: /Select a metric/ })
+  const metricSearchFieldMoreButton = getByRole(metricSearchField, 'button', { name: 'Open' })
   const metricAddButton = screen.getByRole('button', { name: 'Add metric' })
-  await act(async () => {
-    fireEvent.focus(metricSearchField)
-  })
-  await act(async () => {
-    fireEvent.keyDown(metricSearchField, { key: 'Enter' })
-  })
+
+  fireEvent.click(metricSearchFieldMoreButton)
   const metricOption = await screen.findByRole('option', { name: /metric_10/ })
   await act(async () => {
     fireEvent.click(metricOption)

--- a/src/components/experiments/wizard/Metrics.test.tsx
+++ b/src/components/experiments/wizard/Metrics.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, screen } from '@testing-library/react'
+import { act, fireEvent, getByRole, screen } from '@testing-library/react'
 import { Formik } from 'formik'
 import React from 'react'
 
@@ -78,15 +78,15 @@ test('allows adding, editing and removing a Metric Assignment', async () => {
   )
   expect(container).toMatchSnapshot()
 
-  const metricSearchField = screen.getByRole('button', { name: /Select a Metric/ })
+  const metricSearchField = screen.getByRole('combobox', { name: /Select a metric/ })
+  const metricSearchFieldMoreButton = getByRole(metricSearchField, 'button', { name: 'Open' })
   const metricAddButton = screen.getByRole('button', { name: 'Add metric' })
 
   fireEvent.click(metricAddButton)
 
   expect(container).toMatchSnapshot()
 
-  fireEvent.click(metricSearchField)
-  fireEvent.keyDown(metricSearchField, { key: 'Enter' })
+  fireEvent.click(metricSearchFieldMoreButton)
   fireEvent.click(await screen.findByRole('option', { name: /asdf_7d_refund/ }))
   fireEvent.click(metricAddButton)
 
@@ -123,8 +123,7 @@ test('allows adding, editing and removing a Metric Assignment', async () => {
 
   expect(container).toMatchSnapshot()
 
-  fireEvent.click(metricSearchField)
-  fireEvent.keyDown(metricSearchField, { key: 'Enter' })
+  fireEvent.click(metricSearchFieldMoreButton)
   fireEvent.click(await screen.findByRole('option', { name: /registration_start/ }))
   // eslint-disable-next-line @typescript-eslint/require-await
   await act(async () => {

--- a/src/components/experiments/wizard/Metrics.tsx
+++ b/src/components/experiments/wizard/Metrics.tsx
@@ -430,6 +430,16 @@ const Metrics = ({
                     options={Object.values(indexedMetrics)}
                     noOptionsText='No metrics found'
                     getOptionLabel={(metric: MetricBare) => metric.name}
+                    renderOption={(option) => (
+                      <div>
+                        <Typography variant='body1'>
+                          <strong>{option.name}</strong>
+                        </Typography>
+                        <Typography variant='body1'>
+                          <small>{option.description}</small>
+                        </Typography>
+                      </div>
+                    )}
                     renderInput={(params: AutocompleteRenderInputParams) => (
                       <MuiTextField
                         {...params}

--- a/src/components/experiments/wizard/Metrics.tsx
+++ b/src/components/experiments/wizard/Metrics.tsx
@@ -430,6 +430,7 @@ const Metrics = ({
                 <FormControl className={classes.addMetricSelect}>
                   <Autocomplete
                     id='add-metric-select'
+                    aria-label='Select a metric'
                     value={selectedMetric}
                     onChange={onChangeSelectedMetricOption}
                     fullWidth

--- a/src/components/experiments/wizard/Metrics.tsx
+++ b/src/components/experiments/wizard/Metrics.tsx
@@ -17,6 +17,7 @@ import {
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import { Add, Clear } from '@material-ui/icons'
 import { Alert, Autocomplete, AutocompleteRenderInputParams } from '@material-ui/lab'
+import clsx from 'clsx'
 import { Field, FieldArray, useField } from 'formik'
 import { Select, Switch, TextField } from 'formik-material-ui'
 import React, { useState } from 'react'
@@ -47,6 +48,11 @@ const useStyles = makeStyles((theme: Theme) =>
     metricName: {
       fontFamily: theme.custom.fonts.monospace,
       fontWeight: theme.custom.fontWeights.monospaceBold,
+    },
+    tooltipped: {
+      borderBottomWidth: 1,
+      borderBottomStyle: 'dashed',
+      borderBottomColor: theme.palette.grey[500],
     },
     primary: {
       fontFamily: theme.custom.fonts.monospace,
@@ -349,7 +355,7 @@ const Metrics = ({
                         <TableRow key={index}>
                           <TableCell>
                             <Tooltip arrow title={indexedMetrics[metricAssignment.metricId].description}>
-                              <span className={classes.metricName}>
+                              <span className={clsx(classes.metricName, classes.tooltipped)}>
                                 {indexedMetrics[metricAssignment.metricId].name}
                               </span>
                             </Tooltip>

--- a/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
@@ -415,10 +415,10 @@ exports[`renders as expected 1`] = `
 exports[`sections should be browsable by the section buttons 1`] = `
 <div>
   <div
-    class="makeStyles-root-117"
+    class="makeStyles-root-119"
   >
     <div
-      class="makeStyles-navigation-118"
+      class="makeStyles-navigation-120"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -705,17 +705,17 @@ exports[`sections should be browsable by the section buttons 1`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-119"
+        class="makeStyles-form-121"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-120"
+          class="makeStyles-formPart-122"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-122 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-124 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-123"
+              class="makeStyles-root-125"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -761,7 +761,7 @@ exports[`sections should be browsable by the section buttons 1`] = `
                 </div>
               </div>
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-p2EntryField-124"
+                class="MuiFormControl-root MuiTextField-root makeStyles-p2EntryField-126"
               >
                 <label
                   class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
@@ -785,10 +785,10 @@ exports[`sections should be browsable by the section buttons 1`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-126 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-128 MuiOutlinedInput-notchedOutline"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legendLabelled-128 PrivateNotchedOutline-legendNotched-129"
+                      class="PrivateNotchedOutline-legendLabelled-130 PrivateNotchedOutline-legendNotched-131"
                     >
                       <span>
                         Your Post's URL
@@ -800,7 +800,7 @@ exports[`sections should be browsable by the section buttons 1`] = `
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-121"
+            class="makeStyles-formPartActions-123"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -827,10 +827,10 @@ exports[`sections should be browsable by the section buttons 1`] = `
 exports[`sections should be browsable by the section buttons 2`] = `
 <div>
   <div
-    class="makeStyles-root-117"
+    class="makeStyles-root-119"
   >
     <div
-      class="makeStyles-navigation-118"
+      class="makeStyles-navigation-120"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -1107,17 +1107,17 @@ exports[`sections should be browsable by the section buttons 2`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-119"
+        class="makeStyles-form-121"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-120"
+          class="makeStyles-formPart-122"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-122 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-124 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-130"
+              class="makeStyles-root-132"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1125,7 +1125,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
                 Basic Info
               </h4>
               <div
-                class="makeStyles-row-131"
+                class="makeStyles-row-133"
               >
                 <div
                   class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -1161,10 +1161,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-126 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-128 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-128 PrivateNotchedOutline-legendNotched-129"
+                        class="PrivateNotchedOutline-legendLabelled-130 PrivateNotchedOutline-legendNotched-131"
                       >
                         <span>
                           Experiment name
@@ -1182,7 +1182,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-row-131"
+                class="makeStyles-row-133"
               >
                 <div
                   class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -1217,10 +1217,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-126 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-128 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-128 PrivateNotchedOutline-legendNotched-129"
+                        class="PrivateNotchedOutline-legendLabelled-130 PrivateNotchedOutline-legendNotched-131"
                       >
                         <span>
                           Experiment description
@@ -1238,10 +1238,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-row-131"
+                class="makeStyles-row-133"
               >
                 <div
-                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-133"
+                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-135"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
@@ -1274,10 +1274,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-126 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-128 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-128 PrivateNotchedOutline-legendNotched-129"
+                        class="PrivateNotchedOutline-legendLabelled-130 PrivateNotchedOutline-legendNotched-131"
                       >
                         <span>
                           Start date (UTC)
@@ -1288,12 +1288,12 @@ exports[`sections should be browsable by the section buttons 2`] = `
                   </div>
                 </div>
                 <span
-                  class="makeStyles-through-132"
+                  class="makeStyles-through-134"
                 >
                    through 
                 </span>
                 <div
-                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-133"
+                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-135"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
@@ -1324,10 +1324,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-126 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-128 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-128 PrivateNotchedOutline-legendNotched-129"
+                        class="PrivateNotchedOutline-legendLabelled-130 PrivateNotchedOutline-legendNotched-131"
                       >
                         <span>
                           End date (UTC)
@@ -1367,7 +1367,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-row-131"
+                class="makeStyles-row-133"
               >
                 <div
                   aria-expanded="false"
@@ -1475,10 +1475,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                       </div>
                       <fieldset
                         aria-hidden="true"
-                        class="PrivateNotchedOutline-root-126 MuiOutlinedInput-notchedOutline"
+                        class="PrivateNotchedOutline-root-128 MuiOutlinedInput-notchedOutline"
                       >
                         <legend
-                          class="PrivateNotchedOutline-legendLabelled-128 PrivateNotchedOutline-legendNotched-129"
+                          class="PrivateNotchedOutline-legendLabelled-130 PrivateNotchedOutline-legendNotched-131"
                         >
                           <span>
                             Owner
@@ -1499,7 +1499,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-121"
+            class="makeStyles-formPartActions-123"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -1540,10 +1540,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
 exports[`sections should be browsable by the section buttons 3`] = `
 <div>
   <div
-    class="makeStyles-root-117"
+    class="makeStyles-root-119"
   >
     <div
-      class="makeStyles-navigation-118"
+      class="makeStyles-navigation-120"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -1790,14 +1790,14 @@ exports[`sections should be browsable by the section buttons 3`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-119"
+        class="makeStyles-form-121"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-120"
+          class="makeStyles-formPart-122"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-122 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-124 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <h4
               class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1833,7 +1833,7 @@ exports[`sections should be browsable by the section buttons 3`] = `
             </p>
           </div>
           <div
-            class="makeStyles-formPartActions-121"
+            class="makeStyles-formPartActions-123"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -1850,7 +1850,7 @@ exports[`sections should be browsable by the section buttons 3`] = `
               />
             </button>
             <div
-              class="makeStyles-root-135"
+              class="makeStyles-root-137"
             >
               <button
                 class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary Mui-disabled Mui-disabled"
@@ -1876,10 +1876,10 @@ exports[`sections should be browsable by the section buttons 3`] = `
 exports[`sections should be browsable by the section buttons 4`] = `
 <div>
   <div
-    class="makeStyles-root-117"
+    class="makeStyles-root-119"
   >
     <div
-      class="makeStyles-navigation-118"
+      class="makeStyles-navigation-120"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -2136,17 +2136,17 @@ exports[`sections should be browsable by the section buttons 4`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-119"
+        class="makeStyles-form-121"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-120"
+          class="makeStyles-formPart-122"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-122 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-124 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-137"
+              class="makeStyles-root-139"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -2216,11 +2216,11 @@ exports[`sections should be browsable by the section buttons 4`] = `
                 </table>
               </div>
               <div
-                class="makeStyles-addMetric-149"
+                class="makeStyles-addMetric-152"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-150"
+                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-153"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -2229,41 +2229,89 @@ exports[`sections should be browsable by the section buttons 4`] = `
                   />
                 </svg>
                 <div
-                  class="MuiFormControl-root makeStyles-addMetricSelect-139"
+                  class="MuiFormControl-root makeStyles-addMetricSelect-141"
                 >
                   <div
-                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                    aria-expanded="false"
+                    aria-label="Select a metric"
+                    class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+                    role="combobox"
                   >
                     <div
-                      aria-haspopup="listbox"
-                      aria-labelledby="add-metric-label add-metric-select"
-                      class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-                      id="add-metric-select"
-                      role="button"
-                      tabindex="0"
+                      class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
                     >
-                      <span
-                        class="makeStyles-addMetricPlaceholder-138"
+                      <div
+                        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
                       >
-                        Select a Metric
-                      </span>
+                        <input
+                          aria-autocomplete="list"
+                          aria-invalid="false"
+                          autocapitalize="none"
+                          autocomplete="off"
+                          class="MuiInputBase-input MuiInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd"
+                          id="add-metric-select"
+                          placeholder="Select a metric"
+                          required=""
+                          spellcheck="false"
+                          type="text"
+                          value=""
+                        />
+                        <div
+                          class="MuiAutocomplete-endAdornment"
+                        >
+                          <button
+                            aria-label="Clear"
+                            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
+                            tabindex="-1"
+                            title="Clear"
+                            type="button"
+                          >
+                            <span
+                              class="MuiIconButton-label"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiTouchRipple-root"
+                            />
+                          </button>
+                          <button
+                            aria-label="Open"
+                            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+                            tabindex="-1"
+                            title="Open"
+                            type="button"
+                          >
+                            <span
+                              class="MuiIconButton-label"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M7 10l5 5 5-5z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiTouchRipple-root"
+                            />
+                          </button>
+                        </div>
+                      </div>
                     </div>
-                    <input
-                      aria-hidden="true"
-                      class="MuiSelect-nativeInput"
-                      tabindex="-1"
-                      value=""
-                    />
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSelect-icon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M7 10l5 5 5-5z"
-                      />
-                    </svg>
                   </div>
                 </div>
                 <button
@@ -2283,7 +2331,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
                 </button>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-145 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-148 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -2337,7 +2385,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
                 </div>
               </div>
               <h4
-                class="MuiTypography-root makeStyles-exposureEventsTitle-146 MuiTypography-h4"
+                class="MuiTypography-root makeStyles-exposureEventsTitle-149 MuiTypography-h4"
               >
                 Exposure Events (Optional)
               </h4>
@@ -2368,11 +2416,11 @@ exports[`sections should be browsable by the section buttons 4`] = `
                 </table>
               </div>
               <div
-                class="makeStyles-addMetric-149"
+                class="makeStyles-addMetric-152"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-150"
+                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-153"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -2397,7 +2445,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
                 </button>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-147 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-150 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -2429,7 +2477,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-121"
+            class="makeStyles-formPartActions-123"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -2470,10 +2518,10 @@ exports[`sections should be browsable by the section buttons 4`] = `
 exports[`skipping to submit should check all sections 1`] = `
 <div>
   <div
-    class="makeStyles-root-175"
+    class="makeStyles-root-178"
   >
     <div
-      class="makeStyles-navigation-176"
+      class="makeStyles-navigation-179"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -2720,14 +2768,14 @@ exports[`skipping to submit should check all sections 1`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-177"
+        class="makeStyles-form-180"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-178"
+          class="makeStyles-formPart-181"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-180 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-183 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <h4
               class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -2763,7 +2811,7 @@ exports[`skipping to submit should check all sections 1`] = `
             </p>
           </div>
           <div
-            class="makeStyles-formPartActions-179"
+            class="makeStyles-formPartActions-182"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -2780,7 +2828,7 @@ exports[`skipping to submit should check all sections 1`] = `
               />
             </button>
             <div
-              class="makeStyles-root-189"
+              class="makeStyles-root-192"
             >
               <button
                 class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary Mui-disabled Mui-disabled"

--- a/src/components/experiments/wizard/__snapshots__/Metrics.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/Metrics.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`allows adding, editing and removing a Metric Assignment 1`] = `
 <div>
   <div
-    class="makeStyles-root-15"
+    class="makeStyles-root-16"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -73,11 +73,11 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-27"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-28"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -86,41 +86,89 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-17"
+        class="MuiFormControl-root makeStyles-addMetricSelect-18"
       >
         <div
-          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          aria-expanded="false"
+          aria-label="Select a metric"
+          class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+          role="combobox"
         >
           <div
-            aria-haspopup="listbox"
-            aria-labelledby="add-metric-label add-metric-select"
-            class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-            id="add-metric-select"
-            role="button"
-            tabindex="0"
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
           >
-            <span
-              class="makeStyles-addMetricPlaceholder-16"
+            <div
+              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
             >
-              Select a Metric
-            </span>
+              <input
+                aria-autocomplete="list"
+                aria-invalid="false"
+                autocapitalize="none"
+                autocomplete="off"
+                class="MuiInputBase-input MuiInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd"
+                id="add-metric-select"
+                placeholder="Select a metric"
+                required=""
+                spellcheck="false"
+                type="text"
+                value=""
+              />
+              <div
+                class="MuiAutocomplete-endAdornment"
+              >
+                <button
+                  aria-label="Clear"
+                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
+                  tabindex="-1"
+                  title="Clear"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  aria-label="Open"
+                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+                  tabindex="-1"
+                  title="Open"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7 10l5 5 5-5z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
           </div>
-          <input
-            aria-hidden="true"
-            class="MuiSelect-nativeInput"
-            tabindex="-1"
-            value=""
-          />
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSelect-icon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M7 10l5 5 5-5z"
-            />
-          </svg>
         </div>
       </div>
       <button
@@ -140,7 +188,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-23 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-25 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -194,7 +242,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-24 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-26 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -225,11 +273,11 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-27"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-28"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -254,7 +302,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-25 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-27 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -290,7 +338,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
 exports[`allows adding, editing and removing a Metric Assignment 2`] = `
 <div>
   <div
-    class="makeStyles-root-15"
+    class="makeStyles-root-16"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -360,11 +408,11 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-27"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-28"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -373,41 +421,89 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-17"
+        class="MuiFormControl-root makeStyles-addMetricSelect-18"
       >
         <div
-          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          aria-expanded="false"
+          aria-label="Select a metric"
+          class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+          role="combobox"
         >
           <div
-            aria-haspopup="listbox"
-            aria-labelledby="add-metric-label add-metric-select"
-            class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-            id="add-metric-select"
-            role="button"
-            tabindex="0"
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
           >
-            <span
-              class="makeStyles-addMetricPlaceholder-16"
+            <div
+              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
             >
-              Select a Metric
-            </span>
+              <input
+                aria-autocomplete="list"
+                aria-invalid="false"
+                autocapitalize="none"
+                autocomplete="off"
+                class="MuiInputBase-input MuiInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd"
+                id="add-metric-select"
+                placeholder="Select a metric"
+                required=""
+                spellcheck="false"
+                type="text"
+                value=""
+              />
+              <div
+                class="MuiAutocomplete-endAdornment"
+              >
+                <button
+                  aria-label="Clear"
+                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
+                  tabindex="-1"
+                  title="Clear"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  aria-label="Open"
+                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+                  tabindex="-1"
+                  title="Open"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7 10l5 5 5-5z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
           </div>
-          <input
-            aria-hidden="true"
-            class="MuiSelect-nativeInput"
-            tabindex="-1"
-            value=""
-          />
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSelect-icon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M7 10l5 5 5-5z"
-            />
-          </svg>
         </div>
       </div>
       <button
@@ -427,7 +523,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-23 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-25 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -481,7 +577,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-24 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-26 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -512,11 +608,11 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-27"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-28"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -541,7 +637,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-25 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-27 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -577,7 +673,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
 exports[`allows adding, editing and removing a Metric Assignment 3`] = `
 <div>
   <div
-    class="makeStyles-root-15"
+    class="makeStyles-root-16"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -636,14 +732,14 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                class="makeStyles-metricName-19"
+                class="makeStyles-metricName-20 makeStyles-tooltipped-21"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-primary-20"
+                class="makeStyles-primary-22"
               >
                 Primary
               </span>
@@ -652,7 +748,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-18"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-19"
               >
                 <div
                   aria-haspopup="listbox"
@@ -684,11 +780,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-29 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-31 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-30"
+                    class="PrivateNotchedOutline-legend-32"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -699,7 +795,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-22"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-24"
             >
               <span
                 class="MuiSwitch-root"
@@ -707,14 +803,14 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-33 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-35 MuiSwitch-switchBase MuiSwitch-colorSecondary"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-36 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-38 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -737,7 +833,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-21"
+                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-23"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
@@ -764,11 +860,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-29 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-31 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-30"
+                      class="PrivateNotchedOutline-legend-32"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -816,11 +912,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-27"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-28"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -829,41 +925,89 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-17"
+        class="MuiFormControl-root makeStyles-addMetricSelect-18"
       >
         <div
-          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          aria-expanded="false"
+          aria-label="Select a metric"
+          class="MuiAutocomplete-root Mui-focused MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+          role="combobox"
         >
           <div
-            aria-haspopup="listbox"
-            aria-labelledby="add-metric-label add-metric-select"
-            class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-            id="add-metric-select"
-            role="button"
-            tabindex="0"
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
           >
-            <span
-              class="makeStyles-addMetricPlaceholder-16"
+            <div
+              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInput-fullWidth Mui-focused Mui-focused MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
             >
-              Select a Metric
-            </span>
+              <input
+                aria-autocomplete="list"
+                aria-invalid="false"
+                autocapitalize="none"
+                autocomplete="off"
+                class="MuiInputBase-input MuiInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd"
+                id="add-metric-select"
+                placeholder="Select a metric"
+                required=""
+                spellcheck="false"
+                type="text"
+                value=""
+              />
+              <div
+                class="MuiAutocomplete-endAdornment"
+              >
+                <button
+                  aria-label="Clear"
+                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
+                  tabindex="-1"
+                  title="Clear"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  aria-label="Open"
+                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+                  tabindex="-1"
+                  title="Open"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7 10l5 5 5-5z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
           </div>
-          <input
-            aria-hidden="true"
-            class="MuiSelect-nativeInput"
-            tabindex="-1"
-            value=""
-          />
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSelect-icon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M7 10l5 5 5-5z"
-            />
-          </svg>
         </div>
       </div>
       <button
@@ -883,7 +1027,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-23 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-25 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -937,7 +1081,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-24 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-26 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -968,11 +1112,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-27"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-28"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -997,7 +1141,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-25 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-27 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1035,7 +1179,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
   aria-hidden="true"
 >
   <div
-    class="makeStyles-root-15"
+    class="makeStyles-root-16"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1094,14 +1238,14 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                class="makeStyles-metricName-19"
+                class="makeStyles-metricName-20 makeStyles-tooltipped-21"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-primary-20"
+                class="makeStyles-primary-22"
               >
                 Primary
               </span>
@@ -1110,7 +1254,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-18"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-19"
               >
                 <div
                   aria-haspopup="listbox"
@@ -1142,11 +1286,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-29 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-31 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-30"
+                    class="PrivateNotchedOutline-legend-32"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -1157,7 +1301,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-22"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-24"
             >
               <span
                 class="MuiSwitch-root"
@@ -1165,14 +1309,14 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-33 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-35 MuiSwitch-switchBase MuiSwitch-colorSecondary"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-36 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-38 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -1195,7 +1339,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-21"
+                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-23"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
@@ -1222,11 +1366,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-29 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-31 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-30"
+                      class="PrivateNotchedOutline-legend-32"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -1274,11 +1418,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-27"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-28"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1287,41 +1431,89 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-17"
+        class="MuiFormControl-root makeStyles-addMetricSelect-18"
       >
         <div
-          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          aria-expanded="false"
+          aria-label="Select a metric"
+          class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+          role="combobox"
         >
           <div
-            aria-haspopup="listbox"
-            aria-labelledby="add-metric-label add-metric-select"
-            class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-            id="add-metric-select"
-            role="button"
-            tabindex="0"
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
           >
-            <span
-              class="makeStyles-addMetricPlaceholder-16"
+            <div
+              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
             >
-              Select a Metric
-            </span>
+              <input
+                aria-autocomplete="list"
+                aria-invalid="false"
+                autocapitalize="none"
+                autocomplete="off"
+                class="MuiInputBase-input MuiInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd"
+                id="add-metric-select"
+                placeholder="Select a metric"
+                required=""
+                spellcheck="false"
+                type="text"
+                value=""
+              />
+              <div
+                class="MuiAutocomplete-endAdornment"
+              >
+                <button
+                  aria-label="Clear"
+                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
+                  tabindex="-1"
+                  title="Clear"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  aria-label="Open"
+                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+                  tabindex="-1"
+                  title="Open"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7 10l5 5 5-5z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
           </div>
-          <input
-            aria-hidden="true"
-            class="MuiSelect-nativeInput"
-            tabindex="-1"
-            value=""
-          />
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSelect-icon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M7 10l5 5 5-5z"
-            />
-          </svg>
         </div>
       </div>
       <button
@@ -1341,7 +1533,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-23 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-25 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1395,7 +1587,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-24 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-26 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -1426,11 +1618,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-27"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-28"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1455,7 +1647,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-25 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-27 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1491,7 +1683,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
 exports[`allows adding, editing and removing a Metric Assignment 5`] = `
 <div>
   <div
-    class="makeStyles-root-15"
+    class="makeStyles-root-16"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1550,14 +1742,14 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                class="makeStyles-metricName-19"
+                class="makeStyles-metricName-20 makeStyles-tooltipped-21"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-primary-20"
+                class="makeStyles-primary-22"
               >
                 Primary
               </span>
@@ -1566,7 +1758,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-18"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-19"
               >
                 <div
                   aria-haspopup="listbox"
@@ -1598,11 +1790,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-29 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-31 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-30"
+                    class="PrivateNotchedOutline-legend-32"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -1613,7 +1805,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-22"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-24"
             >
               <span
                 class="MuiSwitch-root"
@@ -1621,14 +1813,14 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-33 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-35 MuiSwitch-switchBase MuiSwitch-colorSecondary"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-36 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-38 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -1651,7 +1843,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-21"
+                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-23"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
@@ -1678,11 +1870,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-29 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-31 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-30"
+                      class="PrivateNotchedOutline-legend-32"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -1730,11 +1922,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-27"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-28"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1743,41 +1935,89 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-17"
+        class="MuiFormControl-root makeStyles-addMetricSelect-18"
       >
         <div
-          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          aria-expanded="false"
+          aria-label="Select a metric"
+          class="MuiAutocomplete-root Mui-focused MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+          role="combobox"
         >
           <div
-            aria-haspopup="listbox"
-            aria-labelledby="add-metric-label add-metric-select"
-            class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-            id="add-metric-select"
-            role="button"
-            tabindex="0"
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
           >
-            <span
-              class="makeStyles-addMetricPlaceholder-16"
+            <div
+              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInput-fullWidth Mui-focused Mui-focused MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
             >
-              Select a Metric
-            </span>
+              <input
+                aria-autocomplete="list"
+                aria-invalid="false"
+                autocapitalize="none"
+                autocomplete="off"
+                class="MuiInputBase-input MuiInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd"
+                id="add-metric-select"
+                placeholder="Select a metric"
+                required=""
+                spellcheck="false"
+                type="text"
+                value=""
+              />
+              <div
+                class="MuiAutocomplete-endAdornment"
+              >
+                <button
+                  aria-label="Clear"
+                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
+                  tabindex="-1"
+                  title="Clear"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  aria-label="Open"
+                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+                  tabindex="-1"
+                  title="Open"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7 10l5 5 5-5z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
           </div>
-          <input
-            aria-hidden="true"
-            class="MuiSelect-nativeInput"
-            tabindex="-1"
-            value=""
-          />
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSelect-icon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M7 10l5 5 5-5z"
-            />
-          </svg>
         </div>
       </div>
       <button
@@ -1797,7 +2037,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-23 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-25 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1851,7 +2091,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-24 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-26 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -1882,11 +2122,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-27"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-28"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1911,7 +2151,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-25 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-27 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1947,7 +2187,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
 exports[`allows adding, editing and removing a Metric Assignment 6`] = `
 <div>
   <div
-    class="makeStyles-root-15"
+    class="makeStyles-root-16"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -2017,11 +2257,11 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-27"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-28"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -2030,41 +2270,89 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-17"
+        class="MuiFormControl-root makeStyles-addMetricSelect-18"
       >
         <div
-          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          aria-expanded="false"
+          aria-label="Select a metric"
+          class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+          role="combobox"
         >
           <div
-            aria-haspopup="listbox"
-            aria-labelledby="add-metric-label add-metric-select"
-            class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-            id="add-metric-select"
-            role="button"
-            tabindex="0"
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
           >
-            <span
-              class="makeStyles-addMetricPlaceholder-16"
+            <div
+              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
             >
-              Select a Metric
-            </span>
+              <input
+                aria-autocomplete="list"
+                aria-invalid="false"
+                autocapitalize="none"
+                autocomplete="off"
+                class="MuiInputBase-input MuiInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd"
+                id="add-metric-select"
+                placeholder="Select a metric"
+                required=""
+                spellcheck="false"
+                type="text"
+                value=""
+              />
+              <div
+                class="MuiAutocomplete-endAdornment"
+              >
+                <button
+                  aria-label="Clear"
+                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
+                  tabindex="-1"
+                  title="Clear"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  aria-label="Open"
+                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+                  tabindex="-1"
+                  title="Open"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7 10l5 5 5-5z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
           </div>
-          <input
-            aria-hidden="true"
-            class="MuiSelect-nativeInput"
-            tabindex="-1"
-            value=""
-          />
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSelect-icon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M7 10l5 5 5-5z"
-            />
-          </svg>
         </div>
       </div>
       <button
@@ -2084,7 +2372,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-23 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-25 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -2138,7 +2426,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-24 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-26 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -2169,11 +2457,11 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-27"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-28"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -2198,7 +2486,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-25 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-27 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -2234,7 +2522,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
 exports[`allows adding, editing and removing a Metric Assignment 7`] = `
 <div>
   <div
-    class="makeStyles-root-15"
+    class="makeStyles-root-16"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -2293,14 +2581,14 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                class="makeStyles-metricName-19"
+                class="makeStyles-metricName-20 makeStyles-tooltipped-21"
                 title="string"
               >
                 registration_start
               </span>
               <br />
               <span
-                class="makeStyles-primary-20"
+                class="makeStyles-primary-22"
               >
                 Primary
               </span>
@@ -2309,7 +2597,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-18"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-19"
               >
                 <div
                   aria-haspopup="listbox"
@@ -2341,11 +2629,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-38 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-40 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-39"
+                    class="PrivateNotchedOutline-legend-41"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -2356,7 +2644,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-22"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-24"
             >
               <span
                 class="MuiSwitch-root"
@@ -2364,14 +2652,14 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-42 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-44 MuiSwitch-switchBase MuiSwitch-colorSecondary"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-45 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-47 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -2394,7 +2682,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-21"
+                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-23"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
@@ -2415,7 +2703,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                     class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
                   >
                     <p
-                      class="MuiTypography-root makeStyles-tooltipped-46 MuiTypography-body1 MuiTypography-colorTextSecondary"
+                      class="MuiTypography-root makeStyles-tooltipped-48 MuiTypography-body1 MuiTypography-colorTextSecondary"
                       title="Percentage Points"
                     >
                       pp
@@ -2423,11 +2711,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                   </div>
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-38 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-40 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-39"
+                      class="PrivateNotchedOutline-legend-41"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -2475,11 +2763,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-27"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-28"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -2488,41 +2776,89 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-17"
+        class="MuiFormControl-root makeStyles-addMetricSelect-18"
       >
         <div
-          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          aria-expanded="false"
+          aria-label="Select a metric"
+          class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+          role="combobox"
         >
           <div
-            aria-haspopup="listbox"
-            aria-labelledby="add-metric-label add-metric-select"
-            class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-            id="add-metric-select"
-            role="button"
-            tabindex="0"
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
           >
-            <span
-              class="makeStyles-addMetricPlaceholder-16"
+            <div
+              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
             >
-              Select a Metric
-            </span>
+              <input
+                aria-autocomplete="list"
+                aria-invalid="false"
+                autocapitalize="none"
+                autocomplete="off"
+                class="MuiInputBase-input MuiInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd"
+                id="add-metric-select"
+                placeholder="Select a metric"
+                required=""
+                spellcheck="false"
+                type="text"
+                value=""
+              />
+              <div
+                class="MuiAutocomplete-endAdornment"
+              >
+                <button
+                  aria-label="Clear"
+                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
+                  tabindex="-1"
+                  title="Clear"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  aria-label="Open"
+                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+                  tabindex="-1"
+                  title="Open"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7 10l5 5 5-5z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
           </div>
-          <input
-            aria-hidden="true"
-            class="MuiSelect-nativeInput"
-            tabindex="-1"
-            value=""
-          />
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSelect-icon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M7 10l5 5 5-5z"
-            />
-          </svg>
         </div>
       </div>
       <button
@@ -2542,7 +2878,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-23 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-25 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -2596,7 +2932,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-24 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-26 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -2627,11 +2963,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-27"
+      class="makeStyles-addMetric-29"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-28"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -2656,7 +2992,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-25 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-27 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -2762,11 +3098,11 @@ exports[`renders as expected 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-13"
+      class="makeStyles-addMetric-14"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-14"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-15"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -2778,38 +3114,86 @@ exports[`renders as expected 1`] = `
         class="MuiFormControl-root makeStyles-addMetricSelect-3"
       >
         <div
-          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          aria-expanded="false"
+          aria-label="Select a metric"
+          class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+          role="combobox"
         >
           <div
-            aria-haspopup="listbox"
-            aria-labelledby="add-metric-label add-metric-select"
-            class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-            id="add-metric-select"
-            role="button"
-            tabindex="0"
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
           >
-            <span
-              class="makeStyles-addMetricPlaceholder-2"
+            <div
+              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
             >
-              Select a Metric
-            </span>
+              <input
+                aria-autocomplete="list"
+                aria-invalid="false"
+                autocapitalize="none"
+                autocomplete="off"
+                class="MuiInputBase-input MuiInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd"
+                id="add-metric-select"
+                placeholder="Select a metric"
+                required=""
+                spellcheck="false"
+                type="text"
+                value=""
+              />
+              <div
+                class="MuiAutocomplete-endAdornment"
+              >
+                <button
+                  aria-label="Clear"
+                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
+                  tabindex="-1"
+                  title="Clear"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  aria-label="Open"
+                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+                  tabindex="-1"
+                  title="Open"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7 10l5 5 5-5z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
           </div>
-          <input
-            aria-hidden="true"
-            class="MuiSelect-nativeInput"
-            tabindex="-1"
-            value=""
-          />
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSelect-icon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M7 10l5 5 5-5z"
-            />
-          </svg>
         </div>
       </div>
       <button
@@ -2829,7 +3213,7 @@ exports[`renders as expected 1`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-9 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-10 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -2883,7 +3267,7 @@ exports[`renders as expected 1`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-10 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-11 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -2914,11 +3298,11 @@ exports[`renders as expected 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-13"
+      class="makeStyles-addMetric-14"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-14"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-15"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -2943,7 +3327,7 @@ exports[`renders as expected 1`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-11 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-12 MuiPaper-elevation0"
       role="alert"
     >
       <div

--- a/src/components/general/Autocomplete.tsx
+++ b/src/components/general/Autocomplete.tsx
@@ -34,7 +34,7 @@ export default function AbacusAutocomplete<Multiple extends boolean>(
 
   // ## Translating OuterValues (value | value[]) <-> InnerValues (AutocompleteItem | AutocompleteItem[])
   //
-  // Typescript and esline make this look much more complicated than it is, we are just keeping the form value type
+  // Typescript and eslint make this look much more complicated than it is, we are just keeping the form value type
   // in the form (string | number, and array version for multiple), and inside here we are using Autocomplete.
   //
   // We transform on the way in and on the way out.


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR:**
- Highlights that there are tooltips for metric descriptions
- Switches the metric box for an autocomplete, allowing searching
- Adds metric descriptions to the metrics in the autocomplete

Video to be posted to slack

Resolves #378, I went in the direction of improving the autocomplete instead of adding the table in.
It might be worth adding the metric table in later but we would need to improve the metric table quite a bit first, possibly changing it to use AG-Grid. I think we also need to create one line "Short descriptions" for metrics for an effective table view.
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

**Future PR:**
- Refactor this code and include it in the "Add Metric" dialog.

(BTW, seems like we had the right data already)

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
