### PR TITLE
Make analysis strategy switch generally available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15544,9 +15544,9 @@
       "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
     },
     "dns-packet": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
+      "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
       "requires": {
         "ip": "^1.1.0",
         "safe-buffer": "^5.0.1"

--- a/src/components/experiments/single-view/results/ActualExperimentResults.tsx
+++ b/src/components/experiments/single-view/results/ActualExperimentResults.tsx
@@ -157,13 +157,15 @@ export default function ActualExperimentResults({
   const classes = useStyles()
   const theme = useTheme()
 
+  const availableAnalysisStrategies = [
+    AnalysisStrategy.IttPure,
+    AnalysisStrategy.MittNoCrossovers,
+    AnalysisStrategy.MittNoSpammers,
+    AnalysisStrategy.MittNoSpammersNoCrossovers,
+  ]
+  experiment.exposureEvents && availableAnalysisStrategies.push(AnalysisStrategy.PpNaive)
   const [strategy, setStrategy] = useState<AnalysisStrategy>(() => Experiments.getDefaultAnalysisStrategy(experiment))
-  // istanbul ignore next; Debug only
   const onStrategyChange = (event: React.ChangeEvent<{ value: unknown }>) => {
-    if (!Object.values(AnalysisStrategy).includes(event.target.value as AnalysisStrategy)) {
-      throw new Error('Invalid strategy')
-    }
-
     setStrategy(event.target.value as AnalysisStrategy)
   }
 
@@ -434,23 +436,21 @@ export default function ActualExperimentResults({
 
   return (
     <div className={classes.root}>
-      {
-        // istanbul ignore next; Debug only
-        isDebugMode() && (
-          <Paper className={classes.advancedControls}>
-            <FormControl>
-              <InputLabel htmlFor='strategy-selector'>Strategy:</InputLabel>
-              <Select id='strategy-selector' value={strategy} onChange={onStrategyChange}>
-                {Object.values(AnalysisStrategy).map((strat) => (
-                  <MenuItem key={strat} value={strat}>
-                    {Analyses.AnalysisStrategyToHuman[strat]}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </Paper>
-        )
-      }
+      <Paper className={classes.advancedControls}>
+        <FormControl>
+          <InputLabel htmlFor='strategy-selector' id='strategy-selector-label'>
+            Analysis Strategy:
+          </InputLabel>
+          <Select id='strategy-selector' labelId='strategy-selector-label' value={strategy} onChange={onStrategyChange}>
+            {availableAnalysisStrategies.map((strat) => (
+              <MenuItem key={strat} value={strat}>
+                {Analyses.AnalysisStrategyToHuman[strat]}
+                {strat === Experiments.getDefaultAnalysisStrategy(experiment) && ' (recommended)'}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Paper>
       {hasAnalyses ? (
         <>
           <div className={classes.summary}>

--- a/src/components/experiments/single-view/results/ActualExperimentResults.tsx
+++ b/src/components/experiments/single-view/results/ActualExperimentResults.tsx
@@ -6,6 +6,7 @@ import {
   Chip,
   createStyles,
   FormControl,
+  FormHelperText,
   InputLabel,
   makeStyles,
   MenuItem,
@@ -556,62 +557,65 @@ export default function ActualExperimentResults({
       )}
 
       <div className={classes.accordions}>
-        <Accordion>
-          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-            <Typography variant='h5'>Advanced - Choose an Analysis Strategy</Typography>
-          </AccordionSummary>
-          <AccordionDetails className={classes.accordionDetails}>
-            <Typography variant='body1'>
-              Choosing a different analysis strategy is useful for checking the effect of different modelling decisions
-              on the results:
-            </Typography>
+        {hasAnalyses && (
+          <Accordion>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <Typography variant='h5'>Advanced - Choose an Analysis Strategy</Typography>
+            </AccordionSummary>
+            <AccordionDetails className={classes.accordionDetails}>
+              <Typography variant='body1'>
+                Choosing a different analysis strategy is useful for checking the effect of different modelling
+                decisions on the results:
+              </Typography>
 
-            <ul>
-              <Typography variant='body1' component='li'>
-                <strong>All participants:</strong> All the participants are analysed based on their initial variation
-                assignment. Pure intention-to-treat.
-              </Typography>
-              <Typography variant='body1' component='li'>
-                <strong>Without crossovers:</strong> Same as all participants, but excluding participants that were
-                assigned to multiple experiment variations before or on the analysis date (aka crossovers). Modified
-                intention-to-treat.
-              </Typography>
-              <Typography variant='body1' component='li'>
-                <strong>Without spammers:</strong> Same as all participants, but excluding participants that were
-                flagged as spammers on the analysis date. Modified intention-to-treat.
-              </Typography>
-              <Typography variant='body1' component='li'>
-                <strong>Without crossovers and spammers:</strong> Same as all participants, but excluding both spammers
-                and crossovers. Modified intention-to-treat.
-              </Typography>
-              <Typography variant='body1' component='li'>
-                <strong>Exposed without crossovers and spammers:</strong> Only participants that triggered one of the
-                experiment&apos;s exposure events, excluding both spammers and crossovers. This analysis strategy is
-                only available if the experiment has exposure events, while the other four strategies are used for every
-                experiment. Naive per-protocol.
-              </Typography>
-            </ul>
+              <ul>
+                <Typography variant='body1' component='li'>
+                  <strong>All participants:</strong> All the participants are analysed based on their initial variation
+                  assignment. Pure intention-to-treat.
+                </Typography>
+                <Typography variant='body1' component='li'>
+                  <strong>Without crossovers:</strong> Same as all participants, but excluding participants that were
+                  assigned to multiple experiment variations before or on the analysis date (aka crossovers). Modified
+                  intention-to-treat.
+                </Typography>
+                <Typography variant='body1' component='li'>
+                  <strong>Without spammers:</strong> Same as all participants, but excluding participants that were
+                  flagged as spammers on the analysis date. Modified intention-to-treat.
+                </Typography>
+                <Typography variant='body1' component='li'>
+                  <strong>Without crossovers and spammers:</strong> Same as all participants, but excluding both
+                  spammers and crossovers. Modified intention-to-treat.
+                </Typography>
+                <Typography variant='body1' component='li'>
+                  <strong>Exposed without crossovers and spammers:</strong> Only participants that triggered one of the
+                  experiment&apos;s exposure events, excluding both spammers and crossovers. This analysis strategy is
+                  only available if the experiment has exposure events, while the other four strategies are used for
+                  every experiment. Naive per-protocol.
+                </Typography>
+              </ul>
 
-            <FormControl>
-              <InputLabel htmlFor='strategy-selector' id='strategy-selector-label'>
-                Analysis Strategy:
-              </InputLabel>
-              <Select
-                id='strategy-selector'
-                labelId='strategy-selector-label'
-                value={strategy}
-                onChange={onStrategyChange}
-              >
-                {availableAnalysisStrategies.map((strat) => (
-                  <MenuItem key={strat} value={strat}>
-                    {Analyses.AnalysisStrategyToHuman[strat]}
-                    {strat === Experiments.getDefaultAnalysisStrategy(experiment) && ' (recommended)'}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </AccordionDetails>
-        </Accordion>
+              <FormControl>
+                <InputLabel htmlFor='strategy-selector' id='strategy-selector-label'>
+                  Analysis Strategy:
+                </InputLabel>
+                <Select
+                  id='strategy-selector'
+                  labelId='strategy-selector-label'
+                  value={strategy}
+                  onChange={onStrategyChange}
+                >
+                  {availableAnalysisStrategies.map((strat) => (
+                    <MenuItem key={strat} value={strat}>
+                      {Analyses.AnalysisStrategyToHuman[strat]}
+                      {strat === Experiments.getDefaultAnalysisStrategy(experiment) && ' (recommended)'}
+                    </MenuItem>
+                  ))}
+                </Select>
+                <FormHelperText>Updates the page data.</FormHelperText>
+              </FormControl>
+            </AccordionDetails>
+          </Accordion>
+        )}
         <Accordion>
           <AccordionSummary expandIcon={<ExpandMoreIcon />}>
             <Typography variant='h5'>Early Monitoring - Live Assignment Event Flow</Typography>

--- a/src/components/experiments/single-view/results/ExperimentResults.test.tsx
+++ b/src/components/experiments/single-view/results/ExperimentResults.test.tsx
@@ -96,7 +96,16 @@ test('renders the condensed table with some analyses in non-debug mode for a Rev
 
 test('allows you to change analysis strategy', async () => {
   const { container } = render(
-    <ExperimentResults analyses={[]} experiment={{ ...experiment, exposureEvents: undefined }} metrics={metrics} />,
+    <ExperimentResults
+      analyses={[
+        Fixtures.createAnalysis({ analysisStrategy: AnalysisStrategy.IttPure }),
+        Fixtures.createAnalysis({ analysisStrategy: AnalysisStrategy.MittNoCrossovers }),
+        Fixtures.createAnalysis({ analysisStrategy: AnalysisStrategy.MittNoSpammers }),
+        Fixtures.createAnalysis({ analysisStrategy: AnalysisStrategy.MittNoSpammersNoCrossovers }),
+      ]}
+      experiment={{ ...experiment, exposureEvents: undefined }}
+      metrics={metrics}
+    />,
   )
 
   fireEvent.click(screen.getByRole('button', { name: /Choose an Analysis Strategy/ }))

--- a/src/components/experiments/single-view/results/ExperimentResults.test.tsx
+++ b/src/components/experiments/single-view/results/ExperimentResults.test.tsx
@@ -95,9 +95,12 @@ test('renders the condensed table with some analyses in non-debug mode for a Rev
 })
 
 test('allows you to change analysis strategy', async () => {
-  const { container } = render(<ExperimentResults analyses={[]} experiment={experiment} metrics={metrics} />)
+  const { container } = render(
+    <ExperimentResults analyses={[]} experiment={{ ...experiment, exposureEvents: undefined }} metrics={metrics} />,
+  )
 
-  const analysisStrategy = screen.getByRole('button', { name: /Analysis Strategy/ })
+  fireEvent.click(screen.getByRole('button', { name: /Choose an Analysis Strategy/ }))
+  const analysisStrategy = screen.getByRole('button', { name: /Analysis Strategy:/ })
   fireEvent.focus(analysisStrategy)
   fireEvent.keyDown(analysisStrategy, { key: 'Enter' })
   const analysisStrategyOption = await screen.findByRole('option', { name: /All participants/ })

--- a/src/components/experiments/single-view/results/ExperimentResults.test.tsx
+++ b/src/components/experiments/single-view/results/ExperimentResults.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, getAllByText, getByText, waitFor } from '@testing-library/react'
+import { fireEvent, getAllByText, getByText, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import Plot from 'react-plotly.js'
 
@@ -92,4 +92,16 @@ test('renders the condensed table with some analyses in non-debug mode for a Rev
   expect(container.querySelector('.analysis-latest-results .analysis-detail-panel')).toMatchSnapshot()
 
   expect(mockedPlot).toMatchSnapshot()
+})
+
+test('allows you to change analysis strategy', async () => {
+  const { container } = render(<ExperimentResults analyses={[]} experiment={experiment} metrics={metrics} />)
+
+  const analysisStrategy = screen.getByRole('button', { name: /Analysis Strategy/ })
+  fireEvent.focus(analysisStrategy)
+  fireEvent.keyDown(analysisStrategy, { key: 'Enter' })
+  const analysisStrategyOption = await screen.findByRole('option', { name: /All participants/ })
+  fireEvent.click(analysisStrategyOption)
+
+  expect(container).toMatchSnapshot()
 })

--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -9,38 +9,894 @@ exports[`allows you to change analysis strategy 1`] = `
       class="makeStyles-root-189"
     >
       <div
-        class="MuiPaper-root makeStyles-noAnalysesPaper-207 MuiPaper-elevation1 MuiPaper-rounded"
+        class="makeStyles-summary-191"
       >
-        <h3
-          class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
+        <div
+          class="MuiPaper-root makeStyles-participantsPlotPaper-202 MuiPaper-elevation1 MuiPaper-rounded"
         >
-           
-          No Results
-           
-        </h3>
-        <p
-          class="MuiTypography-root MuiTypography-body1"
+          <h3
+            class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
+          >
+            Participants by Variation
+          </h3>
+        </div>
+        <div
+          class="makeStyles-summaryColumn-193"
         >
-          No results are available at the moment, this can be due to:
-        </p>
-        <ul>
-          <li
-            class="MuiTypography-root MuiTypography-body1"
+          <div
+            class="MuiPaper-root makeStyles-summaryStatsPaper-194 MuiPaper-elevation1 MuiPaper-rounded"
           >
-            <strong>
-               An experiment being new. 
-            </strong>
-             ExPlat can take 24-48 hours for results to process and become available. Updates are usually released at 06:00 UTC daily.
-          </li>
-          <li
-            class="MuiTypography-root MuiTypography-body1"
+            <div
+              class="makeStyles-summaryStatsPart-195"
+            >
+              <h3
+                class="MuiTypography-root makeStyles-summaryStatsStat-197 MuiTypography-h3 MuiTypography-colorPrimary"
+              >
+                1,000
+              </h3>
+              <h6
+                class="MuiTypography-root MuiTypography-subtitle1"
+              >
+                <strong>
+                  analyzed participants
+                </strong>
+                 as at
+                 
+                2020-05-10
+              </h6>
+            </div>
+            <div
+              class="makeStyles-summaryStatsPart-195"
+            >
+              <h3
+                class="MuiTypography-root makeStyles-summaryStatsStat-197 MuiTypography-h3 MuiTypography-colorPrimary"
+              >
+                Deploy 
+                test
+              </h3>
+              <h6
+                class="MuiTypography-root MuiTypography-subtitle1"
+              >
+                <strong>
+                  primary metric
+                </strong>
+                 recommendation
+              </h6>
+            </div>
+          </div>
+          <a
+            class="MuiPaper-root makeStyles-summaryHealthPaper-198 makeStyles-indicationSeverityWarning-200 MuiPaper-elevation1 MuiPaper-rounded"
+            href="#health-report"
           >
-            <strong>
-               No assignments occuring. 
-            </strong>
-             Check the "Early Monitoring" section below to ensure that assignments are occuring.
-          </li>
-        </ul>
+            <div>
+              <h3
+                class="MuiTypography-root makeStyles-summaryStatsStat-197 MuiTypography-h3 MuiTypography-colorPrimary"
+              >
+                Potential issues
+              </h3>
+              <h6
+                class="MuiTypography-root MuiTypography-subtitle1"
+              >
+                see 
+                <strong>
+                  health report
+                </strong>
+              </h6>
+            </div>
+          </a>
+        </div>
+      </div>
+      <h3
+        class="MuiTypography-root makeStyles-tableTitle-204 MuiTypography-h3"
+      >
+        Metric Assignment Results
+      </h3>
+      <div
+        class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+        style="position: relative;"
+      >
+        <div
+          class="Component-horizontalScrollContainer-215"
+          style="overflow-x: auto; position: relative;"
+        >
+          <div>
+            <div
+              style="overflow-y: auto;"
+            >
+              <div>
+                <table
+                  class="MuiTable-root"
+                  style="table-layout: auto;"
+                >
+                  <thead
+                    class="MuiTableHead-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root MuiTableRow-head"
+                    >
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-216 MuiTableCell-paddingNone"
+                        scope="col"
+                        style="font-weight: 700;"
+                      />
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-216 MuiTableCell-alignLeft"
+                        scope="col"
+                        style="font-weight: 700; box-sizing: border-box;"
+                      >
+                        Metric
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-216 MuiTableCell-alignLeft"
+                        scope="col"
+                        style="font-weight: 700; box-sizing: border-box;"
+                      >
+                        Attribution window
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-216 MuiTableCell-alignLeft"
+                        scope="col"
+                        style="font-weight: 700; box-sizing: border-box;"
+                      >
+                        Absolute change
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-216 MuiTableCell-alignLeft"
+                        scope="col"
+                        style="font-weight: 700; box-sizing: border-box;"
+                      >
+                        Relative change (lift)
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-216 MuiTableCell-alignLeft"
+                        scope="col"
+                        style="font-weight: 700; box-sizing: border-box;"
+                      >
+                        Recommendation
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    class="MuiTableBody-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root MuiTableRow-hover"
+                      index="0"
+                      level="0"
+                      path="0"
+                      style="transition: all ease 300ms; opacity: 0.8; cursor: pointer;"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-paddingNone"
+                      >
+                        <div
+                          style="width: 42px; text-align: center; display: flex;"
+                        >
+                          <button
+                            class="MuiButtonBase-root MuiIconButton-root"
+                            style="transition: all ease 200ms; transform: none;"
+                            tabindex="0"
+                            type="button"
+                          >
+                            <span
+                              class="MuiIconButton-label"
+                            >
+                              <span
+                                aria-hidden="true"
+                                class="material-icons MuiIcon-root"
+                              >
+                                chevron_right
+                              </span>
+                            </span>
+                            <span
+                              class="MuiTouchRipple-root"
+                            />
+                          </button>
+                        </div>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
+                      >
+                        <span
+                          class=""
+                          title="This is metric 1"
+                        >
+                          metric_1
+                        </span>
+                         
+                        <div
+                          aria-disabled="true"
+                          class="MuiChip-root makeStyles-primaryChip-190 MuiChip-outlined Mui-disabled"
+                        >
+                          <span
+                            class="MuiChip-label"
+                          >
+                            Primary
+                          </span>
+                        </div>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
+                      >
+                        1 week
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
+                      >
+                        <span
+                          class="makeStyles-topLevelDiff-209"
+                        >
+                          -1
+                           to 
+                          +
+                          1
+                           
+                          pp
+                        </span>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      >
+                        <span
+                          class="makeStyles-topLevelDiff-209"
+                        >
+                          -50.00
+                           to 
+                          +50.00
+                           %
+                        </span>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
+                      >
+                        Deploy 
+                        test
+                      </td>
+                    </tr>
+                    <tr
+                      class="MuiTableRow-root MuiTableRow-hover"
+                      index="1"
+                      level="0"
+                      path="1"
+                      style="transition: all ease 300ms; opacity: 0.8; cursor: pointer;"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-paddingNone"
+                      >
+                        <div
+                          style="width: 42px; text-align: center; display: flex;"
+                        >
+                          <button
+                            class="MuiButtonBase-root MuiIconButton-root"
+                            style="transition: all ease 200ms; transform: none;"
+                            tabindex="0"
+                            type="button"
+                          >
+                            <span
+                              class="MuiIconButton-label"
+                            >
+                              <span
+                                aria-hidden="true"
+                                class="material-icons MuiIcon-root"
+                              >
+                                chevron_right
+                              </span>
+                            </span>
+                            <span
+                              class="MuiTouchRipple-root"
+                            />
+                          </button>
+                        </div>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
+                      >
+                        <span
+                          class=""
+                          title="This is metric 2"
+                        >
+                          metric_2
+                        </span>
+                         
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
+                      >
+                        1 hour
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
+                      >
+                        Not analyzed yet
+                      </td>
+                    </tr>
+                    <tr
+                      class="MuiTableRow-root MuiTableRow-hover"
+                      index="2"
+                      level="0"
+                      path="2"
+                      style="transition: all ease 300ms; opacity: 0.8; cursor: pointer;"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-paddingNone"
+                      >
+                        <div
+                          style="width: 42px; text-align: center; display: flex;"
+                        >
+                          <button
+                            class="MuiButtonBase-root MuiIconButton-root"
+                            style="transition: all ease 200ms; transform: none;"
+                            tabindex="0"
+                            type="button"
+                          >
+                            <span
+                              class="MuiIconButton-label"
+                            >
+                              <span
+                                aria-hidden="true"
+                                class="material-icons MuiIcon-root"
+                              >
+                                chevron_right
+                              </span>
+                            </span>
+                            <span
+                              class="MuiTouchRipple-root"
+                            />
+                          </button>
+                        </div>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
+                      >
+                        <span
+                          class=""
+                          title="This is metric 2"
+                        >
+                          metric_2
+                        </span>
+                         
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
+                      >
+                        4 weeks
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
+                      >
+                        Not analyzed yet
+                      </td>
+                    </tr>
+                    <tr
+                      class="MuiTableRow-root MuiTableRow-hover"
+                      index="3"
+                      level="0"
+                      path="3"
+                      style="transition: all ease 300ms; opacity: 0.8; cursor: pointer;"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-paddingNone"
+                      >
+                        <div
+                          style="width: 42px; text-align: center; display: flex;"
+                        >
+                          <button
+                            class="MuiButtonBase-root MuiIconButton-root"
+                            style="transition: all ease 200ms; transform: none;"
+                            tabindex="0"
+                            type="button"
+                          >
+                            <span
+                              class="MuiIconButton-label"
+                            >
+                              <span
+                                aria-hidden="true"
+                                class="material-icons MuiIcon-root"
+                              >
+                                chevron_right
+                              </span>
+                            </span>
+                            <span
+                              class="MuiTouchRipple-root"
+                            />
+                          </button>
+                        </div>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
+                      >
+                        <span
+                          class=""
+                          title="This is metric 3"
+                        >
+                          metric_3
+                        </span>
+                         
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
+                      >
+                        6 hours
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box;"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
+                        style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
+                      >
+                        Not analyzed yet
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <h3
+        class="MuiTypography-root makeStyles-tableTitle-204 MuiTypography-h3"
+      >
+        Health Report
+      </h3>
+      <div
+        class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
+        id="health-report"
+      >
+        <div
+          class="MuiTableContainer-root"
+        >
+          <table
+            aria-label="simple table"
+            class="MuiTable-root"
+          >
+            <thead
+              class="MuiTableHead-root"
+            >
+              <tr
+                class="MuiTableRow-root MuiTableRow-head"
+              >
+                <th
+                  class="MuiTableCell-root MuiTableCell-head"
+                  scope="col"
+                >
+                  Name
+                </th>
+                <th
+                  class="MuiTableCell-root MuiTableCell-head"
+                  scope="col"
+                >
+                  Unit
+                </th>
+                <th
+                  class="MuiTableCell-root MuiTableCell-head"
+                  scope="col"
+                >
+                  Value
+                </th>
+                <th
+                  class="MuiTableCell-root MuiTableCell-head"
+                  scope="col"
+                />
+                <th
+                  class="MuiTableCell-root MuiTableCell-head"
+                  scope="col"
+                >
+                  Indication
+                </th>
+                <th
+                  class="MuiTableCell-root MuiTableCell-head"
+                  scope="col"
+                >
+                  Reason
+                </th>
+                <th
+                  class="MuiTableCell-root MuiTableCell-head"
+                  scope="col"
+                >
+                  Recommendation
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              class="MuiTableBody-root"
+            >
+              <tr
+                class="MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body"
+                  scope="row"
+                >
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#assignment-distribution-matching-allocated"
+                    target="_blank"
+                  >
+                    Assignment distribution
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-218 makeStyles-deemphasized-219 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  <span
+                    class="makeStyles-tooltip-225"
+                    title="The smaller the p-value the more likely there is an issue."
+                  >
+                    p-value
+                  </span>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-218 makeStyles-deemphasized-219 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  1.0000
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body"
+                  scope="row"
+                >
+                  <span />
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-221 makeStyles-indicationSeverityOk-222 makeStyles-monospace-218 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  <span>
+                    nominal
+                  </span>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-218 makeStyles-deemphasized-219 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  0.05 &lt; x ≤ 1
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-219"
+                  scope="row"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1"
+                  />
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body"
+                  scope="row"
+                >
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#assigned-no-spammers-no-crossovers-distribution-matching-allocated"
+                    target="_blank"
+                  >
+                    Assignment distribution without crossovers and spammers
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-218 makeStyles-deemphasized-219 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  <span
+                    class="makeStyles-tooltip-225"
+                    title="The smaller the p-value the more likely there is an issue."
+                  >
+                    p-value
+                  </span>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-218 makeStyles-deemphasized-219 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  1.0000
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body"
+                  scope="row"
+                >
+                  <span />
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-221 makeStyles-indicationSeverityOk-222 makeStyles-monospace-218 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  <span>
+                    nominal
+                  </span>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-218 makeStyles-deemphasized-219 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  0.05 &lt; x ≤ 1
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-219"
+                  scope="row"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1"
+                  />
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body"
+                  scope="row"
+                >
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#total-crossovers"
+                    target="_blank"
+                  >
+                    Ratio of crossovers to assigned
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-218 makeStyles-deemphasized-219 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  <span>
+                    ratio
+                  </span>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-218 makeStyles-deemphasized-219 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  0.0000
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body"
+                  scope="row"
+                >
+                  <span />
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-221 makeStyles-indicationSeverityOk-222 makeStyles-monospace-218 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  <span>
+                    nominal
+                  </span>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-218 makeStyles-deemphasized-219 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  −∞ &lt; x ≤ 0.01
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-219"
+                  scope="row"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1"
+                  />
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body"
+                  scope="row"
+                >
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#total-spammers"
+                    target="_blank"
+                  >
+                    Ratio of spammers to assigned
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-218 makeStyles-deemphasized-219 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  <span>
+                    ratio
+                  </span>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-218 makeStyles-deemphasized-219 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  0.0000
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body"
+                  scope="row"
+                >
+                  <span />
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-221 makeStyles-indicationSeverityOk-222 makeStyles-monospace-218 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  <span>
+                    nominal
+                  </span>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-218 makeStyles-deemphasized-219 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  −∞ &lt; x ≤ 0.1
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-219"
+                  scope="row"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1"
+                  />
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body"
+                  scope="row"
+                >
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#kruschke-uncertainty"
+                    target="_blank"
+                  >
+                    Kruschke uncertainty (CI to ROPE ratio)
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-218 makeStyles-deemphasized-219 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  <span>
+                    ratio
+                  </span>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-218 makeStyles-deemphasized-219 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  0.1000
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body"
+                  scope="row"
+                >
+                  <span />
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-221 makeStyles-indicationSeverityOk-222 makeStyles-monospace-218 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  <span>
+                    nominal
+                  </span>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-218 makeStyles-deemphasized-219 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  −∞ &lt; x ≤ 0.8
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-219"
+                  scope="row"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1"
+                  />
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body"
+                  scope="row"
+                >
+                  <a
+                    class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                    href="https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#experiment-run-time"
+                    target="_blank"
+                  >
+                    Experiment run time
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-218 makeStyles-deemphasized-219 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  <span>
+                    days
+                  </span>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-218 makeStyles-deemphasized-219 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  0.0000
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body"
+                  scope="row"
+                >
+                  <span>
+                    ℹ️
+                  </span>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-221 makeStyles-indicationSeverityWarning-223 makeStyles-monospace-218 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  <span>
+                    very low
+                  </span>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-218 makeStyles-deemphasized-219 makeStyles-nowrap-220"
+                  scope="row"
+                >
+                  −∞ &lt; x ≤ 3
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-219"
+                  scope="row"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1"
+                  >
+                    Experiments should generally run for at least a week before drawing conclusions.
+                  </p>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
       <div
         class="makeStyles-accordions-205"
@@ -192,6 +1048,11 @@ exports[`allows you to change analysis strategy 1`] = `
                           />
                         </svg>
                       </div>
+                      <p
+                        class="MuiFormHelperText-root MuiFormHelperText-filled Mui-focused"
+                      >
+                        Updates the page data.
+                      </p>
                     </div>
                   </div>
                 </div>
@@ -347,161 +1208,6 @@ exports[`renders an appropriate message with no analyses 1`] = `
       <div
         class="makeStyles-accordions-17"
       >
-        <div
-          class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
-        >
-          <div
-            aria-disabled="false"
-            aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root"
-            role="button"
-            tabindex="0"
-          >
-            <div
-              class="MuiAccordionSummary-content"
-            >
-              <h5
-                class="MuiTypography-root MuiTypography-h5"
-              >
-                Advanced - Choose an Analysis Strategy
-              </h5>
-            </div>
-            <div
-              aria-disabled="false"
-              aria-hidden="true"
-              class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
-            >
-              <span
-                class="MuiIconButton-label"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
-                  />
-                </svg>
-              </span>
-              <span
-                class="MuiTouchRipple-root"
-              />
-            </div>
-          </div>
-          <div
-            class="MuiCollapse-container MuiCollapse-hidden"
-            style="min-height: 0px;"
-          >
-            <div
-              class="MuiCollapse-wrapper"
-            >
-              <div
-                class="MuiCollapse-wrapperInner"
-              >
-                <div
-                  role="region"
-                >
-                  <div
-                    class="MuiAccordionDetails-root makeStyles-accordionDetails-18"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                    >
-                      Choosing a different analysis strategy is useful for checking the effect of different modelling decisions on the results:
-                    </p>
-                    <ul>
-                      <li
-                        class="MuiTypography-root MuiTypography-body1"
-                      >
-                        <strong>
-                          All participants:
-                        </strong>
-                         All the participants are analysed based on their initial variation assignment. Pure intention-to-treat.
-                      </li>
-                      <li
-                        class="MuiTypography-root MuiTypography-body1"
-                      >
-                        <strong>
-                          Without crossovers:
-                        </strong>
-                         Same as all participants, but excluding participants that were assigned to multiple experiment variations before or on the analysis date (aka crossovers). Modified intention-to-treat.
-                      </li>
-                      <li
-                        class="MuiTypography-root MuiTypography-body1"
-                      >
-                        <strong>
-                          Without spammers:
-                        </strong>
-                         Same as all participants, but excluding participants that were flagged as spammers on the analysis date. Modified intention-to-treat.
-                      </li>
-                      <li
-                        class="MuiTypography-root MuiTypography-body1"
-                      >
-                        <strong>
-                          Without crossovers and spammers:
-                        </strong>
-                         Same as all participants, but excluding both spammers and crossovers. Modified intention-to-treat.
-                      </li>
-                      <li
-                        class="MuiTypography-root MuiTypography-body1"
-                      >
-                        <strong>
-                          Exposed without crossovers and spammers:
-                        </strong>
-                         Only participants that triggered one of the experiment's exposure events, excluding both spammers and crossovers. This analysis strategy is only available if the experiment has exposure events, while the other four strategies are used for every experiment. Naive per-protocol.
-                      </li>
-                    </ul>
-                    <div
-                      class="MuiFormControl-root"
-                    >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-                        data-shrink="true"
-                        for="strategy-selector"
-                        id="strategy-selector-label"
-                      >
-                        Analysis Strategy:
-                      </label>
-                      <div
-                        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                      >
-                        <div
-                          aria-haspopup="listbox"
-                          aria-labelledby="strategy-selector-label strategy-selector"
-                          class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-                          id="strategy-selector"
-                          role="button"
-                          tabindex="0"
-                        >
-                          Exposed without crossovers and spammers
-                           (recommended)
-                        </div>
-                        <input
-                          aria-hidden="true"
-                          class="MuiSelect-nativeInput"
-                          tabindex="-1"
-                          value="pp_naive"
-                        />
-                        <svg
-                          aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSelect-icon"
-                          focusable="false"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            d="M7 10l5 5 5-5z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
         <div
           class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
@@ -1714,6 +2420,11 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                         />
                       </svg>
                     </div>
+                    <p
+                      class="MuiFormHelperText-root MuiFormHelperText-filled"
+                    >
+                      Updates the page data.
+                    </p>
                   </div>
                 </div>
               </div>
@@ -3288,6 +3999,11 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                         />
                       </svg>
                     </div>
+                    <p
+                      class="MuiFormHelperText-root MuiFormHelperText-filled"
+                    >
+                      Updates the page data.
+                    </p>
                   </div>
                 </div>
               </div>
@@ -5276,6 +5992,11 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                         />
                       </svg>
                     </div>
+                    <p
+                      class="MuiFormHelperText-root MuiFormHelperText-filled"
+                    >
+                      Updates the page data.
+                    </p>
                   </div>
                 </div>
               </div>

--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -1,5 +1,195 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`allows you to change analysis strategy 1`] = `
+<div>
+  <div
+    class="analysis-latest-results"
+  >
+    <div
+      class="makeStyles-root-189"
+    >
+      <div
+        class="MuiPaper-root makeStyles-advancedControls-192 MuiPaper-elevation1 MuiPaper-rounded"
+      >
+        <div
+          class="MuiFormControl-root"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled Mui-focused Mui-focused"
+            data-shrink="true"
+            for="strategy-selector"
+            id="strategy-selector-label"
+          >
+            Analysis Strategy:
+          </label>
+          <div
+            class="MuiInputBase-root MuiInput-root MuiInput-underline Mui-focused Mui-focused MuiInputBase-formControl MuiInput-formControl"
+          >
+            <div
+              aria-haspopup="listbox"
+              aria-labelledby="strategy-selector-label strategy-selector"
+              class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+              id="strategy-selector"
+              role="button"
+              tabindex="0"
+            >
+              All participants
+            </div>
+            <input
+              aria-hidden="true"
+              class="MuiSelect-nativeInput"
+              tabindex="-1"
+              value="itt_pure"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSelect-icon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiPaper-root makeStyles-noAnalysesPaper-207 MuiPaper-elevation1 MuiPaper-rounded"
+      >
+        <h3
+          class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
+        >
+           
+          No Results
+           
+        </h3>
+        <p
+          class="MuiTypography-root MuiTypography-body1"
+        >
+          No results are available at the moment, this can be due to:
+        </p>
+        <ul>
+          <li
+            class="MuiTypography-root MuiTypography-body1"
+          >
+            <strong>
+               An experiment being new. 
+            </strong>
+             ExPlat can take 24-48 hours for results to process and become available. Updates are usually released at 06:00 UTC daily.
+          </li>
+          <li
+            class="MuiTypography-root MuiTypography-body1"
+          >
+            <strong>
+               No assignments occuring. 
+            </strong>
+             Check the "Early Monitoring" section below to ensure that assignments are occuring.
+          </li>
+        </ul>
+      </div>
+      <div
+        class="MuiPaper-root MuiAccordion-root makeStyles-accordion-205 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+      >
+        <div
+          aria-disabled="false"
+          aria-expanded="false"
+          class="MuiButtonBase-root MuiAccordionSummary-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiAccordionSummary-content"
+          >
+            <h5
+              class="MuiTypography-root MuiTypography-h5"
+            >
+              Early Monitoring - Live Assignment Event Flow
+            </h5>
+          </div>
+          <div
+            aria-disabled="false"
+            aria-hidden="true"
+            class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </div>
+        </div>
+        <div
+          class="MuiCollapse-container MuiCollapse-hidden"
+          style="min-height: 0px;"
+        >
+          <div
+            class="MuiCollapse-wrapper"
+          >
+            <div
+              class="MuiCollapse-wrapperInner"
+            >
+              <div
+                role="region"
+              >
+                <div
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-206"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1"
+                  >
+                    For early monitoring, you can run this query in Hue to retrieve unfiltered assignment counts from the unprocessed tracks queue.
+                  </p>
+                  <p
+                    class="MuiTypography-root MuiTypography-body1"
+                  >
+                    This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
+                  </p>
+                  <pre
+                    class="makeStyles-pre-208"
+                  >
+                    <code>
+                      with tracks_counts as (
+  select
+    cast(a8c.get_json_object(eventprops, '$.experiment_variation_id') as bigint) as experiment_variation_id,
+    count(distinct userid) as unique_users
+  from tracks.etl_events
+  where
+    eventname = 'wpcom_experiment_variation_assigned' and
+    eventprops like '%"experiment_id":"1"%'
+  group by experiment_variation_id
+)
+
+select
+  experiment_variations.name as variation_name,
+  unique_users
+from tracks_counts
+inner join wpcom.experiment_variations using (experiment_variation_id)
+                    </code>
+                  </pre>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders an appropriate message with no analyses 1`] = `
 <div>
   <div
@@ -8,6 +198,53 @@ exports[`renders an appropriate message with no analyses 1`] = `
     <div
       class="makeStyles-root-1"
     >
+      <div
+        class="MuiPaper-root makeStyles-advancedControls-4 MuiPaper-elevation1 MuiPaper-rounded"
+      >
+        <div
+          class="MuiFormControl-root"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+            data-shrink="true"
+            for="strategy-selector"
+            id="strategy-selector-label"
+          >
+            Analysis Strategy:
+          </label>
+          <div
+            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          >
+            <div
+              aria-haspopup="listbox"
+              aria-labelledby="strategy-selector-label strategy-selector"
+              class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+              id="strategy-selector"
+              role="button"
+              tabindex="0"
+            >
+              Exposed without crossovers and spammers
+               (recommended)
+            </div>
+            <input
+              aria-hidden="true"
+              class="MuiSelect-nativeInput"
+              tabindex="-1"
+              value="pp_naive"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSelect-icon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
       <div
         class="MuiPaper-root makeStyles-noAnalysesPaper-19 MuiPaper-elevation1 MuiPaper-rounded"
       >
@@ -151,6 +388,53 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
   <div
     class="makeStyles-root-22"
   >
+    <div
+      class="MuiPaper-root makeStyles-advancedControls-25 MuiPaper-elevation1 MuiPaper-rounded"
+    >
+      <div
+        class="MuiFormControl-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+          data-shrink="true"
+          for="strategy-selector"
+          id="strategy-selector-label"
+        >
+          Analysis Strategy:
+        </label>
+        <div
+          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+        >
+          <div
+            aria-haspopup="listbox"
+            aria-labelledby="strategy-selector-label strategy-selector"
+            class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+            id="strategy-selector"
+            role="button"
+            tabindex="0"
+          >
+            Exposed without crossovers and spammers
+             (recommended)
+          </div>
+          <input
+            aria-hidden="true"
+            class="MuiSelect-nativeInput"
+            tabindex="-1"
+            value="pp_naive"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSelect-icon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
     <div
       class="makeStyles-summary-24"
     >
@@ -1537,6 +1821,53 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   <div
     class="makeStyles-root-78"
   >
+    <div
+      class="MuiPaper-root makeStyles-advancedControls-81 MuiPaper-elevation1 MuiPaper-rounded"
+    >
+      <div
+        class="MuiFormControl-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+          data-shrink="true"
+          for="strategy-selector"
+          id="strategy-selector-label"
+        >
+          Analysis Strategy:
+        </label>
+        <div
+          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+        >
+          <div
+            aria-haspopup="listbox"
+            aria-labelledby="strategy-selector-label strategy-selector"
+            class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+            id="strategy-selector"
+            role="button"
+            tabindex="0"
+          >
+            Exposed without crossovers and spammers
+             (recommended)
+          </div>
+          <input
+            aria-hidden="true"
+            class="MuiSelect-nativeInput"
+            tabindex="-1"
+            value="pp_naive"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSelect-icon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
     <div
       class="makeStyles-summary-80"
     >
@@ -3366,6 +3697,53 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   <div
     class="makeStyles-root-134"
   >
+    <div
+      class="MuiPaper-root makeStyles-advancedControls-137 MuiPaper-elevation1 MuiPaper-rounded"
+    >
+      <div
+        class="MuiFormControl-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+          data-shrink="true"
+          for="strategy-selector"
+          id="strategy-selector-label"
+        >
+          Analysis Strategy:
+        </label>
+        <div
+          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+        >
+          <div
+            aria-haspopup="listbox"
+            aria-labelledby="strategy-selector-label strategy-selector"
+            class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+            id="strategy-selector"
+            role="button"
+            tabindex="0"
+          >
+            Exposed without crossovers and spammers
+             (recommended)
+          </div>
+          <input
+            aria-hidden="true"
+            class="MuiSelect-nativeInput"
+            tabindex="-1"
+            value="pp_naive"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSelect-icon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
     <div
       class="makeStyles-summary-136"
     >

--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -9,52 +9,6 @@ exports[`allows you to change analysis strategy 1`] = `
       class="makeStyles-root-189"
     >
       <div
-        class="MuiPaper-root makeStyles-advancedControls-192 MuiPaper-elevation1 MuiPaper-rounded"
-      >
-        <div
-          class="MuiFormControl-root"
-        >
-          <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled Mui-focused Mui-focused"
-            data-shrink="true"
-            for="strategy-selector"
-            id="strategy-selector-label"
-          >
-            Analysis Strategy:
-          </label>
-          <div
-            class="MuiInputBase-root MuiInput-root MuiInput-underline Mui-focused Mui-focused MuiInputBase-formControl MuiInput-formControl"
-          >
-            <div
-              aria-haspopup="listbox"
-              aria-labelledby="strategy-selector-label strategy-selector"
-              class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-              id="strategy-selector"
-              role="button"
-              tabindex="0"
-            >
-              All participants
-            </div>
-            <input
-              aria-hidden="true"
-              class="MuiSelect-nativeInput"
-              tabindex="-1"
-              value="itt_pure"
-            />
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSelect-icon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M7 10l5 5 5-5z"
-              />
-            </svg>
-          </div>
-        </div>
-      </div>
-      <div
         class="MuiPaper-root makeStyles-noAnalysesPaper-207 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
@@ -89,79 +43,236 @@ exports[`allows you to change analysis strategy 1`] = `
         </ul>
       </div>
       <div
-        class="MuiPaper-root MuiAccordion-root makeStyles-accordion-205 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+        class="makeStyles-accordions-205"
       >
         <div
-          aria-disabled="false"
-          aria-expanded="false"
-          class="MuiButtonBase-root MuiAccordionSummary-root"
-          role="button"
-          tabindex="0"
+          class="MuiPaper-root MuiAccordion-root Mui-expanded MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="MuiAccordionSummary-content"
+            aria-disabled="false"
+            aria-expanded="true"
+            class="MuiButtonBase-root MuiAccordionSummary-root Mui-expanded"
+            role="button"
+            tabindex="0"
           >
-            <h5
-              class="MuiTypography-root MuiTypography-h5"
+            <div
+              class="MuiAccordionSummary-content Mui-expanded"
             >
-              Early Monitoring - Live Assignment Event Flow
-            </h5>
+              <h5
+                class="MuiTypography-root MuiTypography-h5"
+              >
+                Advanced - Choose an Analysis Strategy
+              </h5>
+            </div>
+            <div
+              aria-disabled="false"
+              aria-hidden="true"
+              class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon Mui-expanded MuiIconButton-edgeEnd"
+            >
+              <span
+                class="MuiIconButton-label"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </div>
           </div>
           <div
-            aria-disabled="false"
-            aria-hidden="true"
-            class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
+            class="MuiCollapse-container MuiCollapse-entered"
+            style="min-height: 0px; height: auto; transition-duration: 0ms;"
           >
-            <span
-              class="MuiIconButton-label"
+            <div
+              class="MuiCollapse-wrapper"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <div
+                class="MuiCollapse-wrapperInner"
               >
-                <path
-                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
-                />
-              </svg>
-            </span>
-            <span
-              class="MuiTouchRipple-root"
-            />
+                <div
+                  role="region"
+                >
+                  <div
+                    class="MuiAccordionDetails-root makeStyles-accordionDetails-206"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      Choosing a different analysis strategy is useful for checking the effect of different modelling decisions on the results:
+                    </p>
+                    <ul>
+                      <li
+                        class="MuiTypography-root MuiTypography-body1"
+                      >
+                        <strong>
+                          All participants:
+                        </strong>
+                         All the participants are analysed based on their initial variation assignment. Pure intention-to-treat.
+                      </li>
+                      <li
+                        class="MuiTypography-root MuiTypography-body1"
+                      >
+                        <strong>
+                          Without crossovers:
+                        </strong>
+                         Same as all participants, but excluding participants that were assigned to multiple experiment variations before or on the analysis date (aka crossovers). Modified intention-to-treat.
+                      </li>
+                      <li
+                        class="MuiTypography-root MuiTypography-body1"
+                      >
+                        <strong>
+                          Without spammers:
+                        </strong>
+                         Same as all participants, but excluding participants that were flagged as spammers on the analysis date. Modified intention-to-treat.
+                      </li>
+                      <li
+                        class="MuiTypography-root MuiTypography-body1"
+                      >
+                        <strong>
+                          Without crossovers and spammers:
+                        </strong>
+                         Same as all participants, but excluding both spammers and crossovers. Modified intention-to-treat.
+                      </li>
+                      <li
+                        class="MuiTypography-root MuiTypography-body1"
+                      >
+                        <strong>
+                          Exposed without crossovers and spammers:
+                        </strong>
+                         Only participants that triggered one of the experiment's exposure events, excluding both spammers and crossovers. This analysis strategy is only available if the experiment has exposure events, while the other four strategies are used for every experiment. Naive per-protocol.
+                      </li>
+                    </ul>
+                    <div
+                      class="MuiFormControl-root"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled Mui-focused Mui-focused"
+                        data-shrink="true"
+                        for="strategy-selector"
+                        id="strategy-selector-label"
+                      >
+                        Analysis Strategy:
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInput-root MuiInput-underline Mui-focused Mui-focused MuiInputBase-formControl MuiInput-formControl"
+                      >
+                        <div
+                          aria-haspopup="listbox"
+                          aria-labelledby="strategy-selector-label strategy-selector"
+                          class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                          id="strategy-selector"
+                          role="button"
+                          tabindex="0"
+                        >
+                          All participants
+                        </div>
+                        <input
+                          aria-hidden="true"
+                          class="MuiSelect-nativeInput"
+                          tabindex="-1"
+                          value="itt_pure"
+                        />
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSelect-icon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M7 10l5 5 5-5z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
         <div
-          class="MuiCollapse-container MuiCollapse-hidden"
-          style="min-height: 0px;"
+          class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="MuiCollapse-wrapper"
+            aria-disabled="false"
+            aria-expanded="false"
+            class="MuiButtonBase-root MuiAccordionSummary-root"
+            role="button"
+            tabindex="0"
           >
             <div
-              class="MuiCollapse-wrapperInner"
+              class="MuiAccordionSummary-content"
+            >
+              <h5
+                class="MuiTypography-root MuiTypography-h5"
+              >
+                Early Monitoring - Live Assignment Event Flow
+              </h5>
+            </div>
+            <div
+              aria-disabled="false"
+              aria-hidden="true"
+              class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
+            >
+              <span
+                class="MuiIconButton-label"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </div>
+          </div>
+          <div
+            class="MuiCollapse-container MuiCollapse-hidden"
+            style="min-height: 0px;"
+          >
+            <div
+              class="MuiCollapse-wrapper"
             >
               <div
-                role="region"
+                class="MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-206"
+                  role="region"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body1"
+                  <div
+                    class="MuiAccordionDetails-root makeStyles-accordionDetails-206"
                   >
-                    For early monitoring, you can run this query in Hue to retrieve unfiltered assignment counts from the unprocessed tracks queue.
-                  </p>
-                  <p
-                    class="MuiTypography-root MuiTypography-body1"
-                  >
-                    This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
-                  </p>
-                  <pre
-                    class="makeStyles-pre-208"
-                  >
-                    <code>
-                      with tracks_counts as (
+                    <p
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      For early monitoring, you can run this query in Hue to retrieve unfiltered assignment counts from the unprocessed tracks queue.
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
+                    </p>
+                    <pre
+                      class="makeStyles-pre-208"
+                    >
+                      <code>
+                        with tracks_counts as (
   select
     cast(a8c.get_json_object(eventprops, '$.experiment_variation_id') as bigint) as experiment_variation_id,
     count(distinct userid) as unique_users
@@ -177,8 +288,9 @@ select
   unique_users
 from tracks_counts
 inner join wpcom.experiment_variations using (experiment_variation_id)
-                    </code>
-                  </pre>
+                      </code>
+                    </pre>
+                  </div>
                 </div>
               </div>
             </div>
@@ -198,53 +310,6 @@ exports[`renders an appropriate message with no analyses 1`] = `
     <div
       class="makeStyles-root-1"
     >
-      <div
-        class="MuiPaper-root makeStyles-advancedControls-4 MuiPaper-elevation1 MuiPaper-rounded"
-      >
-        <div
-          class="MuiFormControl-root"
-        >
-          <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-            data-shrink="true"
-            for="strategy-selector"
-            id="strategy-selector-label"
-          >
-            Analysis Strategy:
-          </label>
-          <div
-            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-          >
-            <div
-              aria-haspopup="listbox"
-              aria-labelledby="strategy-selector-label strategy-selector"
-              class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-              id="strategy-selector"
-              role="button"
-              tabindex="0"
-            >
-              Exposed without crossovers and spammers
-               (recommended)
-            </div>
-            <input
-              aria-hidden="true"
-              class="MuiSelect-nativeInput"
-              tabindex="-1"
-              value="pp_naive"
-            />
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSelect-icon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M7 10l5 5 5-5z"
-              />
-            </svg>
-          </div>
-        </div>
-      </div>
       <div
         class="MuiPaper-root makeStyles-noAnalysesPaper-19 MuiPaper-elevation1 MuiPaper-rounded"
       >
@@ -280,79 +345,237 @@ exports[`renders an appropriate message with no analyses 1`] = `
         </ul>
       </div>
       <div
-        class="MuiPaper-root MuiAccordion-root makeStyles-accordion-17 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+        class="makeStyles-accordions-17"
       >
         <div
-          aria-disabled="false"
-          aria-expanded="false"
-          class="MuiButtonBase-root MuiAccordionSummary-root"
-          role="button"
-          tabindex="0"
+          class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="MuiAccordionSummary-content"
+            aria-disabled="false"
+            aria-expanded="false"
+            class="MuiButtonBase-root MuiAccordionSummary-root"
+            role="button"
+            tabindex="0"
           >
-            <h5
-              class="MuiTypography-root MuiTypography-h5"
+            <div
+              class="MuiAccordionSummary-content"
             >
-              Early Monitoring - Live Assignment Event Flow
-            </h5>
+              <h5
+                class="MuiTypography-root MuiTypography-h5"
+              >
+                Advanced - Choose an Analysis Strategy
+              </h5>
+            </div>
+            <div
+              aria-disabled="false"
+              aria-hidden="true"
+              class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
+            >
+              <span
+                class="MuiIconButton-label"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </div>
           </div>
           <div
-            aria-disabled="false"
-            aria-hidden="true"
-            class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
+            class="MuiCollapse-container MuiCollapse-hidden"
+            style="min-height: 0px;"
           >
-            <span
-              class="MuiIconButton-label"
+            <div
+              class="MuiCollapse-wrapper"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <div
+                class="MuiCollapse-wrapperInner"
               >
-                <path
-                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
-                />
-              </svg>
-            </span>
-            <span
-              class="MuiTouchRipple-root"
-            />
+                <div
+                  role="region"
+                >
+                  <div
+                    class="MuiAccordionDetails-root makeStyles-accordionDetails-18"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      Choosing a different analysis strategy is useful for checking the effect of different modelling decisions on the results:
+                    </p>
+                    <ul>
+                      <li
+                        class="MuiTypography-root MuiTypography-body1"
+                      >
+                        <strong>
+                          All participants:
+                        </strong>
+                         All the participants are analysed based on their initial variation assignment. Pure intention-to-treat.
+                      </li>
+                      <li
+                        class="MuiTypography-root MuiTypography-body1"
+                      >
+                        <strong>
+                          Without crossovers:
+                        </strong>
+                         Same as all participants, but excluding participants that were assigned to multiple experiment variations before or on the analysis date (aka crossovers). Modified intention-to-treat.
+                      </li>
+                      <li
+                        class="MuiTypography-root MuiTypography-body1"
+                      >
+                        <strong>
+                          Without spammers:
+                        </strong>
+                         Same as all participants, but excluding participants that were flagged as spammers on the analysis date. Modified intention-to-treat.
+                      </li>
+                      <li
+                        class="MuiTypography-root MuiTypography-body1"
+                      >
+                        <strong>
+                          Without crossovers and spammers:
+                        </strong>
+                         Same as all participants, but excluding both spammers and crossovers. Modified intention-to-treat.
+                      </li>
+                      <li
+                        class="MuiTypography-root MuiTypography-body1"
+                      >
+                        <strong>
+                          Exposed without crossovers and spammers:
+                        </strong>
+                         Only participants that triggered one of the experiment's exposure events, excluding both spammers and crossovers. This analysis strategy is only available if the experiment has exposure events, while the other four strategies are used for every experiment. Naive per-protocol.
+                      </li>
+                    </ul>
+                    <div
+                      class="MuiFormControl-root"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                        data-shrink="true"
+                        for="strategy-selector"
+                        id="strategy-selector-label"
+                      >
+                        Analysis Strategy:
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                      >
+                        <div
+                          aria-haspopup="listbox"
+                          aria-labelledby="strategy-selector-label strategy-selector"
+                          class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                          id="strategy-selector"
+                          role="button"
+                          tabindex="0"
+                        >
+                          Exposed without crossovers and spammers
+                           (recommended)
+                        </div>
+                        <input
+                          aria-hidden="true"
+                          class="MuiSelect-nativeInput"
+                          tabindex="-1"
+                          value="pp_naive"
+                        />
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSelect-icon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M7 10l5 5 5-5z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
         <div
-          class="MuiCollapse-container MuiCollapse-hidden"
-          style="min-height: 0px;"
+          class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="MuiCollapse-wrapper"
+            aria-disabled="false"
+            aria-expanded="false"
+            class="MuiButtonBase-root MuiAccordionSummary-root"
+            role="button"
+            tabindex="0"
           >
             <div
-              class="MuiCollapse-wrapperInner"
+              class="MuiAccordionSummary-content"
+            >
+              <h5
+                class="MuiTypography-root MuiTypography-h5"
+              >
+                Early Monitoring - Live Assignment Event Flow
+              </h5>
+            </div>
+            <div
+              aria-disabled="false"
+              aria-hidden="true"
+              class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
+            >
+              <span
+                class="MuiIconButton-label"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </div>
+          </div>
+          <div
+            class="MuiCollapse-container MuiCollapse-hidden"
+            style="min-height: 0px;"
+          >
+            <div
+              class="MuiCollapse-wrapper"
             >
               <div
-                role="region"
+                class="MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-18"
+                  role="region"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body1"
+                  <div
+                    class="MuiAccordionDetails-root makeStyles-accordionDetails-18"
                   >
-                    For early monitoring, you can run this query in Hue to retrieve unfiltered assignment counts from the unprocessed tracks queue.
-                  </p>
-                  <p
-                    class="MuiTypography-root MuiTypography-body1"
-                  >
-                    This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
-                  </p>
-                  <pre
-                    class="makeStyles-pre-20"
-                  >
-                    <code>
-                      with tracks_counts as (
+                    <p
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      For early monitoring, you can run this query in Hue to retrieve unfiltered assignment counts from the unprocessed tracks queue.
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
+                    </p>
+                    <pre
+                      class="makeStyles-pre-20"
+                    >
+                      <code>
+                        with tracks_counts as (
   select
     cast(a8c.get_json_object(eventprops, '$.experiment_variation_id') as bigint) as experiment_variation_id,
     count(distinct userid) as unique_users
@@ -368,8 +591,9 @@ select
   unique_users
 from tracks_counts
 inner join wpcom.experiment_variations using (experiment_variation_id)
-                    </code>
-                  </pre>
+                      </code>
+                    </pre>
+                  </div>
                 </div>
               </div>
             </div>
@@ -388,53 +612,6 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
   <div
     class="makeStyles-root-22"
   >
-    <div
-      class="MuiPaper-root makeStyles-advancedControls-25 MuiPaper-elevation1 MuiPaper-rounded"
-    >
-      <div
-        class="MuiFormControl-root"
-      >
-        <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-          data-shrink="true"
-          for="strategy-selector"
-          id="strategy-selector-label"
-        >
-          Analysis Strategy:
-        </label>
-        <div
-          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        >
-          <div
-            aria-haspopup="listbox"
-            aria-labelledby="strategy-selector-label strategy-selector"
-            class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-            id="strategy-selector"
-            role="button"
-            tabindex="0"
-          >
-            Exposed without crossovers and spammers
-             (recommended)
-          </div>
-          <input
-            aria-hidden="true"
-            class="MuiSelect-nativeInput"
-            tabindex="-1"
-            value="pp_naive"
-          />
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSelect-icon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M7 10l5 5 5-5z"
-            />
-          </svg>
-        </div>
-      </div>
-    </div>
     <div
       class="makeStyles-summary-24"
     >
@@ -1387,79 +1564,237 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-38 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+      class="makeStyles-accordions-38"
     >
       <div
-        aria-disabled="false"
-        aria-expanded="false"
-        class="MuiButtonBase-root MuiAccordionSummary-root"
-        role="button"
-        tabindex="0"
+        class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
       >
         <div
-          class="MuiAccordionSummary-content"
+          aria-disabled="false"
+          aria-expanded="false"
+          class="MuiButtonBase-root MuiAccordionSummary-root"
+          role="button"
+          tabindex="0"
         >
-          <h5
-            class="MuiTypography-root MuiTypography-h5"
+          <div
+            class="MuiAccordionSummary-content"
           >
-            Early Monitoring - Live Assignment Event Flow
-          </h5>
+            <h5
+              class="MuiTypography-root MuiTypography-h5"
+            >
+              Advanced - Choose an Analysis Strategy
+            </h5>
+          </div>
+          <div
+            aria-disabled="false"
+            aria-hidden="true"
+            class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </div>
         </div>
         <div
-          aria-disabled="false"
-          aria-hidden="true"
-          class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
+          class="MuiCollapse-container MuiCollapse-hidden"
+          style="min-height: 0px;"
         >
-          <span
-            class="MuiIconButton-label"
+          <div
+            class="MuiCollapse-wrapper"
           >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root"
-              focusable="false"
-              viewBox="0 0 24 24"
+            <div
+              class="MuiCollapse-wrapperInner"
             >
-              <path
-                d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
-              />
-            </svg>
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
+              <div
+                role="region"
+              >
+                <div
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-39"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1"
+                  >
+                    Choosing a different analysis strategy is useful for checking the effect of different modelling decisions on the results:
+                  </p>
+                  <ul>
+                    <li
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      <strong>
+                        All participants:
+                      </strong>
+                       All the participants are analysed based on their initial variation assignment. Pure intention-to-treat.
+                    </li>
+                    <li
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      <strong>
+                        Without crossovers:
+                      </strong>
+                       Same as all participants, but excluding participants that were assigned to multiple experiment variations before or on the analysis date (aka crossovers). Modified intention-to-treat.
+                    </li>
+                    <li
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      <strong>
+                        Without spammers:
+                      </strong>
+                       Same as all participants, but excluding participants that were flagged as spammers on the analysis date. Modified intention-to-treat.
+                    </li>
+                    <li
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      <strong>
+                        Without crossovers and spammers:
+                      </strong>
+                       Same as all participants, but excluding both spammers and crossovers. Modified intention-to-treat.
+                    </li>
+                    <li
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      <strong>
+                        Exposed without crossovers and spammers:
+                      </strong>
+                       Only participants that triggered one of the experiment's exposure events, excluding both spammers and crossovers. This analysis strategy is only available if the experiment has exposure events, while the other four strategies are used for every experiment. Naive per-protocol.
+                    </li>
+                  </ul>
+                  <div
+                    class="MuiFormControl-root"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                      data-shrink="true"
+                      for="strategy-selector"
+                      id="strategy-selector-label"
+                    >
+                      Analysis Strategy:
+                    </label>
+                    <div
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                    >
+                      <div
+                        aria-haspopup="listbox"
+                        aria-labelledby="strategy-selector-label strategy-selector"
+                        class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                        id="strategy-selector"
+                        role="button"
+                        tabindex="0"
+                      >
+                        Exposed without crossovers and spammers
+                         (recommended)
+                      </div>
+                      <input
+                        aria-hidden="true"
+                        class="MuiSelect-nativeInput"
+                        tabindex="-1"
+                        value="pp_naive"
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSelect-icon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M7 10l5 5 5-5z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
       <div
-        class="MuiCollapse-container MuiCollapse-hidden"
-        style="min-height: 0px;"
+        class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
       >
         <div
-          class="MuiCollapse-wrapper"
+          aria-disabled="false"
+          aria-expanded="false"
+          class="MuiButtonBase-root MuiAccordionSummary-root"
+          role="button"
+          tabindex="0"
         >
           <div
-            class="MuiCollapse-wrapperInner"
+            class="MuiAccordionSummary-content"
+          >
+            <h5
+              class="MuiTypography-root MuiTypography-h5"
+            >
+              Early Monitoring - Live Assignment Event Flow
+            </h5>
+          </div>
+          <div
+            aria-disabled="false"
+            aria-hidden="true"
+            class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </div>
+        </div>
+        <div
+          class="MuiCollapse-container MuiCollapse-hidden"
+          style="min-height: 0px;"
+        >
+          <div
+            class="MuiCollapse-wrapper"
           >
             <div
-              role="region"
+              class="MuiCollapse-wrapperInner"
             >
               <div
-                class="MuiAccordionDetails-root makeStyles-accordionDetails-39"
+                role="region"
               >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
+                <div
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-39"
                 >
-                  For early monitoring, you can run this query in Hue to retrieve unfiltered assignment counts from the unprocessed tracks queue.
-                </p>
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                >
-                  This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
-                </p>
-                <pre
-                  class="makeStyles-pre-41"
-                >
-                  <code>
-                    with tracks_counts as (
+                  <p
+                    class="MuiTypography-root MuiTypography-body1"
+                  >
+                    For early monitoring, you can run this query in Hue to retrieve unfiltered assignment counts from the unprocessed tracks queue.
+                  </p>
+                  <p
+                    class="MuiTypography-root MuiTypography-body1"
+                  >
+                    This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
+                  </p>
+                  <pre
+                    class="makeStyles-pre-41"
+                  >
+                    <code>
+                      with tracks_counts as (
   select
     cast(a8c.get_json_object(eventprops, '$.experiment_variation_id') as bigint) as experiment_variation_id,
     count(distinct userid) as unique_users
@@ -1475,8 +1810,9 @@ select
   unique_users
 from tracks_counts
 inner join wpcom.experiment_variations using (experiment_variation_id)
-                  </code>
-                </pre>
+                    </code>
+                  </pre>
+                </div>
               </div>
             </div>
           </div>
@@ -1821,53 +2157,6 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   <div
     class="makeStyles-root-78"
   >
-    <div
-      class="MuiPaper-root makeStyles-advancedControls-81 MuiPaper-elevation1 MuiPaper-rounded"
-    >
-      <div
-        class="MuiFormControl-root"
-      >
-        <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-          data-shrink="true"
-          for="strategy-selector"
-          id="strategy-selector-label"
-        >
-          Analysis Strategy:
-        </label>
-        <div
-          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        >
-          <div
-            aria-haspopup="listbox"
-            aria-labelledby="strategy-selector-label strategy-selector"
-            class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-            id="strategy-selector"
-            role="button"
-            tabindex="0"
-          >
-            Exposed without crossovers and spammers
-             (recommended)
-          </div>
-          <input
-            aria-hidden="true"
-            class="MuiSelect-nativeInput"
-            tabindex="-1"
-            value="pp_naive"
-          />
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSelect-icon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M7 10l5 5 5-5z"
-            />
-          </svg>
-        </div>
-      </div>
-    </div>
     <div
       class="makeStyles-summary-80"
     >
@@ -2849,79 +3138,237 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-94 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+      class="makeStyles-accordions-94"
     >
       <div
-        aria-disabled="false"
-        aria-expanded="false"
-        class="MuiButtonBase-root MuiAccordionSummary-root"
-        role="button"
-        tabindex="0"
+        class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
       >
         <div
-          class="MuiAccordionSummary-content"
+          aria-disabled="false"
+          aria-expanded="false"
+          class="MuiButtonBase-root MuiAccordionSummary-root"
+          role="button"
+          tabindex="0"
         >
-          <h5
-            class="MuiTypography-root MuiTypography-h5"
+          <div
+            class="MuiAccordionSummary-content"
           >
-            Early Monitoring - Live Assignment Event Flow
-          </h5>
+            <h5
+              class="MuiTypography-root MuiTypography-h5"
+            >
+              Advanced - Choose an Analysis Strategy
+            </h5>
+          </div>
+          <div
+            aria-disabled="false"
+            aria-hidden="true"
+            class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </div>
         </div>
         <div
-          aria-disabled="false"
-          aria-hidden="true"
-          class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
+          class="MuiCollapse-container MuiCollapse-hidden"
+          style="min-height: 0px;"
         >
-          <span
-            class="MuiIconButton-label"
+          <div
+            class="MuiCollapse-wrapper"
           >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root"
-              focusable="false"
-              viewBox="0 0 24 24"
+            <div
+              class="MuiCollapse-wrapperInner"
             >
-              <path
-                d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
-              />
-            </svg>
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
+              <div
+                role="region"
+              >
+                <div
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-95"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1"
+                  >
+                    Choosing a different analysis strategy is useful for checking the effect of different modelling decisions on the results:
+                  </p>
+                  <ul>
+                    <li
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      <strong>
+                        All participants:
+                      </strong>
+                       All the participants are analysed based on their initial variation assignment. Pure intention-to-treat.
+                    </li>
+                    <li
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      <strong>
+                        Without crossovers:
+                      </strong>
+                       Same as all participants, but excluding participants that were assigned to multiple experiment variations before or on the analysis date (aka crossovers). Modified intention-to-treat.
+                    </li>
+                    <li
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      <strong>
+                        Without spammers:
+                      </strong>
+                       Same as all participants, but excluding participants that were flagged as spammers on the analysis date. Modified intention-to-treat.
+                    </li>
+                    <li
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      <strong>
+                        Without crossovers and spammers:
+                      </strong>
+                       Same as all participants, but excluding both spammers and crossovers. Modified intention-to-treat.
+                    </li>
+                    <li
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      <strong>
+                        Exposed without crossovers and spammers:
+                      </strong>
+                       Only participants that triggered one of the experiment's exposure events, excluding both spammers and crossovers. This analysis strategy is only available if the experiment has exposure events, while the other four strategies are used for every experiment. Naive per-protocol.
+                    </li>
+                  </ul>
+                  <div
+                    class="MuiFormControl-root"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                      data-shrink="true"
+                      for="strategy-selector"
+                      id="strategy-selector-label"
+                    >
+                      Analysis Strategy:
+                    </label>
+                    <div
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                    >
+                      <div
+                        aria-haspopup="listbox"
+                        aria-labelledby="strategy-selector-label strategy-selector"
+                        class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                        id="strategy-selector"
+                        role="button"
+                        tabindex="0"
+                      >
+                        Exposed without crossovers and spammers
+                         (recommended)
+                      </div>
+                      <input
+                        aria-hidden="true"
+                        class="MuiSelect-nativeInput"
+                        tabindex="-1"
+                        value="pp_naive"
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSelect-icon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M7 10l5 5 5-5z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
       <div
-        class="MuiCollapse-container MuiCollapse-hidden"
-        style="min-height: 0px;"
+        class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
       >
         <div
-          class="MuiCollapse-wrapper"
+          aria-disabled="false"
+          aria-expanded="false"
+          class="MuiButtonBase-root MuiAccordionSummary-root"
+          role="button"
+          tabindex="0"
         >
           <div
-            class="MuiCollapse-wrapperInner"
+            class="MuiAccordionSummary-content"
+          >
+            <h5
+              class="MuiTypography-root MuiTypography-h5"
+            >
+              Early Monitoring - Live Assignment Event Flow
+            </h5>
+          </div>
+          <div
+            aria-disabled="false"
+            aria-hidden="true"
+            class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </div>
+        </div>
+        <div
+          class="MuiCollapse-container MuiCollapse-hidden"
+          style="min-height: 0px;"
+        >
+          <div
+            class="MuiCollapse-wrapper"
           >
             <div
-              role="region"
+              class="MuiCollapse-wrapperInner"
             >
               <div
-                class="MuiAccordionDetails-root makeStyles-accordionDetails-95"
+                role="region"
               >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
+                <div
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-95"
                 >
-                  For early monitoring, you can run this query in Hue to retrieve unfiltered assignment counts from the unprocessed tracks queue.
-                </p>
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                >
-                  This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
-                </p>
-                <pre
-                  class="makeStyles-pre-97"
-                >
-                  <code>
-                    with tracks_counts as (
+                  <p
+                    class="MuiTypography-root MuiTypography-body1"
+                  >
+                    For early monitoring, you can run this query in Hue to retrieve unfiltered assignment counts from the unprocessed tracks queue.
+                  </p>
+                  <p
+                    class="MuiTypography-root MuiTypography-body1"
+                  >
+                    This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
+                  </p>
+                  <pre
+                    class="makeStyles-pre-97"
+                  >
+                    <code>
+                      with tracks_counts as (
   select
     cast(a8c.get_json_object(eventprops, '$.experiment_variation_id') as bigint) as experiment_variation_id,
     count(distinct userid) as unique_users
@@ -2937,8 +3384,9 @@ select
   unique_users
 from tracks_counts
 inner join wpcom.experiment_variations using (experiment_variation_id)
-                  </code>
-                </pre>
+                    </code>
+                  </pre>
+                </div>
               </div>
             </div>
           </div>
@@ -3697,53 +4145,6 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   <div
     class="makeStyles-root-134"
   >
-    <div
-      class="MuiPaper-root makeStyles-advancedControls-137 MuiPaper-elevation1 MuiPaper-rounded"
-    >
-      <div
-        class="MuiFormControl-root"
-      >
-        <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-          data-shrink="true"
-          for="strategy-selector"
-          id="strategy-selector-label"
-        >
-          Analysis Strategy:
-        </label>
-        <div
-          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        >
-          <div
-            aria-haspopup="listbox"
-            aria-labelledby="strategy-selector-label strategy-selector"
-            class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-            id="strategy-selector"
-            role="button"
-            tabindex="0"
-          >
-            Exposed without crossovers and spammers
-             (recommended)
-          </div>
-          <input
-            aria-hidden="true"
-            class="MuiSelect-nativeInput"
-            tabindex="-1"
-            value="pp_naive"
-          />
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSelect-icon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M7 10l5 5 5-5z"
-            />
-          </svg>
-        </div>
-      </div>
-    </div>
     <div
       class="makeStyles-summary-136"
     >
@@ -4725,79 +5126,237 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-150 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+      class="makeStyles-accordions-150"
     >
       <div
-        aria-disabled="false"
-        aria-expanded="false"
-        class="MuiButtonBase-root MuiAccordionSummary-root"
-        role="button"
-        tabindex="0"
+        class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
       >
         <div
-          class="MuiAccordionSummary-content"
+          aria-disabled="false"
+          aria-expanded="false"
+          class="MuiButtonBase-root MuiAccordionSummary-root"
+          role="button"
+          tabindex="0"
         >
-          <h5
-            class="MuiTypography-root MuiTypography-h5"
+          <div
+            class="MuiAccordionSummary-content"
           >
-            Early Monitoring - Live Assignment Event Flow
-          </h5>
+            <h5
+              class="MuiTypography-root MuiTypography-h5"
+            >
+              Advanced - Choose an Analysis Strategy
+            </h5>
+          </div>
+          <div
+            aria-disabled="false"
+            aria-hidden="true"
+            class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </div>
         </div>
         <div
-          aria-disabled="false"
-          aria-hidden="true"
-          class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
+          class="MuiCollapse-container MuiCollapse-hidden"
+          style="min-height: 0px;"
         >
-          <span
-            class="MuiIconButton-label"
+          <div
+            class="MuiCollapse-wrapper"
           >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root"
-              focusable="false"
-              viewBox="0 0 24 24"
+            <div
+              class="MuiCollapse-wrapperInner"
             >
-              <path
-                d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
-              />
-            </svg>
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
+              <div
+                role="region"
+              >
+                <div
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-151"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1"
+                  >
+                    Choosing a different analysis strategy is useful for checking the effect of different modelling decisions on the results:
+                  </p>
+                  <ul>
+                    <li
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      <strong>
+                        All participants:
+                      </strong>
+                       All the participants are analysed based on their initial variation assignment. Pure intention-to-treat.
+                    </li>
+                    <li
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      <strong>
+                        Without crossovers:
+                      </strong>
+                       Same as all participants, but excluding participants that were assigned to multiple experiment variations before or on the analysis date (aka crossovers). Modified intention-to-treat.
+                    </li>
+                    <li
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      <strong>
+                        Without spammers:
+                      </strong>
+                       Same as all participants, but excluding participants that were flagged as spammers on the analysis date. Modified intention-to-treat.
+                    </li>
+                    <li
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      <strong>
+                        Without crossovers and spammers:
+                      </strong>
+                       Same as all participants, but excluding both spammers and crossovers. Modified intention-to-treat.
+                    </li>
+                    <li
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      <strong>
+                        Exposed without crossovers and spammers:
+                      </strong>
+                       Only participants that triggered one of the experiment's exposure events, excluding both spammers and crossovers. This analysis strategy is only available if the experiment has exposure events, while the other four strategies are used for every experiment. Naive per-protocol.
+                    </li>
+                  </ul>
+                  <div
+                    class="MuiFormControl-root"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                      data-shrink="true"
+                      for="strategy-selector"
+                      id="strategy-selector-label"
+                    >
+                      Analysis Strategy:
+                    </label>
+                    <div
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                    >
+                      <div
+                        aria-haspopup="listbox"
+                        aria-labelledby="strategy-selector-label strategy-selector"
+                        class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                        id="strategy-selector"
+                        role="button"
+                        tabindex="0"
+                      >
+                        Exposed without crossovers and spammers
+                         (recommended)
+                      </div>
+                      <input
+                        aria-hidden="true"
+                        class="MuiSelect-nativeInput"
+                        tabindex="-1"
+                        value="pp_naive"
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSelect-icon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M7 10l5 5 5-5z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
       <div
-        class="MuiCollapse-container MuiCollapse-hidden"
-        style="min-height: 0px;"
+        class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
       >
         <div
-          class="MuiCollapse-wrapper"
+          aria-disabled="false"
+          aria-expanded="false"
+          class="MuiButtonBase-root MuiAccordionSummary-root"
+          role="button"
+          tabindex="0"
         >
           <div
-            class="MuiCollapse-wrapperInner"
+            class="MuiAccordionSummary-content"
+          >
+            <h5
+              class="MuiTypography-root MuiTypography-h5"
+            >
+              Early Monitoring - Live Assignment Event Flow
+            </h5>
+          </div>
+          <div
+            aria-disabled="false"
+            aria-hidden="true"
+            class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </div>
+        </div>
+        <div
+          class="MuiCollapse-container MuiCollapse-hidden"
+          style="min-height: 0px;"
+        >
+          <div
+            class="MuiCollapse-wrapper"
           >
             <div
-              role="region"
+              class="MuiCollapse-wrapperInner"
             >
               <div
-                class="MuiAccordionDetails-root makeStyles-accordionDetails-151"
+                role="region"
               >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
+                <div
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-151"
                 >
-                  For early monitoring, you can run this query in Hue to retrieve unfiltered assignment counts from the unprocessed tracks queue.
-                </p>
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                >
-                  This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
-                </p>
-                <pre
-                  class="makeStyles-pre-153"
-                >
-                  <code>
-                    with tracks_counts as (
+                  <p
+                    class="MuiTypography-root MuiTypography-body1"
+                  >
+                    For early monitoring, you can run this query in Hue to retrieve unfiltered assignment counts from the unprocessed tracks queue.
+                  </p>
+                  <p
+                    class="MuiTypography-root MuiTypography-body1"
+                  >
+                    This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
+                  </p>
+                  <pre
+                    class="makeStyles-pre-153"
+                  >
+                    <code>
+                      with tracks_counts as (
   select
     cast(a8c.get_json_object(eventprops, '$.experiment_variation_id') as bigint) as experiment_variation_id,
     count(distinct userid) as unique_users
@@ -4813,8 +5372,9 @@ select
   unique_users
 from tracks_counts
 inner join wpcom.experiment_variations using (experiment_variation_id)
-                  </code>
-                </pre>
+                    </code>
+                  </pre>
+                </div>
               </div>
             </div>
           </div>

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -17,7 +17,7 @@ export function createUnresolvingPromise<T>(): Promise<T> {
   return new Promise<T>(() => null)
 }
 
-const debugModeLocalStorageKey = 'abacus-debug-mode'
+const debugModeLocalStorageKey = `Rob, this totally isn't the debug mode.`
 
 // istanbul ignore next; Debug only
 export function isDebugMode(): boolean {


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR makes the analysis strategy switch generally available:**
- Limits the options to what is available
- Specifies which option is recommended
- Changes the debug mode key, hiding it again from experimenters.
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Can't find a reference in slack, I think me and Yanir talked about opening it up in our 1:1?
- Experimenters already know about it.
- It is educational being able to explore it.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
