### PR TITLE
Update bookmarklet to pass in anon ID

### DIFF
--- a/src/components/experiments/single-view/overview/VariationsTable.tsx
+++ b/src/components/experiments/single-view/overview/VariationsTable.tsx
@@ -47,6 +47,7 @@ function assignmentHref(variationName: string, experimentName: string) {
   nameSchema.validateSync(variationName)
   return `javascript:(async () => {
     const token = JSON.parse(localStorage.getItem('experiments_auth_info'));
+    const anonId = document.cookie.match('(^|;)\\\\s*tk_ai\\\\s*=\\\\s*([^;]+)')?.pop() || '';
     const headers = {'Content-Type': 'application/json'};
     if (token && token.accessToken) {
        headers.Authorization = 'Bearer ' + token['accessToken'];
@@ -57,7 +58,7 @@ function assignmentHref(variationName: string, experimentName: string) {
         credentials: 'include', 
         method: 'PATCH', 
         headers, 
-        body: JSON.stringify({variations: {${experimentName}: '${variationName}'}})
+        body: JSON.stringify({variations: {${experimentName}: '${variationName}'}, anon_id: anonId})
       }
     );
     const responseBody = await response.json();
@@ -71,30 +72,21 @@ function assignmentHref(variationName: string, experimentName: string) {
       case 'user_not_assignable':
         alert('You must be proxied or sandboxed to use this bookmark');
         break;
+      case 'invalid_ids':
+        alert('To assign yourself, you must run this from Abacus.\\n\\nTo assign the current anonymous user, verify ' +
+              'that Tracks is not blocked and run in an environment where the tk_ai cookie is set.');
+        break;
       default:
         if (!responseBody.variations) {
           alert('An unknown error occurred: ' + responseBody.message);
           break;
         }
-        const duration = responseBody.duration === 'unlimited' ?
-          responseBody.duration : Math.ceil(responseBody.duration / 60 / 60);
-
-        if (responseBody.storage_method === 'cookie') {
-          window.localStorage.setItem(
-            'explat-experiment--${experimentName}',
-            JSON.stringify(
-              {
-                'experimentName':'${experimentName}',
-                'variationName': '${variationName}',
-                'retrievedTimestamp': Date.now(),
-                'ttl': responseBody.duration === 'unlimited' ? Infinity : responseBody.duration,
-              }
-            )
-          );
-
-          alert('ExPlat: Successful Assignment\\n–––––––––––––––––––––––––––––\\n\\nExperiment: ${experimentName}\\nVariation: ${variationName}\\n\\nMethod: Logged-out assignment, expires in ' + duration + ' hours\\nClient-side: Applies to the current domain (LocalStorage).\\nServer-side: Applies to current session (Cookie).');
+        const baseMessage = 'ExPlat: Successful Assignment\\n–––––––––––––––––––––––––––––\\n\\n' +
+          'Experiment: ${experimentName}\\nVariation: ${variationName}\\n\\n';
+        if (responseBody.storage_method === 'anon_sqooped_out_table') {
+          alert(baseMessage + 'Method: Logged-out assignment\\nApplies to the current anon user.');
         } else {
-          alert('ExPlat: Successful Assignment\\n–––––––––––––––––––––––––––––\\n\\nExperiment: ${experimentName}\\nVariation: ${variationName}\\n\\nMethod: Logged-in assignment\\nApplies to the current logged-in user.');
+          alert(baseMessage + 'Method: Logged-in assignment\\nApplies to the current logged-in user.');
         }
     }
 })()`

--- a/src/components/experiments/single-view/overview/VariationsTable.tsx
+++ b/src/components/experiments/single-view/overview/VariationsTable.tsx
@@ -54,12 +54,13 @@ function assignmentHref(variationName: string, experimentName: string) {
        headers.Authorization = 'Bearer ' + token['accessToken'];
     }
     const response = await fetch(
-      'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments', 
+      /* The anonId is URI encoded by the server or Tracks client, so appending it to the API call should just work. */
+      'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments?anon_id=' + anonId, 
       {
         credentials: 'include', 
         method: 'PATCH', 
         headers, 
-        body: JSON.stringify({variations: {${experimentName}: '${variationName}'}, anon_id: anonId})
+        body: JSON.stringify({variations: {${experimentName}: '${variationName}'}})
       }
     );
     const responseBody = await response.json();

--- a/src/components/experiments/single-view/overview/VariationsTable.tsx
+++ b/src/components/experiments/single-view/overview/VariationsTable.tsx
@@ -48,19 +48,18 @@ function assignmentHref(variationName: string, experimentName: string) {
   nameSchema.validateSync(variationName)
   return `javascript:(async () => {
     const token = JSON.parse(localStorage.getItem('experiments_auth_info'));
-    const anonId = document.cookie.match('(^|;)\\\\s*tk_ai\\\\s*=\\\\s*([^;]+)')?.pop() || '';
+    const anonId = decodeURIComponent(document.cookie.match('(^|;)\\\\s*tk_ai\\\\s*=\\\\s*([^;]+)')?.pop() || '');
     const headers = {'Content-Type': 'application/json'};
     if (token && token.accessToken) {
        headers.Authorization = 'Bearer ' + token['accessToken'];
     }
     const response = await fetch(
-      /* The anonId is URI encoded by the server or Tracks client, so appending it to the API call should just work. */
-      'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments?anon_id=' + anonId, 
+      'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments', 
       {
         credentials: 'include', 
         method: 'PATCH', 
         headers, 
-        body: JSON.stringify({variations: {${experimentName}: '${variationName}'}})
+        body: JSON.stringify({variations: {${experimentName}: '${variationName}'}, anon_id: anonId})
       }
     );
     const responseBody = await response.json();

--- a/src/components/experiments/single-view/overview/VariationsTable.tsx
+++ b/src/components/experiments/single-view/overview/VariationsTable.tsx
@@ -84,7 +84,7 @@ function assignmentHref(variationName: string, experimentName: string) {
         const baseMessage = 'ExPlat: Successful Assignment\\n–––––––––––––––––––––––––––––\\n\\n' +
           'Experiment: ${experimentName}\\nVariation: ${variationName}\\n\\n';
         if (responseBody.storage_method === 'anon_sqooped_out_table') {
-          alert(baseMessage + 'Method: Logged-out assignment\\nApplies to the current anon user.');
+          alert(baseMessage + 'Method: Logged-out assignment\\nApplies to the current anon user (tk_ai cookie).');
         } else {
           alert(baseMessage + 'Method: Logged-in assignment\\nApplies to the current logged-in user.');
         }


### PR DESCRIPTION
As part of the change to backend storage systems, update the bookmarklet code to pass in the anon ID from the `tk_ai` cookie (if available) and handle the updated return values from D62396-code.

## How has this been tested?

Applied D62396-code on the backend, sandboxed the API, and tested three scenarios on a production A/A experiment:
* Authenticated user in Abacus
* A page with logged out IDs and a correct `tk_ai` cookie (e.g., logged out WP.com)
* No IDs passed in (e.g., a non-WP.com site)

Checked that the backend tables get written as expected.