### PR TITLE
Move attribution window and change "attribute" styling

### DIFF
--- a/src/components/experiments/single-view/overview/MetricAssignmentsPanel.test.tsx
+++ b/src/components/experiments/single-view/overview/MetricAssignmentsPanel.test.tsx
@@ -106,20 +106,30 @@ test('renders as expected with all metrics resolvable', () => {
               class="MuiTableRow-root"
             >
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-2"
+                class="MuiTableCell-root MuiTableCell-body"
               >
-                metric_1
-                <br />
-                <div
-                  aria-disabled="true"
-                  class="MuiChip-root makeStyles-primaryChip-7 MuiChip-outlined Mui-disabled"
+                <strong
+                  class="makeStyles-monospace-2"
                 >
-                  <span
-                    class="MuiChip-label"
+                  metric_1
+                  <br />
+                  <div
+                    aria-disabled="true"
+                    class="MuiChip-root makeStyles-primaryChip-7 MuiChip-outlined Mui-disabled"
                   >
-                    Primary
-                  </span>
-                </div>
+                    <span
+                      class="MuiChip-label"
+                    >
+                      Primary
+                    </span>
+                  </div>
+                </strong>
+                <br />
+                <small
+                  class="makeStyles-monospace-2"
+                >
+                  This is metric 1
+                </small>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-2"
@@ -148,10 +158,20 @@ test('renders as expected with all metrics resolvable', () => {
               class="MuiTableRow-root"
             >
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-2"
+                class="MuiTableCell-root MuiTableCell-body"
               >
-                metric_2
+                <strong
+                  class="makeStyles-monospace-2"
+                >
+                  metric_2
+                  <br />
+                </strong>
                 <br />
+                <small
+                  class="makeStyles-monospace-2"
+                >
+                  This is metric 2
+                </small>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-2"
@@ -175,10 +195,20 @@ test('renders as expected with all metrics resolvable', () => {
               class="MuiTableRow-root"
             >
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-2"
+                class="MuiTableCell-root MuiTableCell-body"
               >
-                metric_2
+                <strong
+                  class="makeStyles-monospace-2"
+                >
+                  metric_2
+                  <br />
+                </strong>
                 <br />
+                <small
+                  class="makeStyles-monospace-2"
+                >
+                  This is metric 2
+                </small>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-2"
@@ -202,10 +232,20 @@ test('renders as expected with all metrics resolvable', () => {
               class="MuiTableRow-root"
             >
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-2"
+                class="MuiTableCell-root MuiTableCell-body"
               >
-                metric_3
+                <strong
+                  class="makeStyles-monospace-2"
+                >
+                  metric_3
+                  <br />
+                </strong>
                 <br />
+                <small
+                  class="makeStyles-monospace-2"
+                >
+                  This is metric 3
+                </small>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-2"

--- a/src/components/experiments/single-view/overview/MetricAssignmentsPanel.test.tsx
+++ b/src/components/experiments/single-view/overview/MetricAssignmentsPanel.test.tsx
@@ -112,17 +112,12 @@ test('renders as expected with all metrics resolvable', () => {
                   class="makeStyles-monospace-2"
                 >
                   metric_1
-                  <br />
-                  <div
-                    aria-disabled="true"
-                    class="MuiChip-root makeStyles-primaryChip-7 MuiChip-outlined Mui-disabled"
+                   
+                  <span
+                    class="makeStyles-root-7"
                   >
-                    <span
-                      class="MuiChip-label"
-                    >
-                      Primary
-                    </span>
-                  </div>
+                    primary
+                  </span>
                 </strong>
                 <br />
                 <small
@@ -164,7 +159,7 @@ test('renders as expected with all metrics resolvable', () => {
                   class="makeStyles-monospace-2"
                 >
                   metric_2
-                  <br />
+                   
                 </strong>
                 <br />
                 <small
@@ -201,7 +196,7 @@ test('renders as expected with all metrics resolvable', () => {
                   class="makeStyles-monospace-2"
                 >
                   metric_2
-                  <br />
+                   
                 </strong>
                 <br />
                 <small
@@ -238,7 +233,7 @@ test('renders as expected with all metrics resolvable', () => {
                   class="makeStyles-monospace-2"
                 >
                   metric_3
-                  <br />
+                   
                 </strong>
                 <br />
                 <small

--- a/src/components/experiments/single-view/overview/MetricAssignmentsPanel.tsx
+++ b/src/components/experiments/single-view/overview/MetricAssignmentsPanel.tsx
@@ -198,12 +198,16 @@ function MetricAssignmentsPanel({
         <TableBody>
           {resolvedMetricAssignments.map((resolvedMetricAssignment) => (
             <TableRow key={resolvedMetricAssignment.metricAssignmentId}>
-              <TableCell className={classes.monospace}>
-                {resolvedMetricAssignment.metric.name}
+              <TableCell>
+                <strong className={classes.monospace}>
+                  {resolvedMetricAssignment.metric.name}
+                  <br />
+                  {resolvedMetricAssignment.isPrimary && (
+                    <Chip label='Primary' variant='outlined' disabled className={classes.primaryChip} />
+                  )}
+                </strong>
                 <br />
-                {resolvedMetricAssignment.isPrimary && (
-                  <Chip label='Primary' variant='outlined' disabled className={classes.primaryChip} />
-                )}
+                <small className={classes.monospace}>{resolvedMetricAssignment.metric.description}</small>
               </TableCell>
               <TableCell className={classes.monospace}>
                 {AttributionWindowSecondsToHuman[resolvedMetricAssignment.attributionWindowSeconds]}

--- a/src/components/experiments/single-view/overview/MetricAssignmentsPanel.tsx
+++ b/src/components/experiments/single-view/overview/MetricAssignmentsPanel.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  Chip,
   Dialog,
   DialogActions,
   DialogContent,
@@ -29,6 +28,7 @@ import * as yup from 'yup'
 
 import ExperimentsApi from 'src/api/ExperimentsApi'
 import { serverErrorMessage } from 'src/api/HttpResponseError'
+import Attribute from 'src/components/general/Attribute'
 import MetricDifferenceField from 'src/components/general/MetricDifferenceField'
 import MetricValue from 'src/components/general/MetricValue'
 import { AttributionWindowSecondsToHuman } from 'src/lib/metric-assignments'
@@ -98,9 +98,6 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     label: {
       marginBottom: theme.spacing(1),
-    },
-    primaryChip: {
-      marginTop: theme.spacing(1),
     },
   }),
 )
@@ -201,10 +198,8 @@ function MetricAssignmentsPanel({
               <TableCell>
                 <strong className={classes.monospace}>
                   {resolvedMetricAssignment.metric.name}
-                  <br />
-                  {resolvedMetricAssignment.isPrimary && (
-                    <Chip label='Primary' variant='outlined' disabled className={classes.primaryChip} />
-                  )}
+                  &nbsp;
+                  {resolvedMetricAssignment.isPrimary && <Attribute name='primary' />}
                 </strong>
                 <br />
                 <small className={classes.monospace}>{resolvedMetricAssignment.metric.description}</small>

--- a/src/components/experiments/single-view/overview/SegmentsTable.test.tsx
+++ b/src/components/experiments/single-view/overview/SegmentsTable.test.tsx
@@ -45,16 +45,11 @@ test('renders as expected with segment names not in order', () => {
             >
               bar
                
-              <div
-                aria-disabled="true"
-                class="MuiChip-root MuiChip-outlined Mui-disabled"
+              <span
+                class="makeStyles-root-4"
               >
-                <span
-                  class="MuiChip-label"
-                >
-                  Excluded
-                </span>
-              </div>
+                excluded
+              </span>
             </td>
           </tr>
           <tr

--- a/src/components/experiments/single-view/overview/SegmentsTable.tsx
+++ b/src/components/experiments/single-view/overview/SegmentsTable.tsx
@@ -1,4 +1,3 @@
-import { Chip } from '@material-ui/core'
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import Table from '@material-ui/core/Table'
 import TableBody from '@material-ui/core/TableBody'
@@ -8,6 +7,7 @@ import TableRow from '@material-ui/core/TableRow'
 import _ from 'lodash'
 import React, { useMemo } from 'react'
 
+import Attribute from 'src/components/general/Attribute'
 import { Segment, SegmentType } from 'src/lib/schemas'
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -79,7 +79,7 @@ function SegmentsTable({
                 <TableRow key={resolvedSegmentAssignment.segment.segmentId}>
                   <TableCell className={classes.monospace}>
                     {resolvedSegmentAssignment.segment.name}{' '}
-                    {resolvedSegmentAssignment.isExcluded && <Chip label='Excluded' variant='outlined' disabled />}
+                    {resolvedSegmentAssignment.isExcluded && <Attribute name='excluded' />}
                   </TableCell>
                 </TableRow>
               ),

--- a/src/components/experiments/single-view/overview/VariationsTable.tsx
+++ b/src/components/experiments/single-view/overview/VariationsTable.tsx
@@ -1,4 +1,4 @@
-import { Chip, Link, Tooltip, Typography } from '@material-ui/core'
+import { Link, Tooltip, Typography } from '@material-ui/core'
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import Table from '@material-ui/core/Table'
 import TableBody from '@material-ui/core/TableBody'
@@ -7,6 +7,7 @@ import TableHead from '@material-ui/core/TableHead'
 import TableRow from '@material-ui/core/TableRow'
 import React from 'react'
 
+import Attribute from 'src/components/general/Attribute'
 import { ExperimentFull, nameSchema } from 'src/lib/schemas'
 import * as Variations from 'src/lib/variations'
 
@@ -132,7 +133,12 @@ function VariationsTable({
             <TableRow key={variation.variationId}>
               <TableCell className={classes.monospace}>
                 <span>{variation.name}</span>
-                {variation.isDefault && <Chip label='Default' variant='outlined' disabled />}
+                {variation.isDefault && (
+                  <>
+                    <br />
+                    <Attribute name='default' />
+                  </>
+                )}
               </TableCell>
               <TableCell className={classes.monospace}>{variation.allocatedPercentage}%</TableCell>
               <TableCell className={classes.monospace}>

--- a/src/components/experiments/single-view/overview/__snapshots__/AudiencePanel.test.tsx.snap
+++ b/src/components/experiments/single-view/overview/__snapshots__/AudiencePanel.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Empty array shows no exposure events 1`] = `
       class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
     >
       <h3
-        class="MuiTypography-root makeStyles-title-61 MuiTypography-h3 MuiTypography-colorTextPrimary"
+        class="MuiTypography-root makeStyles-title-65 MuiTypography-h3 MuiTypography-colorTextPrimary"
       >
         Audience
       </h3>
@@ -34,7 +34,7 @@ exports[`Empty array shows no exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <span
-              class="makeStyles-monospace-62"
+              class="makeStyles-monospace-66"
             >
               calypso
             </span>
@@ -54,7 +54,7 @@ exports[`Empty array shows no exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <span
-              class="makeStyles-monospace-62"
+              class="makeStyles-monospace-66"
             >
               New logged-in users only
             </span>
@@ -74,7 +74,7 @@ exports[`Empty array shows no exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <table
-              class="MuiTable-root makeStyles-root-76"
+              class="MuiTable-root makeStyles-root-81"
             >
               <thead
                 class="MuiTableHead-root"
@@ -112,33 +112,29 @@ exports[`Empty array shows no exposure events 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-81"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-86"
                   >
                     <span>
                       control
                     </span>
-                    <div
-                      aria-disabled="true"
-                      class="MuiChip-root MuiChip-outlined Mui-disabled"
+                    <br />
+                    <span
+                      class="makeStyles-root-87"
                     >
-                      <span
-                        class="MuiChip-label"
-                      >
-                        Default
-                      </span>
-                    </div>
+                      default
+                    </span>
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-81"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-86"
                   >
                     60
                     %
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-81"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-86"
                   >
                     <span
-                      class="makeStyles-tooltipped-79"
+                      class="makeStyles-tooltipped-84"
                     >
                       Bookmarklet
                     </span>
@@ -149,23 +145,23 @@ exports[`Empty array shows no exposure events 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-81"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-86"
                   >
                     <span>
                       test
                     </span>
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-81"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-86"
                   >
                     40
                     %
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-81"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-86"
                   >
                     <span
-                      class="makeStyles-tooltipped-79"
+                      class="makeStyles-tooltipped-84"
                     >
                       Bookmarklet
                     </span>
@@ -190,7 +186,7 @@ exports[`Empty array shows no exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <table
-              class="MuiTable-root makeStyles-root-82"
+              class="MuiTable-root makeStyles-root-88"
             >
               <thead
                 class="MuiTableHead-root"
@@ -214,7 +210,7 @@ exports[`Empty array shows no exposure events 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-84"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-90"
                   >
                     All 
                     locales
@@ -224,7 +220,7 @@ exports[`Empty array shows no exposure events 1`] = `
               </tbody>
             </table>
             <table
-              class="MuiTable-root makeStyles-root-82"
+              class="MuiTable-root makeStyles-root-88"
             >
               <thead
                 class="MuiTableHead-root"
@@ -248,7 +244,7 @@ exports[`Empty array shows no exposure events 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-84"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-90"
                   >
                     All 
                     countries
@@ -273,10 +269,10 @@ exports[`Empty array shows no exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <div
-              class="makeStyles-eventList-87"
+              class="makeStyles-eventList-93"
             >
               <span
-                class="makeStyles-monospace-88"
+                class="makeStyles-monospace-94"
               >
                 No exposure events defined
               </span>
@@ -324,7 +320,7 @@ exports[`Shows exposure events 1`] = `
       class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
     >
       <h3
-        class="MuiTypography-root makeStyles-title-61 MuiTypography-h3 MuiTypography-colorTextPrimary"
+        class="MuiTypography-root makeStyles-title-65 MuiTypography-h3 MuiTypography-colorTextPrimary"
       >
         Audience
       </h3>
@@ -349,7 +345,7 @@ exports[`Shows exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <span
-              class="makeStyles-monospace-62"
+              class="makeStyles-monospace-66"
             >
               calypso
             </span>
@@ -369,7 +365,7 @@ exports[`Shows exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <span
-              class="makeStyles-monospace-62"
+              class="makeStyles-monospace-66"
             >
               New logged-in users only
             </span>
@@ -389,7 +385,7 @@ exports[`Shows exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <table
-              class="MuiTable-root makeStyles-root-63"
+              class="MuiTable-root makeStyles-root-67"
             >
               <thead
                 class="MuiTableHead-root"
@@ -427,33 +423,29 @@ exports[`Shows exposure events 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-72"
                   >
                     <span>
                       control
                     </span>
-                    <div
-                      aria-disabled="true"
-                      class="MuiChip-root MuiChip-outlined Mui-disabled"
+                    <br />
+                    <span
+                      class="makeStyles-root-73"
                     >
-                      <span
-                        class="MuiChip-label"
-                      >
-                        Default
-                      </span>
-                    </div>
+                      default
+                    </span>
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-72"
                   >
                     60
                     %
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-72"
                   >
                     <span
-                      class="makeStyles-tooltipped-66"
+                      class="makeStyles-tooltipped-70"
                     >
                       Bookmarklet
                     </span>
@@ -464,23 +456,23 @@ exports[`Shows exposure events 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-72"
                   >
                     <span>
                       test
                     </span>
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-72"
                   >
                     40
                     %
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-68"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-72"
                   >
                     <span
-                      class="makeStyles-tooltipped-66"
+                      class="makeStyles-tooltipped-70"
                     >
                       Bookmarklet
                     </span>
@@ -505,7 +497,7 @@ exports[`Shows exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <table
-              class="MuiTable-root makeStyles-root-69"
+              class="MuiTable-root makeStyles-root-74"
             >
               <thead
                 class="MuiTableHead-root"
@@ -529,7 +521,7 @@ exports[`Shows exposure events 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-71"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-76"
                   >
                     All 
                     locales
@@ -539,7 +531,7 @@ exports[`Shows exposure events 1`] = `
               </tbody>
             </table>
             <table
-              class="MuiTable-root makeStyles-root-69"
+              class="MuiTable-root makeStyles-root-74"
             >
               <thead
                 class="MuiTableHead-root"
@@ -563,7 +555,7 @@ exports[`Shows exposure events 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-71"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-76"
                   >
                     All 
                     countries
@@ -588,18 +580,18 @@ exports[`Shows exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <div
-              class="makeStyles-eventList-74"
+              class="makeStyles-eventList-79"
             >
               <p
-                class="MuiTypography-root makeStyles-monospace-75 MuiTypography-body1"
+                class="MuiTypography-root makeStyles-monospace-80 MuiTypography-body1"
               >
                 <span
-                  class="makeStyles-eventName-73"
+                  class="makeStyles-eventName-78"
                 >
                   test
                 </span>
                 <span
-                  class="makeStyles-entry-72"
+                  class="makeStyles-entry-77"
                 >
                   prop1
                   : 
@@ -650,7 +642,7 @@ exports[`null shows no exposure events 1`] = `
       class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
     >
       <h3
-        class="MuiTypography-root makeStyles-title-61 MuiTypography-h3 MuiTypography-colorTextPrimary"
+        class="MuiTypography-root makeStyles-title-65 MuiTypography-h3 MuiTypography-colorTextPrimary"
       >
         Audience
       </h3>
@@ -675,7 +667,7 @@ exports[`null shows no exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <span
-              class="makeStyles-monospace-62"
+              class="makeStyles-monospace-66"
             >
               calypso
             </span>
@@ -695,7 +687,7 @@ exports[`null shows no exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <span
-              class="makeStyles-monospace-62"
+              class="makeStyles-monospace-66"
             >
               New logged-in users only
             </span>
@@ -715,7 +707,7 @@ exports[`null shows no exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <table
-              class="MuiTable-root makeStyles-root-89"
+              class="MuiTable-root makeStyles-root-95"
             >
               <thead
                 class="MuiTableHead-root"
@@ -753,33 +745,29 @@ exports[`null shows no exposure events 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-94"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-100"
                   >
                     <span>
                       control
                     </span>
-                    <div
-                      aria-disabled="true"
-                      class="MuiChip-root MuiChip-outlined Mui-disabled"
+                    <br />
+                    <span
+                      class="makeStyles-root-101"
                     >
-                      <span
-                        class="MuiChip-label"
-                      >
-                        Default
-                      </span>
-                    </div>
+                      default
+                    </span>
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-94"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-100"
                   >
                     60
                     %
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-94"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-100"
                   >
                     <span
-                      class="makeStyles-tooltipped-92"
+                      class="makeStyles-tooltipped-98"
                     >
                       Bookmarklet
                     </span>
@@ -790,23 +778,23 @@ exports[`null shows no exposure events 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-94"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-100"
                   >
                     <span>
                       test
                     </span>
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-94"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-100"
                   >
                     40
                     %
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-94"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-100"
                   >
                     <span
-                      class="makeStyles-tooltipped-92"
+                      class="makeStyles-tooltipped-98"
                     >
                       Bookmarklet
                     </span>
@@ -831,7 +819,7 @@ exports[`null shows no exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <table
-              class="MuiTable-root makeStyles-root-95"
+              class="MuiTable-root makeStyles-root-102"
             >
               <thead
                 class="MuiTableHead-root"
@@ -855,7 +843,7 @@ exports[`null shows no exposure events 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-97"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
                   >
                     All 
                     locales
@@ -865,7 +853,7 @@ exports[`null shows no exposure events 1`] = `
               </tbody>
             </table>
             <table
-              class="MuiTable-root makeStyles-root-95"
+              class="MuiTable-root makeStyles-root-102"
             >
               <thead
                 class="MuiTableHead-root"
@@ -889,7 +877,7 @@ exports[`null shows no exposure events 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-97"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
                   >
                     All 
                     countries
@@ -914,10 +902,10 @@ exports[`null shows no exposure events 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <div
-              class="makeStyles-eventList-100"
+              class="makeStyles-eventList-107"
             >
               <span
-                class="makeStyles-monospace-101"
+                class="makeStyles-monospace-108"
               >
                 No exposure events defined
               </span>
@@ -965,7 +953,7 @@ exports[`renders as expected with all segments resolvable 1`] = `
       class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
     >
       <h3
-        class="MuiTypography-root makeStyles-title-46 MuiTypography-h3 MuiTypography-colorTextPrimary"
+        class="MuiTypography-root makeStyles-title-49 MuiTypography-h3 MuiTypography-colorTextPrimary"
       >
         Audience
       </h3>
@@ -990,7 +978,7 @@ exports[`renders as expected with all segments resolvable 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <span
-              class="makeStyles-monospace-47"
+              class="makeStyles-monospace-50"
             >
               calypso
             </span>
@@ -1010,7 +998,7 @@ exports[`renders as expected with all segments resolvable 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <span
-              class="makeStyles-monospace-47"
+              class="makeStyles-monospace-50"
             >
               New logged-in users only
             </span>
@@ -1030,7 +1018,7 @@ exports[`renders as expected with all segments resolvable 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <table
-              class="MuiTable-root makeStyles-root-48"
+              class="MuiTable-root makeStyles-root-51"
             >
               <thead
                 class="MuiTableHead-root"
@@ -1068,33 +1056,29 @@ exports[`renders as expected with all segments resolvable 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-53"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56"
                   >
                     <span>
                       control
                     </span>
-                    <div
-                      aria-disabled="true"
-                      class="MuiChip-root MuiChip-outlined Mui-disabled"
+                    <br />
+                    <span
+                      class="makeStyles-root-57"
                     >
-                      <span
-                        class="MuiChip-label"
-                      >
-                        Default
-                      </span>
-                    </div>
+                      default
+                    </span>
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-53"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56"
                   >
                     60
                     %
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-53"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56"
                   >
                     <span
-                      class="makeStyles-tooltipped-51"
+                      class="makeStyles-tooltipped-54"
                     >
                       Bookmarklet
                     </span>
@@ -1105,23 +1089,23 @@ exports[`renders as expected with all segments resolvable 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-53"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56"
                   >
                     <span>
                       test
                     </span>
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-53"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56"
                   >
                     40
                     %
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-53"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56"
                   >
                     <span
-                      class="makeStyles-tooltipped-51"
+                      class="makeStyles-tooltipped-54"
                     >
                       Bookmarklet
                     </span>
@@ -1146,7 +1130,7 @@ exports[`renders as expected with all segments resolvable 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <table
-              class="MuiTable-root makeStyles-root-54"
+              class="MuiTable-root makeStyles-root-58"
             >
               <thead
                 class="MuiTableHead-root"
@@ -1170,7 +1154,7 @@ exports[`renders as expected with all segments resolvable 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
                   >
                     segment_1
                      
@@ -1180,27 +1164,22 @@ exports[`renders as expected with all segments resolvable 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
                   >
                     segment_3
                      
-                    <div
-                      aria-disabled="true"
-                      class="MuiChip-root MuiChip-outlined Mui-disabled"
+                    <span
+                      class="makeStyles-root-57"
                     >
-                      <span
-                        class="MuiChip-label"
-                      >
-                        Excluded
-                      </span>
-                    </div>
+                      excluded
+                    </span>
                   </td>
                 </tr>
                 <tr
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
                   >
                     segment_5
                      
@@ -1209,7 +1188,7 @@ exports[`renders as expected with all segments resolvable 1`] = `
               </tbody>
             </table>
             <table
-              class="MuiTable-root makeStyles-root-54"
+              class="MuiTable-root makeStyles-root-58"
             >
               <thead
                 class="MuiTableHead-root"
@@ -1233,27 +1212,22 @@ exports[`renders as expected with all segments resolvable 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
                   >
                     segment_2
                      
-                    <div
-                      aria-disabled="true"
-                      class="MuiChip-root MuiChip-outlined Mui-disabled"
+                    <span
+                      class="makeStyles-root-57"
                     >
-                      <span
-                        class="MuiChip-label"
-                      >
-                        Excluded
-                      </span>
-                    </div>
+                      excluded
+                    </span>
                   </td>
                 </tr>
                 <tr
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
                   >
                     segment_4
                      
@@ -1277,32 +1251,32 @@ exports[`renders as expected with all segments resolvable 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <div
-              class="makeStyles-eventList-59"
+              class="makeStyles-eventList-63"
             >
               <p
-                class="MuiTypography-root makeStyles-monospace-60 MuiTypography-body1"
+                class="MuiTypography-root makeStyles-monospace-64 MuiTypography-body1"
               >
                 <span
-                  class="makeStyles-eventName-58"
+                  class="makeStyles-eventName-62"
                 >
                   event_name
                 </span>
                 <span
-                  class="makeStyles-entry-57"
+                  class="makeStyles-entry-61"
                 >
                   additionalProp1
                   : 
                   prop1Value
                 </span>
                 <span
-                  class="makeStyles-entry-57"
+                  class="makeStyles-entry-61"
                 >
                   additionalProp2
                   : 
                   prop2Value
                 </span>
                 <span
-                  class="makeStyles-entry-57"
+                  class="makeStyles-entry-61"
                 >
                   additionalProp3
                   : 
@@ -1310,10 +1284,10 @@ exports[`renders as expected with all segments resolvable 1`] = `
                 </span>
               </p>
               <p
-                class="MuiTypography-root makeStyles-monospace-60 MuiTypography-body1"
+                class="MuiTypography-root makeStyles-monospace-64 MuiTypography-body1"
               >
                 <span
-                  class="makeStyles-eventName-58"
+                  class="makeStyles-eventName-62"
                 >
                   event_without_props
                 </span>
@@ -1362,7 +1336,7 @@ exports[`renders as expected with existing users allowed 1`] = `
       class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
     >
       <h3
-        class="MuiTypography-root makeStyles-title-31 MuiTypography-h3 MuiTypography-colorTextPrimary"
+        class="MuiTypography-root makeStyles-title-33 MuiTypography-h3 MuiTypography-colorTextPrimary"
       >
         Audience
       </h3>
@@ -1387,7 +1361,7 @@ exports[`renders as expected with existing users allowed 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <span
-              class="makeStyles-monospace-32"
+              class="makeStyles-monospace-34"
             >
               calypso
             </span>
@@ -1407,7 +1381,7 @@ exports[`renders as expected with existing users allowed 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <span
-              class="makeStyles-monospace-32"
+              class="makeStyles-monospace-34"
             >
               All users (new + existing + anonymous)
             </span>
@@ -1427,7 +1401,7 @@ exports[`renders as expected with existing users allowed 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <table
-              class="MuiTable-root makeStyles-root-33"
+              class="MuiTable-root makeStyles-root-35"
             >
               <thead
                 class="MuiTableHead-root"
@@ -1465,33 +1439,29 @@ exports[`renders as expected with existing users allowed 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-38"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-40"
                   >
                     <span>
                       control
                     </span>
-                    <div
-                      aria-disabled="true"
-                      class="MuiChip-root MuiChip-outlined Mui-disabled"
+                    <br />
+                    <span
+                      class="makeStyles-root-41"
                     >
-                      <span
-                        class="MuiChip-label"
-                      >
-                        Default
-                      </span>
-                    </div>
+                      default
+                    </span>
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-38"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-40"
                   >
                     60
                     %
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-38"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-40"
                   >
                     <span
-                      class="makeStyles-tooltipped-36"
+                      class="makeStyles-tooltipped-38"
                     >
                       Bookmarklet
                     </span>
@@ -1502,23 +1472,23 @@ exports[`renders as expected with existing users allowed 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-38"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-40"
                   >
                     <span>
                       test
                     </span>
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-38"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-40"
                   >
                     40
                     %
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-38"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-40"
                   >
                     <span
-                      class="makeStyles-tooltipped-36"
+                      class="makeStyles-tooltipped-38"
                     >
                       Bookmarklet
                     </span>
@@ -1543,7 +1513,7 @@ exports[`renders as expected with existing users allowed 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <table
-              class="MuiTable-root makeStyles-root-39"
+              class="MuiTable-root makeStyles-root-42"
             >
               <thead
                 class="MuiTableHead-root"
@@ -1567,7 +1537,7 @@ exports[`renders as expected with existing users allowed 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-41"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-44"
                   >
                     All 
                     locales
@@ -1577,7 +1547,7 @@ exports[`renders as expected with existing users allowed 1`] = `
               </tbody>
             </table>
             <table
-              class="MuiTable-root makeStyles-root-39"
+              class="MuiTable-root makeStyles-root-42"
             >
               <thead
                 class="MuiTableHead-root"
@@ -1601,7 +1571,7 @@ exports[`renders as expected with existing users allowed 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-41"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-44"
                   >
                     All 
                     countries
@@ -1626,32 +1596,32 @@ exports[`renders as expected with existing users allowed 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <div
-              class="makeStyles-eventList-44"
+              class="makeStyles-eventList-47"
             >
               <p
-                class="MuiTypography-root makeStyles-monospace-45 MuiTypography-body1"
+                class="MuiTypography-root makeStyles-monospace-48 MuiTypography-body1"
               >
                 <span
-                  class="makeStyles-eventName-43"
+                  class="makeStyles-eventName-46"
                 >
                   event_name
                 </span>
                 <span
-                  class="makeStyles-entry-42"
+                  class="makeStyles-entry-45"
                 >
                   additionalProp1
                   : 
                   prop1Value
                 </span>
                 <span
-                  class="makeStyles-entry-42"
+                  class="makeStyles-entry-45"
                 >
                   additionalProp2
                   : 
                   prop2Value
                 </span>
                 <span
-                  class="makeStyles-entry-42"
+                  class="makeStyles-entry-45"
                 >
                   additionalProp3
                   : 
@@ -1659,10 +1629,10 @@ exports[`renders as expected with existing users allowed 1`] = `
                 </span>
               </p>
               <p
-                class="MuiTypography-root makeStyles-monospace-45 MuiTypography-body1"
+                class="MuiTypography-root makeStyles-monospace-48 MuiTypography-body1"
               >
                 <span
-                  class="makeStyles-eventName-43"
+                  class="makeStyles-eventName-46"
                 >
                   event_without_props
                 </span>
@@ -1711,7 +1681,7 @@ exports[`renders as expected with no exclusion groups 1`] = `
       class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
     >
       <h3
-        class="MuiTypography-root makeStyles-title-16 MuiTypography-h3 MuiTypography-colorTextPrimary"
+        class="MuiTypography-root makeStyles-title-17 MuiTypography-h3 MuiTypography-colorTextPrimary"
       >
         Audience
       </h3>
@@ -1736,7 +1706,7 @@ exports[`renders as expected with no exclusion groups 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <span
-              class="makeStyles-monospace-17"
+              class="makeStyles-monospace-18"
             >
               calypso
             </span>
@@ -1756,7 +1726,7 @@ exports[`renders as expected with no exclusion groups 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <span
-              class="makeStyles-monospace-17"
+              class="makeStyles-monospace-18"
             >
               New logged-in users only
             </span>
@@ -1776,7 +1746,7 @@ exports[`renders as expected with no exclusion groups 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <table
-              class="MuiTable-root makeStyles-root-18"
+              class="MuiTable-root makeStyles-root-19"
             >
               <thead
                 class="MuiTableHead-root"
@@ -1814,33 +1784,29 @@ exports[`renders as expected with no exclusion groups 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-23"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-24"
                   >
                     <span>
                       control
                     </span>
-                    <div
-                      aria-disabled="true"
-                      class="MuiChip-root MuiChip-outlined Mui-disabled"
+                    <br />
+                    <span
+                      class="makeStyles-root-25"
                     >
-                      <span
-                        class="MuiChip-label"
-                      >
-                        Default
-                      </span>
-                    </div>
+                      default
+                    </span>
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-23"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-24"
                   >
                     60
                     %
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-23"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-24"
                   >
                     <span
-                      class="makeStyles-tooltipped-21"
+                      class="makeStyles-tooltipped-22"
                     >
                       Bookmarklet
                     </span>
@@ -1851,23 +1817,23 @@ exports[`renders as expected with no exclusion groups 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-23"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-24"
                   >
                     <span>
                       test
                     </span>
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-23"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-24"
                   >
                     40
                     %
                   </td>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-23"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-24"
                   >
                     <span
-                      class="makeStyles-tooltipped-21"
+                      class="makeStyles-tooltipped-22"
                     >
                       Bookmarklet
                     </span>
@@ -1892,7 +1858,7 @@ exports[`renders as expected with no exclusion groups 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <table
-              class="MuiTable-root makeStyles-root-24"
+              class="MuiTable-root makeStyles-root-26"
             >
               <thead
                 class="MuiTableHead-root"
@@ -1916,7 +1882,7 @@ exports[`renders as expected with no exclusion groups 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-26"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-28"
                   >
                     All 
                     locales
@@ -1926,7 +1892,7 @@ exports[`renders as expected with no exclusion groups 1`] = `
               </tbody>
             </table>
             <table
-              class="MuiTable-root makeStyles-root-24"
+              class="MuiTable-root makeStyles-root-26"
             >
               <thead
                 class="MuiTableHead-root"
@@ -1950,7 +1916,7 @@ exports[`renders as expected with no exclusion groups 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-26"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-28"
                   >
                     All 
                     countries
@@ -1975,32 +1941,32 @@ exports[`renders as expected with no exclusion groups 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <div
-              class="makeStyles-eventList-29"
+              class="makeStyles-eventList-31"
             >
               <p
-                class="MuiTypography-root makeStyles-monospace-30 MuiTypography-body1"
+                class="MuiTypography-root makeStyles-monospace-32 MuiTypography-body1"
               >
                 <span
-                  class="makeStyles-eventName-28"
+                  class="makeStyles-eventName-30"
                 >
                   event_name
                 </span>
                 <span
-                  class="makeStyles-entry-27"
+                  class="makeStyles-entry-29"
                 >
                   additionalProp1
                   : 
                   prop1Value
                 </span>
                 <span
-                  class="makeStyles-entry-27"
+                  class="makeStyles-entry-29"
                 >
                   additionalProp2
                   : 
                   prop2Value
                 </span>
                 <span
-                  class="makeStyles-entry-27"
+                  class="makeStyles-entry-29"
                 >
                   additionalProp3
                   : 
@@ -2008,10 +1974,10 @@ exports[`renders as expected with no exclusion groups 1`] = `
                 </span>
               </p>
               <p
-                class="MuiTypography-root makeStyles-monospace-30 MuiTypography-body1"
+                class="MuiTypography-root makeStyles-monospace-32 MuiTypography-body1"
               >
                 <span
-                  class="makeStyles-eventName-28"
+                  class="makeStyles-eventName-30"
                 >
                   event_without_props
                 </span>
@@ -2142,16 +2108,12 @@ exports[`renders as expected with no segment assignments 1`] = `
                     <span>
                       control
                     </span>
-                    <div
-                      aria-disabled="true"
-                      class="MuiChip-root MuiChip-outlined Mui-disabled"
+                    <br />
+                    <span
+                      class="makeStyles-root-9"
                     >
-                      <span
-                        class="MuiChip-label"
-                      >
-                        Default
-                      </span>
-                    </div>
+                      default
+                    </span>
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-8"
@@ -2215,7 +2177,7 @@ exports[`renders as expected with no segment assignments 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <table
-              class="MuiTable-root makeStyles-root-9"
+              class="MuiTable-root makeStyles-root-10"
             >
               <thead
                 class="MuiTableHead-root"
@@ -2239,7 +2201,7 @@ exports[`renders as expected with no segment assignments 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-11"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-12"
                   >
                     All 
                     locales
@@ -2249,7 +2211,7 @@ exports[`renders as expected with no segment assignments 1`] = `
               </tbody>
             </table>
             <table
-              class="MuiTable-root makeStyles-root-9"
+              class="MuiTable-root makeStyles-root-10"
             >
               <thead
                 class="MuiTableHead-root"
@@ -2273,7 +2235,7 @@ exports[`renders as expected with no segment assignments 1`] = `
                   class="MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-11"
+                    class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-12"
                   >
                     All 
                     countries
@@ -2298,32 +2260,32 @@ exports[`renders as expected with no segment assignments 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <div
-              class="makeStyles-eventList-14"
+              class="makeStyles-eventList-15"
             >
               <p
-                class="MuiTypography-root makeStyles-monospace-15 MuiTypography-body1"
+                class="MuiTypography-root makeStyles-monospace-16 MuiTypography-body1"
               >
                 <span
-                  class="makeStyles-eventName-13"
+                  class="makeStyles-eventName-14"
                 >
                   event_name
                 </span>
                 <span
-                  class="makeStyles-entry-12"
+                  class="makeStyles-entry-13"
                 >
                   additionalProp1
                   : 
                   prop1Value
                 </span>
                 <span
-                  class="makeStyles-entry-12"
+                  class="makeStyles-entry-13"
                 >
                   additionalProp2
                   : 
                   prop2Value
                 </span>
                 <span
-                  class="makeStyles-entry-12"
+                  class="makeStyles-entry-13"
                 >
                   additionalProp3
                   : 
@@ -2331,10 +2293,10 @@ exports[`renders as expected with no segment assignments 1`] = `
                 </span>
               </p>
               <p
-                class="MuiTypography-root makeStyles-monospace-15 MuiTypography-body1"
+                class="MuiTypography-root makeStyles-monospace-16 MuiTypography-body1"
               >
                 <span
-                  class="makeStyles-eventName-13"
+                  class="makeStyles-eventName-14"
                 >
                   event_without_props
                 </span>

--- a/src/components/experiments/single-view/overview/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/src/components/experiments/single-view/overview/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -663,17 +663,12 @@ exports[`renders as expected at large width 1`] = `
               class="makeStyles-monospace-30"
             >
               metric_1
-              <br />
-              <div
-                aria-disabled="true"
-                class="MuiChip-root makeStyles-primaryChip-35 MuiChip-outlined Mui-disabled"
+               
+              <span
+                class="makeStyles-root-35"
               >
-                <span
-                  class="MuiChip-label"
-                >
-                  Primary
-                </span>
-              </div>
+                primary
+              </span>
             </strong>
             <br />
             <small
@@ -715,7 +710,7 @@ exports[`renders as expected at large width 1`] = `
               class="makeStyles-monospace-30"
             >
               metric_2
-              <br />
+               
             </strong>
             <br />
             <small
@@ -752,7 +747,7 @@ exports[`renders as expected at large width 1`] = `
               class="makeStyles-monospace-30"
             >
               metric_2
-              <br />
+               
             </strong>
             <br />
             <small
@@ -789,7 +784,7 @@ exports[`renders as expected at large width 1`] = `
               class="makeStyles-monospace-30"
             >
               metric_3
-              <br />
+               
             </strong>
             <br />
             <small
@@ -1490,17 +1485,12 @@ exports[`renders as expected at small width 1`] = `
               class="makeStyles-monospace-66"
             >
               metric_1
-              <br />
-              <div
-                aria-disabled="true"
-                class="MuiChip-root makeStyles-primaryChip-71 MuiChip-outlined Mui-disabled"
+               
+              <span
+                class="makeStyles-root-71"
               >
-                <span
-                  class="MuiChip-label"
-                >
-                  Primary
-                </span>
-              </div>
+                primary
+              </span>
             </strong>
             <br />
             <small
@@ -1542,7 +1532,7 @@ exports[`renders as expected at small width 1`] = `
               class="makeStyles-monospace-66"
             >
               metric_2
-              <br />
+               
             </strong>
             <br />
             <small
@@ -1579,7 +1569,7 @@ exports[`renders as expected at small width 1`] = `
               class="makeStyles-monospace-66"
             >
               metric_2
-              <br />
+               
             </strong>
             <br />
             <small
@@ -1616,7 +1606,7 @@ exports[`renders as expected at small width 1`] = `
               class="makeStyles-monospace-66"
             >
               metric_3
-              <br />
+               
             </strong>
             <br />
             <small
@@ -2421,17 +2411,12 @@ exports[`renders as expected with conclusion data 1`] = `
               class="makeStyles-monospace-104"
             >
               metric_1
-              <br />
-              <div
-                aria-disabled="true"
-                class="MuiChip-root makeStyles-primaryChip-109 MuiChip-outlined Mui-disabled"
+               
+              <span
+                class="makeStyles-root-109"
               >
-                <span
-                  class="MuiChip-label"
-                >
-                  Primary
-                </span>
-              </div>
+                primary
+              </span>
             </strong>
             <br />
             <small
@@ -2473,7 +2458,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="makeStyles-monospace-104"
             >
               metric_2
-              <br />
+               
             </strong>
             <br />
             <small
@@ -2510,7 +2495,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="makeStyles-monospace-104"
             >
               metric_2
-              <br />
+               
             </strong>
             <br />
             <small
@@ -2547,7 +2532,7 @@ exports[`renders as expected with conclusion data 1`] = `
               class="makeStyles-monospace-104"
             >
               metric_3
-              <br />
+               
             </strong>
             <br />
             <small
@@ -3248,17 +3233,12 @@ exports[`renders as expected without conclusion data 1`] = `
               class="makeStyles-monospace-140"
             >
               metric_1
-              <br />
-              <div
-                aria-disabled="true"
-                class="MuiChip-root makeStyles-primaryChip-145 MuiChip-outlined Mui-disabled"
+               
+              <span
+                class="makeStyles-root-145"
               >
-                <span
-                  class="MuiChip-label"
-                >
-                  Primary
-                </span>
-              </div>
+                primary
+              </span>
             </strong>
             <br />
             <small
@@ -3300,7 +3280,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="makeStyles-monospace-140"
             >
               metric_2
-              <br />
+               
             </strong>
             <br />
             <small
@@ -3337,7 +3317,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="makeStyles-monospace-140"
             >
               metric_2
-              <br />
+               
             </strong>
             <br />
             <small
@@ -3374,7 +3354,7 @@ exports[`renders as expected without conclusion data 1`] = `
               class="makeStyles-monospace-140"
             >
               metric_3
-              <br />
+               
             </strong>
             <br />
             <small

--- a/src/components/experiments/single-view/overview/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/src/components/experiments/single-view/overview/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -333,16 +333,12 @@ exports[`renders as expected at large width 1`] = `
                         <span>
                           control
                         </span>
-                        <div
-                          aria-disabled="true"
-                          class="MuiChip-root MuiChip-outlined Mui-disabled"
+                        <br />
+                        <span
+                          class="makeStyles-root-22"
                         >
-                          <span
-                            class="MuiChip-label"
-                          >
-                            Default
-                          </span>
-                        </div>
+                          default
+                        </span>
                       </td>
                       <td
                         class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-21"
@@ -406,7 +402,7 @@ exports[`renders as expected at large width 1`] = `
                 class="MuiTableCell-root MuiTableCell-body"
               >
                 <table
-                  class="MuiTable-root makeStyles-root-22"
+                  class="MuiTable-root makeStyles-root-23"
                 >
                   <thead
                     class="MuiTableHead-root"
@@ -430,7 +426,7 @@ exports[`renders as expected at large width 1`] = `
                       class="MuiTableRow-root"
                     >
                       <td
-                        class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-24"
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25"
                       >
                         segment_1
                          
@@ -439,7 +435,7 @@ exports[`renders as expected at large width 1`] = `
                   </tbody>
                 </table>
                 <table
-                  class="MuiTable-root makeStyles-root-22"
+                  class="MuiTable-root makeStyles-root-23"
                 >
                   <thead
                     class="MuiTableHead-root"
@@ -463,20 +459,15 @@ exports[`renders as expected at large width 1`] = `
                       class="MuiTableRow-root"
                     >
                       <td
-                        class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-24"
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-25"
                       >
                         segment_2
                          
-                        <div
-                          aria-disabled="true"
-                          class="MuiChip-root MuiChip-outlined Mui-disabled"
+                        <span
+                          class="makeStyles-root-22"
                         >
-                          <span
-                            class="MuiChip-label"
-                          >
-                            Excluded
-                          </span>
-                        </div>
+                          excluded
+                        </span>
                       </td>
                     </tr>
                   </tbody>
@@ -497,32 +488,32 @@ exports[`renders as expected at large width 1`] = `
                 class="MuiTableCell-root MuiTableCell-body"
               >
                 <div
-                  class="makeStyles-eventList-27"
+                  class="makeStyles-eventList-28"
                 >
                   <p
-                    class="MuiTypography-root makeStyles-monospace-28 MuiTypography-body1"
+                    class="MuiTypography-root makeStyles-monospace-29 MuiTypography-body1"
                   >
                     <span
-                      class="makeStyles-eventName-26"
+                      class="makeStyles-eventName-27"
                     >
                       event_name
                     </span>
                     <span
-                      class="makeStyles-entry-25"
+                      class="makeStyles-entry-26"
                     >
                       additionalProp1
                       : 
                       prop1Value
                     </span>
                     <span
-                      class="makeStyles-entry-25"
+                      class="makeStyles-entry-26"
                     >
                       additionalProp2
                       : 
                       prop2Value
                     </span>
                     <span
-                      class="makeStyles-entry-25"
+                      class="makeStyles-entry-26"
                     >
                       additionalProp3
                       : 
@@ -530,10 +521,10 @@ exports[`renders as expected at large width 1`] = `
                     </span>
                   </p>
                   <p
-                    class="MuiTypography-root makeStyles-monospace-28 MuiTypography-body1"
+                    class="MuiTypography-root makeStyles-monospace-29 MuiTypography-body1"
                   >
                     <span
-                      class="makeStyles-eventName-26"
+                      class="makeStyles-eventName-27"
                     >
                       event_without_props
                     </span>
@@ -579,7 +570,7 @@ exports[`renders as expected at large width 1`] = `
       class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
     >
       <h3
-        class="MuiTypography-root makeStyles-title-31 MuiTypography-h3 MuiTypography-colorTextPrimary"
+        class="MuiTypography-root makeStyles-title-32 MuiTypography-h3 MuiTypography-colorTextPrimary"
       >
         Metrics
       </h3>
@@ -660,35 +651,35 @@ exports[`renders as expected at large width 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <strong
-              class="makeStyles-monospace-30"
+              class="makeStyles-monospace-31"
             >
               metric_1
                
               <span
-                class="makeStyles-root-35"
+                class="makeStyles-root-22"
               >
                 primary
               </span>
             </strong>
             <br />
             <small
-              class="makeStyles-monospace-30"
+              class="makeStyles-monospace-31"
             >
               This is metric 1
             </small>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-31"
           >
             1 week
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-31"
           >
             Yes
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-31"
           >
             
             10
@@ -707,30 +698,30 @@ exports[`renders as expected at large width 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <strong
-              class="makeStyles-monospace-30"
+              class="makeStyles-monospace-31"
             >
               metric_2
                
             </strong>
             <br />
             <small
-              class="makeStyles-monospace-30"
+              class="makeStyles-monospace-31"
             >
               This is metric 2
             </small>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-31"
           >
             1 hour
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-31"
           >
             Yes
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-31"
           >
             USD 
             0.5
@@ -744,30 +735,30 @@ exports[`renders as expected at large width 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <strong
-              class="makeStyles-monospace-30"
+              class="makeStyles-monospace-31"
             >
               metric_2
                
             </strong>
             <br />
             <small
-              class="makeStyles-monospace-30"
+              class="makeStyles-monospace-31"
             >
               This is metric 2
             </small>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-31"
           >
             4 weeks
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-31"
           >
             No
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-31"
           >
             USD 
             10.5
@@ -781,30 +772,30 @@ exports[`renders as expected at large width 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <strong
-              class="makeStyles-monospace-30"
+              class="makeStyles-monospace-31"
             >
               metric_3
                
             </strong>
             <br />
             <small
-              class="makeStyles-monospace-30"
+              class="makeStyles-monospace-31"
             >
               This is metric 3
             </small>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-31"
           >
             6 hours
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-31"
           >
             Yes
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-31"
           >
             
             1200
@@ -1153,16 +1144,12 @@ exports[`renders as expected at small width 1`] = `
                             <span>
                               control
                             </span>
-                            <div
-                              aria-disabled="true"
-                              class="MuiChip-root MuiChip-outlined Mui-disabled"
+                            <br />
+                            <span
+                              class="makeStyles-root-58"
                             >
-                              <span
-                                class="MuiChip-label"
-                              >
-                                Default
-                              </span>
-                            </div>
+                              default
+                            </span>
                           </td>
                           <td
                             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-57"
@@ -1226,7 +1213,7 @@ exports[`renders as expected at small width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <table
-                      class="MuiTable-root makeStyles-root-58"
+                      class="MuiTable-root makeStyles-root-59"
                     >
                       <thead
                         class="MuiTableHead-root"
@@ -1250,7 +1237,7 @@ exports[`renders as expected at small width 1`] = `
                           class="MuiTableRow-root"
                         >
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-61"
                           >
                             segment_1
                              
@@ -1259,7 +1246,7 @@ exports[`renders as expected at small width 1`] = `
                       </tbody>
                     </table>
                     <table
-                      class="MuiTable-root makeStyles-root-58"
+                      class="MuiTable-root makeStyles-root-59"
                     >
                       <thead
                         class="MuiTableHead-root"
@@ -1283,20 +1270,15 @@ exports[`renders as expected at small width 1`] = `
                           class="MuiTableRow-root"
                         >
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-61"
                           >
                             segment_2
                              
-                            <div
-                              aria-disabled="true"
-                              class="MuiChip-root MuiChip-outlined Mui-disabled"
+                            <span
+                              class="makeStyles-root-58"
                             >
-                              <span
-                                class="MuiChip-label"
-                              >
-                                Excluded
-                              </span>
-                            </div>
+                              excluded
+                            </span>
                           </td>
                         </tr>
                       </tbody>
@@ -1317,32 +1299,32 @@ exports[`renders as expected at small width 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <div
-                      class="makeStyles-eventList-63"
+                      class="makeStyles-eventList-64"
                     >
                       <p
-                        class="MuiTypography-root makeStyles-monospace-64 MuiTypography-body1"
+                        class="MuiTypography-root makeStyles-monospace-65 MuiTypography-body1"
                       >
                         <span
-                          class="makeStyles-eventName-62"
+                          class="makeStyles-eventName-63"
                         >
                           event_name
                         </span>
                         <span
-                          class="makeStyles-entry-61"
+                          class="makeStyles-entry-62"
                         >
                           additionalProp1
                           : 
                           prop1Value
                         </span>
                         <span
-                          class="makeStyles-entry-61"
+                          class="makeStyles-entry-62"
                         >
                           additionalProp2
                           : 
                           prop2Value
                         </span>
                         <span
-                          class="makeStyles-entry-61"
+                          class="makeStyles-entry-62"
                         >
                           additionalProp3
                           : 
@@ -1350,10 +1332,10 @@ exports[`renders as expected at small width 1`] = `
                         </span>
                       </p>
                       <p
-                        class="MuiTypography-root makeStyles-monospace-64 MuiTypography-body1"
+                        class="MuiTypography-root makeStyles-monospace-65 MuiTypography-body1"
                       >
                         <span
-                          class="makeStyles-eventName-62"
+                          class="makeStyles-eventName-63"
                         >
                           event_without_props
                         </span>
@@ -1401,7 +1383,7 @@ exports[`renders as expected at small width 1`] = `
       class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
     >
       <h3
-        class="MuiTypography-root makeStyles-title-67 MuiTypography-h3 MuiTypography-colorTextPrimary"
+        class="MuiTypography-root makeStyles-title-68 MuiTypography-h3 MuiTypography-colorTextPrimary"
       >
         Metrics
       </h3>
@@ -1482,35 +1464,35 @@ exports[`renders as expected at small width 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <strong
-              class="makeStyles-monospace-66"
+              class="makeStyles-monospace-67"
             >
               metric_1
                
               <span
-                class="makeStyles-root-71"
+                class="makeStyles-root-58"
               >
                 primary
               </span>
             </strong>
             <br />
             <small
-              class="makeStyles-monospace-66"
+              class="makeStyles-monospace-67"
             >
               This is metric 1
             </small>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-67"
           >
             1 week
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-67"
           >
             Yes
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-67"
           >
             
             10
@@ -1529,30 +1511,30 @@ exports[`renders as expected at small width 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <strong
-              class="makeStyles-monospace-66"
+              class="makeStyles-monospace-67"
             >
               metric_2
                
             </strong>
             <br />
             <small
-              class="makeStyles-monospace-66"
+              class="makeStyles-monospace-67"
             >
               This is metric 2
             </small>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-67"
           >
             1 hour
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-67"
           >
             Yes
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-67"
           >
             USD 
             0.5
@@ -1566,30 +1548,30 @@ exports[`renders as expected at small width 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <strong
-              class="makeStyles-monospace-66"
+              class="makeStyles-monospace-67"
             >
               metric_2
                
             </strong>
             <br />
             <small
-              class="makeStyles-monospace-66"
+              class="makeStyles-monospace-67"
             >
               This is metric 2
             </small>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-67"
           >
             4 weeks
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-67"
           >
             No
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-67"
           >
             USD 
             10.5
@@ -1603,30 +1585,30 @@ exports[`renders as expected at small width 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <strong
-              class="makeStyles-monospace-66"
+              class="makeStyles-monospace-67"
             >
               metric_3
                
             </strong>
             <br />
             <small
-              class="makeStyles-monospace-66"
+              class="makeStyles-monospace-67"
             >
               This is metric 3
             </small>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-67"
           >
             6 hours
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-67"
           >
             Yes
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-67"
           >
             
             1200
@@ -2077,16 +2059,12 @@ exports[`renders as expected with conclusion data 1`] = `
                             <span>
                               control
                             </span>
-                            <div
-                              aria-disabled="true"
-                              class="MuiChip-root MuiChip-outlined Mui-disabled"
+                            <br />
+                            <span
+                              class="makeStyles-root-96"
                             >
-                              <span
-                                class="MuiChip-label"
-                              >
-                                Default
-                              </span>
-                            </div>
+                              default
+                            </span>
                           </td>
                           <td
                             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-95"
@@ -2150,7 +2128,7 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <table
-                      class="MuiTable-root makeStyles-root-96"
+                      class="MuiTable-root makeStyles-root-97"
                     >
                       <thead
                         class="MuiTableHead-root"
@@ -2174,7 +2152,7 @@ exports[`renders as expected with conclusion data 1`] = `
                           class="MuiTableRow-root"
                         >
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-99"
                           >
                             segment_1
                              
@@ -2183,7 +2161,7 @@ exports[`renders as expected with conclusion data 1`] = `
                       </tbody>
                     </table>
                     <table
-                      class="MuiTable-root makeStyles-root-96"
+                      class="MuiTable-root makeStyles-root-97"
                     >
                       <thead
                         class="MuiTableHead-root"
@@ -2207,20 +2185,15 @@ exports[`renders as expected with conclusion data 1`] = `
                           class="MuiTableRow-root"
                         >
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-99"
                           >
                             segment_2
                              
-                            <div
-                              aria-disabled="true"
-                              class="MuiChip-root MuiChip-outlined Mui-disabled"
+                            <span
+                              class="makeStyles-root-96"
                             >
-                              <span
-                                class="MuiChip-label"
-                              >
-                                Excluded
-                              </span>
-                            </div>
+                              excluded
+                            </span>
                           </td>
                         </tr>
                       </tbody>
@@ -2241,32 +2214,32 @@ exports[`renders as expected with conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <div
-                      class="makeStyles-eventList-101"
+                      class="makeStyles-eventList-102"
                     >
                       <p
-                        class="MuiTypography-root makeStyles-monospace-102 MuiTypography-body1"
+                        class="MuiTypography-root makeStyles-monospace-103 MuiTypography-body1"
                       >
                         <span
-                          class="makeStyles-eventName-100"
+                          class="makeStyles-eventName-101"
                         >
                           event_name
                         </span>
                         <span
-                          class="makeStyles-entry-99"
+                          class="makeStyles-entry-100"
                         >
                           additionalProp1
                           : 
                           prop1Value
                         </span>
                         <span
-                          class="makeStyles-entry-99"
+                          class="makeStyles-entry-100"
                         >
                           additionalProp2
                           : 
                           prop2Value
                         </span>
                         <span
-                          class="makeStyles-entry-99"
+                          class="makeStyles-entry-100"
                         >
                           additionalProp3
                           : 
@@ -2274,10 +2247,10 @@ exports[`renders as expected with conclusion data 1`] = `
                         </span>
                       </p>
                       <p
-                        class="MuiTypography-root makeStyles-monospace-102 MuiTypography-body1"
+                        class="MuiTypography-root makeStyles-monospace-103 MuiTypography-body1"
                       >
                         <span
-                          class="makeStyles-eventName-100"
+                          class="makeStyles-eventName-101"
                         >
                           event_without_props
                         </span>
@@ -2325,7 +2298,7 @@ exports[`renders as expected with conclusion data 1`] = `
       class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
     >
       <h3
-        class="MuiTypography-root makeStyles-title-105 MuiTypography-h3 MuiTypography-colorTextPrimary"
+        class="MuiTypography-root makeStyles-title-106 MuiTypography-h3 MuiTypography-colorTextPrimary"
       >
         Metrics
       </h3>
@@ -2408,35 +2381,35 @@ exports[`renders as expected with conclusion data 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <strong
-              class="makeStyles-monospace-104"
+              class="makeStyles-monospace-105"
             >
               metric_1
                
               <span
-                class="makeStyles-root-109"
+                class="makeStyles-root-96"
               >
                 primary
               </span>
             </strong>
             <br />
             <small
-              class="makeStyles-monospace-104"
+              class="makeStyles-monospace-105"
             >
               This is metric 1
             </small>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-105"
           >
             1 week
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-105"
           >
             Yes
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-105"
           >
             
             10
@@ -2455,30 +2428,30 @@ exports[`renders as expected with conclusion data 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <strong
-              class="makeStyles-monospace-104"
+              class="makeStyles-monospace-105"
             >
               metric_2
                
             </strong>
             <br />
             <small
-              class="makeStyles-monospace-104"
+              class="makeStyles-monospace-105"
             >
               This is metric 2
             </small>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-105"
           >
             1 hour
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-105"
           >
             Yes
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-105"
           >
             USD 
             0.5
@@ -2492,30 +2465,30 @@ exports[`renders as expected with conclusion data 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <strong
-              class="makeStyles-monospace-104"
+              class="makeStyles-monospace-105"
             >
               metric_2
                
             </strong>
             <br />
             <small
-              class="makeStyles-monospace-104"
+              class="makeStyles-monospace-105"
             >
               This is metric 2
             </small>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-105"
           >
             4 weeks
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-105"
           >
             No
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-105"
           >
             USD 
             10.5
@@ -2529,30 +2502,30 @@ exports[`renders as expected with conclusion data 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <strong
-              class="makeStyles-monospace-104"
+              class="makeStyles-monospace-105"
             >
               metric_3
                
             </strong>
             <br />
             <small
-              class="makeStyles-monospace-104"
+              class="makeStyles-monospace-105"
             >
               This is metric 3
             </small>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-105"
           >
             6 hours
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-105"
           >
             Yes
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-105"
           >
             
             1200
@@ -2901,16 +2874,12 @@ exports[`renders as expected without conclusion data 1`] = `
                             <span>
                               control
                             </span>
-                            <div
-                              aria-disabled="true"
-                              class="MuiChip-root MuiChip-outlined Mui-disabled"
+                            <br />
+                            <span
+                              class="makeStyles-root-132"
                             >
-                              <span
-                                class="MuiChip-label"
-                              >
-                                Default
-                              </span>
-                            </div>
+                              default
+                            </span>
                           </td>
                           <td
                             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-131"
@@ -2974,7 +2943,7 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <table
-                      class="MuiTable-root makeStyles-root-132"
+                      class="MuiTable-root makeStyles-root-133"
                     >
                       <thead
                         class="MuiTableHead-root"
@@ -2998,7 +2967,7 @@ exports[`renders as expected without conclusion data 1`] = `
                           class="MuiTableRow-root"
                         >
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-134"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-135"
                           >
                             segment_1
                              
@@ -3007,7 +2976,7 @@ exports[`renders as expected without conclusion data 1`] = `
                       </tbody>
                     </table>
                     <table
-                      class="MuiTable-root makeStyles-root-132"
+                      class="MuiTable-root makeStyles-root-133"
                     >
                       <thead
                         class="MuiTableHead-root"
@@ -3031,20 +3000,15 @@ exports[`renders as expected without conclusion data 1`] = `
                           class="MuiTableRow-root"
                         >
                           <td
-                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-134"
+                            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-135"
                           >
                             segment_2
                              
-                            <div
-                              aria-disabled="true"
-                              class="MuiChip-root MuiChip-outlined Mui-disabled"
+                            <span
+                              class="makeStyles-root-132"
                             >
-                              <span
-                                class="MuiChip-label"
-                              >
-                                Excluded
-                              </span>
-                            </div>
+                              excluded
+                            </span>
                           </td>
                         </tr>
                       </tbody>
@@ -3065,32 +3029,32 @@ exports[`renders as expected without conclusion data 1`] = `
                     class="MuiTableCell-root MuiTableCell-body"
                   >
                     <div
-                      class="makeStyles-eventList-137"
+                      class="makeStyles-eventList-138"
                     >
                       <p
-                        class="MuiTypography-root makeStyles-monospace-138 MuiTypography-body1"
+                        class="MuiTypography-root makeStyles-monospace-139 MuiTypography-body1"
                       >
                         <span
-                          class="makeStyles-eventName-136"
+                          class="makeStyles-eventName-137"
                         >
                           event_name
                         </span>
                         <span
-                          class="makeStyles-entry-135"
+                          class="makeStyles-entry-136"
                         >
                           additionalProp1
                           : 
                           prop1Value
                         </span>
                         <span
-                          class="makeStyles-entry-135"
+                          class="makeStyles-entry-136"
                         >
                           additionalProp2
                           : 
                           prop2Value
                         </span>
                         <span
-                          class="makeStyles-entry-135"
+                          class="makeStyles-entry-136"
                         >
                           additionalProp3
                           : 
@@ -3098,10 +3062,10 @@ exports[`renders as expected without conclusion data 1`] = `
                         </span>
                       </p>
                       <p
-                        class="MuiTypography-root makeStyles-monospace-138 MuiTypography-body1"
+                        class="MuiTypography-root makeStyles-monospace-139 MuiTypography-body1"
                       >
                         <span
-                          class="makeStyles-eventName-136"
+                          class="makeStyles-eventName-137"
                         >
                           event_without_props
                         </span>
@@ -3149,7 +3113,7 @@ exports[`renders as expected without conclusion data 1`] = `
       class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
     >
       <h3
-        class="MuiTypography-root makeStyles-title-141 MuiTypography-h3 MuiTypography-colorTextPrimary"
+        class="MuiTypography-root makeStyles-title-142 MuiTypography-h3 MuiTypography-colorTextPrimary"
       >
         Metrics
       </h3>
@@ -3230,35 +3194,35 @@ exports[`renders as expected without conclusion data 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <strong
-              class="makeStyles-monospace-140"
+              class="makeStyles-monospace-141"
             >
               metric_1
                
               <span
-                class="makeStyles-root-145"
+                class="makeStyles-root-132"
               >
                 primary
               </span>
             </strong>
             <br />
             <small
-              class="makeStyles-monospace-140"
+              class="makeStyles-monospace-141"
             >
               This is metric 1
             </small>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-140"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-141"
           >
             1 week
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-140"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-141"
           >
             Yes
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-140"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-141"
           >
             
             10
@@ -3277,30 +3241,30 @@ exports[`renders as expected without conclusion data 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <strong
-              class="makeStyles-monospace-140"
+              class="makeStyles-monospace-141"
             >
               metric_2
                
             </strong>
             <br />
             <small
-              class="makeStyles-monospace-140"
+              class="makeStyles-monospace-141"
             >
               This is metric 2
             </small>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-140"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-141"
           >
             1 hour
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-140"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-141"
           >
             Yes
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-140"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-141"
           >
             USD 
             0.5
@@ -3314,30 +3278,30 @@ exports[`renders as expected without conclusion data 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <strong
-              class="makeStyles-monospace-140"
+              class="makeStyles-monospace-141"
             >
               metric_2
                
             </strong>
             <br />
             <small
-              class="makeStyles-monospace-140"
+              class="makeStyles-monospace-141"
             >
               This is metric 2
             </small>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-140"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-141"
           >
             4 weeks
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-140"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-141"
           >
             No
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-140"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-141"
           >
             USD 
             10.5
@@ -3351,30 +3315,30 @@ exports[`renders as expected without conclusion data 1`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <strong
-              class="makeStyles-monospace-140"
+              class="makeStyles-monospace-141"
             >
               metric_3
                
             </strong>
             <br />
             <small
-              class="makeStyles-monospace-140"
+              class="makeStyles-monospace-141"
             >
               This is metric 3
             </small>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-140"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-141"
           >
             6 hours
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-140"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-141"
           >
             Yes
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-140"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-141"
           >
             
             1200

--- a/src/components/experiments/single-view/overview/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/src/components/experiments/single-view/overview/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -657,20 +657,30 @@ exports[`renders as expected at large width 1`] = `
           class="MuiTableRow-root"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
+            class="MuiTableCell-root MuiTableCell-body"
           >
-            metric_1
-            <br />
-            <div
-              aria-disabled="true"
-              class="MuiChip-root makeStyles-primaryChip-35 MuiChip-outlined Mui-disabled"
+            <strong
+              class="makeStyles-monospace-30"
             >
-              <span
-                class="MuiChip-label"
+              metric_1
+              <br />
+              <div
+                aria-disabled="true"
+                class="MuiChip-root makeStyles-primaryChip-35 MuiChip-outlined Mui-disabled"
               >
-                Primary
-              </span>
-            </div>
+                <span
+                  class="MuiChip-label"
+                >
+                  Primary
+                </span>
+              </div>
+            </strong>
+            <br />
+            <small
+              class="makeStyles-monospace-30"
+            >
+              This is metric 1
+            </small>
           </td>
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
@@ -699,10 +709,20 @@ exports[`renders as expected at large width 1`] = `
           class="MuiTableRow-root"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
+            class="MuiTableCell-root MuiTableCell-body"
           >
-            metric_2
+            <strong
+              class="makeStyles-monospace-30"
+            >
+              metric_2
+              <br />
+            </strong>
             <br />
+            <small
+              class="makeStyles-monospace-30"
+            >
+              This is metric 2
+            </small>
           </td>
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
@@ -726,10 +746,20 @@ exports[`renders as expected at large width 1`] = `
           class="MuiTableRow-root"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
+            class="MuiTableCell-root MuiTableCell-body"
           >
-            metric_2
+            <strong
+              class="makeStyles-monospace-30"
+            >
+              metric_2
+              <br />
+            </strong>
             <br />
+            <small
+              class="makeStyles-monospace-30"
+            >
+              This is metric 2
+            </small>
           </td>
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
@@ -753,10 +783,20 @@ exports[`renders as expected at large width 1`] = `
           class="MuiTableRow-root"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
+            class="MuiTableCell-root MuiTableCell-body"
           >
-            metric_3
+            <strong
+              class="makeStyles-monospace-30"
+            >
+              metric_3
+              <br />
+            </strong>
             <br />
+            <small
+              class="makeStyles-monospace-30"
+            >
+              This is metric 3
+            </small>
           </td>
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-30"
@@ -1444,20 +1484,30 @@ exports[`renders as expected at small width 1`] = `
           class="MuiTableRow-root"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
+            class="MuiTableCell-root MuiTableCell-body"
           >
-            metric_1
-            <br />
-            <div
-              aria-disabled="true"
-              class="MuiChip-root makeStyles-primaryChip-71 MuiChip-outlined Mui-disabled"
+            <strong
+              class="makeStyles-monospace-66"
             >
-              <span
-                class="MuiChip-label"
+              metric_1
+              <br />
+              <div
+                aria-disabled="true"
+                class="MuiChip-root makeStyles-primaryChip-71 MuiChip-outlined Mui-disabled"
               >
-                Primary
-              </span>
-            </div>
+                <span
+                  class="MuiChip-label"
+                >
+                  Primary
+                </span>
+              </div>
+            </strong>
+            <br />
+            <small
+              class="makeStyles-monospace-66"
+            >
+              This is metric 1
+            </small>
           </td>
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
@@ -1486,10 +1536,20 @@ exports[`renders as expected at small width 1`] = `
           class="MuiTableRow-root"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
+            class="MuiTableCell-root MuiTableCell-body"
           >
-            metric_2
+            <strong
+              class="makeStyles-monospace-66"
+            >
+              metric_2
+              <br />
+            </strong>
             <br />
+            <small
+              class="makeStyles-monospace-66"
+            >
+              This is metric 2
+            </small>
           </td>
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
@@ -1513,10 +1573,20 @@ exports[`renders as expected at small width 1`] = `
           class="MuiTableRow-root"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
+            class="MuiTableCell-root MuiTableCell-body"
           >
-            metric_2
+            <strong
+              class="makeStyles-monospace-66"
+            >
+              metric_2
+              <br />
+            </strong>
             <br />
+            <small
+              class="makeStyles-monospace-66"
+            >
+              This is metric 2
+            </small>
           </td>
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
@@ -1540,10 +1610,20 @@ exports[`renders as expected at small width 1`] = `
           class="MuiTableRow-root"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
+            class="MuiTableCell-root MuiTableCell-body"
           >
-            metric_3
+            <strong
+              class="makeStyles-monospace-66"
+            >
+              metric_3
+              <br />
+            </strong>
             <br />
+            <small
+              class="makeStyles-monospace-66"
+            >
+              This is metric 3
+            </small>
           </td>
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-66"
@@ -2335,20 +2415,30 @@ exports[`renders as expected with conclusion data 1`] = `
           class="MuiTableRow-root"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
+            class="MuiTableCell-root MuiTableCell-body"
           >
-            metric_1
-            <br />
-            <div
-              aria-disabled="true"
-              class="MuiChip-root makeStyles-primaryChip-109 MuiChip-outlined Mui-disabled"
+            <strong
+              class="makeStyles-monospace-104"
             >
-              <span
-                class="MuiChip-label"
+              metric_1
+              <br />
+              <div
+                aria-disabled="true"
+                class="MuiChip-root makeStyles-primaryChip-109 MuiChip-outlined Mui-disabled"
               >
-                Primary
-              </span>
-            </div>
+                <span
+                  class="MuiChip-label"
+                >
+                  Primary
+                </span>
+              </div>
+            </strong>
+            <br />
+            <small
+              class="makeStyles-monospace-104"
+            >
+              This is metric 1
+            </small>
           </td>
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
@@ -2377,10 +2467,20 @@ exports[`renders as expected with conclusion data 1`] = `
           class="MuiTableRow-root"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
+            class="MuiTableCell-root MuiTableCell-body"
           >
-            metric_2
+            <strong
+              class="makeStyles-monospace-104"
+            >
+              metric_2
+              <br />
+            </strong>
             <br />
+            <small
+              class="makeStyles-monospace-104"
+            >
+              This is metric 2
+            </small>
           </td>
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
@@ -2404,10 +2504,20 @@ exports[`renders as expected with conclusion data 1`] = `
           class="MuiTableRow-root"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
+            class="MuiTableCell-root MuiTableCell-body"
           >
-            metric_2
+            <strong
+              class="makeStyles-monospace-104"
+            >
+              metric_2
+              <br />
+            </strong>
             <br />
+            <small
+              class="makeStyles-monospace-104"
+            >
+              This is metric 2
+            </small>
           </td>
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
@@ -2431,10 +2541,20 @@ exports[`renders as expected with conclusion data 1`] = `
           class="MuiTableRow-root"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
+            class="MuiTableCell-root MuiTableCell-body"
           >
-            metric_3
+            <strong
+              class="makeStyles-monospace-104"
+            >
+              metric_3
+              <br />
+            </strong>
             <br />
+            <small
+              class="makeStyles-monospace-104"
+            >
+              This is metric 3
+            </small>
           </td>
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-104"
@@ -3122,20 +3242,30 @@ exports[`renders as expected without conclusion data 1`] = `
           class="MuiTableRow-root"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-140"
+            class="MuiTableCell-root MuiTableCell-body"
           >
-            metric_1
-            <br />
-            <div
-              aria-disabled="true"
-              class="MuiChip-root makeStyles-primaryChip-145 MuiChip-outlined Mui-disabled"
+            <strong
+              class="makeStyles-monospace-140"
             >
-              <span
-                class="MuiChip-label"
+              metric_1
+              <br />
+              <div
+                aria-disabled="true"
+                class="MuiChip-root makeStyles-primaryChip-145 MuiChip-outlined Mui-disabled"
               >
-                Primary
-              </span>
-            </div>
+                <span
+                  class="MuiChip-label"
+                >
+                  Primary
+                </span>
+              </div>
+            </strong>
+            <br />
+            <small
+              class="makeStyles-monospace-140"
+            >
+              This is metric 1
+            </small>
           </td>
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-140"
@@ -3164,10 +3294,20 @@ exports[`renders as expected without conclusion data 1`] = `
           class="MuiTableRow-root"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-140"
+            class="MuiTableCell-root MuiTableCell-body"
           >
-            metric_2
+            <strong
+              class="makeStyles-monospace-140"
+            >
+              metric_2
+              <br />
+            </strong>
             <br />
+            <small
+              class="makeStyles-monospace-140"
+            >
+              This is metric 2
+            </small>
           </td>
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-140"
@@ -3191,10 +3331,20 @@ exports[`renders as expected without conclusion data 1`] = `
           class="MuiTableRow-root"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-140"
+            class="MuiTableCell-root MuiTableCell-body"
           >
-            metric_2
+            <strong
+              class="makeStyles-monospace-140"
+            >
+              metric_2
+              <br />
+            </strong>
             <br />
+            <small
+              class="makeStyles-monospace-140"
+            >
+              This is metric 2
+            </small>
           </td>
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-140"
@@ -3218,10 +3368,20 @@ exports[`renders as expected without conclusion data 1`] = `
           class="MuiTableRow-root"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-140"
+            class="MuiTableCell-root MuiTableCell-body"
           >
-            metric_3
+            <strong
+              class="makeStyles-monospace-140"
+            >
+              metric_3
+              <br />
+            </strong>
             <br />
+            <small
+              class="makeStyles-monospace-140"
+            >
+              This is metric 3
+            </small>
           </td>
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-140"

--- a/src/components/experiments/single-view/results/ActualExperimentResults.tsx
+++ b/src/components/experiments/single-view/results/ActualExperimentResults.tsx
@@ -3,7 +3,6 @@ import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
-  Chip,
   createStyles,
   FormControl,
   InputLabel,
@@ -24,6 +23,7 @@ import { PlotData } from 'plotly.js'
 import React, { useState } from 'react'
 import Plot from 'react-plotly.js'
 
+import Attribute from 'src/components/general/Attribute'
 import MetricValue, { metricValueFormatData } from 'src/components/general/MetricValue'
 import * as Analyses from 'src/lib/analyses'
 import * as Experiments from 'src/lib/experiments'
@@ -52,9 +52,6 @@ const useStyles = makeStyles((theme: Theme) =>
       '& .MuiIconButton-root.Mui-disabled': {
         opacity: 0,
       },
-    },
-    primaryChip: {
-      marginTop: theme.spacing(1),
     },
     summary: {
       display: 'flex',
@@ -257,9 +254,13 @@ export default function ActualExperimentResults({
         <>
           <Tooltip title={metric.description}>
             <span>{metric.name}</span>
-          </Tooltip>{' '}
+          </Tooltip>
+          &nbsp;
           {metricAssignment.isPrimary && (
-            <Chip label='Primary' variant='outlined' disabled className={classes.primaryChip} />
+            <>
+              <br />
+              <Attribute name='primary' />
+            </>
           )}
         </>
       ),

--- a/src/components/experiments/single-view/results/ActualExperimentResults.tsx
+++ b/src/components/experiments/single-view/results/ActualExperimentResults.tsx
@@ -135,6 +135,9 @@ const useStyles = makeStyles((theme: Theme) =>
       color: theme.palette.grey[600],
       whiteSpace: 'pre',
     },
+    metricAssignmentNameLine: {
+      whiteSpace: 'nowrap',
+    },
   }),
 )
 
@@ -249,13 +252,15 @@ export default function ActualExperimentResults({
 
   const tableColumns = [
     {
-      title: 'Metric',
+      title: 'Metric (attribution window)',
       render: ({ metric, metricAssignment }: { metric: MetricBare; metricAssignment: MetricAssignment }) => (
         <>
-          <Tooltip title={metric.description}>
-            <span>{metric.name}</span>
-          </Tooltip>
-          &nbsp;
+          <span className={classes.metricAssignmentNameLine}>
+            <Tooltip title={metric.description}>
+              <span>{metric.name}</span>
+            </Tooltip>
+            &nbsp;({AttributionWindowSecondsToHuman[metricAssignment.attributionWindowSeconds]})
+          </span>
           {metricAssignment.isPrimary && (
             <>
               <br />
@@ -267,14 +272,6 @@ export default function ActualExperimentResults({
       cellStyle: {
         fontFamily: theme.custom.fonts.monospace,
         fontWeight: 600,
-      },
-    },
-    {
-      title: 'Attribution window',
-      render: ({ metricAssignment }: { metricAssignment: MetricAssignment }) =>
-        AttributionWindowSecondsToHuman[metricAssignment.attributionWindowSeconds],
-      cellStyle: {
-        fontFamily: theme.custom.fonts.monospace,
       },
     },
     {

--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`renders an appropriate message with no analyses 1`] = `
       class="makeStyles-root-1"
     >
       <div
-        class="MuiPaper-root makeStyles-noAnalysesPaper-19 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-noAnalysesPaper-18 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -43,7 +43,7 @@ exports[`renders an appropriate message with no analyses 1`] = `
         </ul>
       </div>
       <div
-        class="MuiPaper-root MuiAccordion-root makeStyles-accordion-17 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root MuiAccordion-root makeStyles-accordion-16 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
       >
         <div
           aria-disabled="false"
@@ -99,7 +99,7 @@ exports[`renders an appropriate message with no analyses 1`] = `
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-18"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-17"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -112,7 +112,7 @@ exports[`renders an appropriate message with no analyses 1`] = `
                     This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                   </p>
                   <pre
-                    class="makeStyles-pre-20"
+                    class="makeStyles-pre-19"
                   >
                     <code>
                       with tracks_counts as (
@@ -149,13 +149,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-22"
+    class="makeStyles-root-21"
   >
     <div
-      class="makeStyles-summary-24"
+      class="makeStyles-summary-22"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-35 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-33 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -164,16 +164,16 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-26"
+        class="makeStyles-summaryColumn-24"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-27 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-25 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-28"
+            class="makeStyles-summaryStatsPart-26"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-30 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-28 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               1,000
             </h3>
@@ -189,10 +189,10 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-28"
+            class="makeStyles-summaryStatsPart-26"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-30 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-28 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Deploy 
               test
@@ -208,12 +208,12 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-31 makeStyles-indicationSeverityWarning-33 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-29 makeStyles-indicationSeverityWarning-31 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-30 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-28 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Potential issues
             </h3>
@@ -230,7 +230,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-37 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-35 MuiTypography-h3"
     >
       Metric Assignment Results
     </h3>
@@ -239,7 +239,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-48"
+        class="Component-horizontalScrollContainer-46"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -258,40 +258,40 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-49 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-47 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-49 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-47 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-49 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-47 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Attribution window
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-49 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-47 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Absolute change
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-49 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-47 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Relative change (lift)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-49 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-47 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -347,17 +347,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                       >
                         metric_1
                       </span>
-                       
-                      <div
-                        aria-disabled="true"
-                        class="MuiChip-root makeStyles-primaryChip-23 MuiChip-outlined Mui-disabled"
+                       
+                      <br />
+                      <span
+                        class="makeStyles-root-48"
                       >
-                        <span
-                          class="MuiChip-label"
-                        >
-                          Primary
-                        </span>
-                      </div>
+                        primary
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -370,7 +366,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
                       <span
-                        class="makeStyles-topLevelDiff-42"
+                        class="makeStyles-topLevelDiff-40"
                       >
                         -1
                          to 
@@ -385,7 +381,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                       style="box-sizing: border-box;"
                     >
                       <span
-                        class="makeStyles-topLevelDiff-42"
+                        class="makeStyles-topLevelDiff-40"
                       >
                         -50.00
                          to 
@@ -446,7 +442,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                       >
                         metric_2
                       </span>
-                       
+                       
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -514,7 +510,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                       >
                         metric_2
                       </span>
-                       
+                       
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -582,7 +578,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                       >
                         metric_3
                       </span>
-                       
+                       
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -613,7 +609,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-37 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-35 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -695,18 +691,18 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-51 makeStyles-deemphasized-52 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-58"
+                  class="makeStyles-tooltip-57"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-51 makeStyles-deemphasized-52 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
                 scope="row"
               >
                 1.0000
@@ -718,7 +714,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-54 makeStyles-indicationSeverityOk-55 makeStyles-monospace-51 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-53 makeStyles-indicationSeverityOk-54 makeStyles-monospace-50 makeStyles-nowrap-52"
                 scope="row"
               >
                 <span>
@@ -726,13 +722,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-51 makeStyles-deemphasized-52 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-51"
                 scope="row"
               >
                 <p
@@ -756,18 +752,18 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-51 makeStyles-deemphasized-52 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-58"
+                  class="makeStyles-tooltip-57"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-51 makeStyles-deemphasized-52 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
                 scope="row"
               >
                 1.0000
@@ -779,7 +775,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-54 makeStyles-indicationSeverityOk-55 makeStyles-monospace-51 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-53 makeStyles-indicationSeverityOk-54 makeStyles-monospace-50 makeStyles-nowrap-52"
                 scope="row"
               >
                 <span>
@@ -787,13 +783,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-51 makeStyles-deemphasized-52 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-51"
                 scope="row"
               >
                 <p
@@ -817,18 +813,18 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-51 makeStyles-deemphasized-52 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-58"
+                  class="makeStyles-tooltip-57"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-51 makeStyles-deemphasized-52 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
                 scope="row"
               >
                 1.0000
@@ -840,7 +836,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-54 makeStyles-indicationSeverityOk-55 makeStyles-monospace-51 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-53 makeStyles-indicationSeverityOk-54 makeStyles-monospace-50 makeStyles-nowrap-52"
                 scope="row"
               >
                 <span>
@@ -848,13 +844,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-51 makeStyles-deemphasized-52 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-51"
                 scope="row"
               >
                 <p
@@ -878,7 +874,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-51 makeStyles-deemphasized-52 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
                 scope="row"
               >
                 <span>
@@ -886,7 +882,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-51 makeStyles-deemphasized-52 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
                 scope="row"
               >
                 0.0000
@@ -898,7 +894,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-54 makeStyles-indicationSeverityOk-55 makeStyles-monospace-51 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-53 makeStyles-indicationSeverityOk-54 makeStyles-monospace-50 makeStyles-nowrap-52"
                 scope="row"
               >
                 <span>
@@ -906,13 +902,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-51 makeStyles-deemphasized-52 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.01
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-51"
                 scope="row"
               >
                 <p
@@ -936,7 +932,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-51 makeStyles-deemphasized-52 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
                 scope="row"
               >
                 <span>
@@ -944,7 +940,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-51 makeStyles-deemphasized-52 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
                 scope="row"
               >
                 0.0000
@@ -956,7 +952,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-54 makeStyles-indicationSeverityOk-55 makeStyles-monospace-51 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-53 makeStyles-indicationSeverityOk-54 makeStyles-monospace-50 makeStyles-nowrap-52"
                 scope="row"
               >
                 <span>
@@ -964,13 +960,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-51 makeStyles-deemphasized-52 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-51"
                 scope="row"
               >
                 <p
@@ -994,7 +990,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-51 makeStyles-deemphasized-52 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
                 scope="row"
               >
                 <span>
@@ -1002,7 +998,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-51 makeStyles-deemphasized-52 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
                 scope="row"
               >
                 0.1000
@@ -1014,7 +1010,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-54 makeStyles-indicationSeverityOk-55 makeStyles-monospace-51 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-53 makeStyles-indicationSeverityOk-54 makeStyles-monospace-50 makeStyles-nowrap-52"
                 scope="row"
               >
                 <span>
@@ -1022,13 +1018,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-51 makeStyles-deemphasized-52 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.8
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-51"
                 scope="row"
               >
                 <p
@@ -1052,7 +1048,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-51 makeStyles-deemphasized-52 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
                 scope="row"
               >
                 <span>
@@ -1060,7 +1056,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-51 makeStyles-deemphasized-52 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
                 scope="row"
               >
                 0.0000
@@ -1074,7 +1070,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-54 makeStyles-indicationSeverityWarning-56 makeStyles-monospace-51 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-53 makeStyles-indicationSeverityWarning-55 makeStyles-monospace-50 makeStyles-nowrap-52"
                 scope="row"
               >
                 <span>
@@ -1082,13 +1078,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-51 makeStyles-deemphasized-52 makeStyles-nowrap-53"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-51"
                 scope="row"
               >
                 <p
@@ -1103,7 +1099,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-38 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-36 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         aria-disabled="false"
@@ -1159,7 +1155,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
               role="region"
             >
               <div
-                class="MuiAccordionDetails-root makeStyles-accordionDetails-39"
+                class="MuiAccordionDetails-root makeStyles-accordionDetails-37"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -1172,7 +1168,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                   This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                 </p>
                 <pre
-                  class="makeStyles-pre-41"
+                  class="makeStyles-pre-39"
                 >
                   <code>
                     with tracks_counts as (
@@ -1205,7 +1201,7 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders correctly for 1 analysis datapoint 2`] = `
 <div
-  class="MuiTableContainer-root makeStyles-root-59 analysis-detail-panel"
+  class="MuiTableContainer-root makeStyles-root-58 analysis-detail-panel"
 >
   <table
     class="MuiTable-root"
@@ -1217,14 +1213,14 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-60"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-59"
           role="cell"
           scope="row"
         >
           Metric Description
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-metricDescription-72"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-metricDescription-71"
         >
           This is metric 1
         </td>
@@ -1232,13 +1228,13 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
     </tbody>
   </table>
   <div
-    class="makeStyles-dataTableContainer-69"
+    class="makeStyles-dataTableContainer-68"
   >
     <div
-      class="makeStyles-latestEstimates-70"
+      class="makeStyles-latestEstimates-69"
     >
       <h5
-        class="MuiTypography-root makeStyles-dataTableHeader-75 MuiTypography-h5"
+        class="MuiTypography-root makeStyles-dataTableHeader-74 MuiTypography-h5"
       >
         Estimated 95% Credible Intervals (CIs)
          
@@ -1253,22 +1249,22 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-67 makeStyles-headerCell-60 makeStyles-credibleIntervalHeader-74"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-66 makeStyles-headerCell-59 makeStyles-credibleIntervalHeader-73"
               role="cell"
               scope="row"
             >
               Difference
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-61"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
             >
               <span
-                class="makeStyles-tooltipped-68"
+                class="makeStyles-tooltipped-67"
               >
                 
                 -1
                 <span
-                  class="makeStyles-root-76"
+                  class="makeStyles-root-75"
                   title="Percentage points."
                 >
                   pp
@@ -1277,7 +1273,7 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
                 
                 1
                 <span
-                  class="makeStyles-root-76"
+                  class="makeStyles-root-75"
                   title="Percentage points."
                 >
                   pp
@@ -1289,22 +1285,22 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-67 makeStyles-headerCell-60 makeStyles-credibleIntervalHeader-74"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-66 makeStyles-headerCell-59 makeStyles-credibleIntervalHeader-73"
               role="cell"
               scope="row"
               valign="top"
             >
               <span
-                class="makeStyles-monospace-61"
+                class="makeStyles-monospace-60"
               >
                 test
               </span>
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-61"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
             >
               <span
-                class="makeStyles-tooltipped-68"
+                class="makeStyles-tooltipped-67"
               >
                 
                 -112.3
@@ -1320,22 +1316,22 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-67 makeStyles-headerCell-60 makeStyles-credibleIntervalHeader-74"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-66 makeStyles-headerCell-59 makeStyles-credibleIntervalHeader-73"
               role="cell"
               scope="row"
               valign="top"
             >
               <span
-                class="makeStyles-monospace-61"
+                class="makeStyles-monospace-60"
               >
                 control
               </span>
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-61"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
             >
               <span
-                class="makeStyles-tooltipped-68"
+                class="makeStyles-tooltipped-67"
               >
                 
                 0
@@ -1351,10 +1347,10 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
       </table>
     </div>
     <div
-      class="makeStyles-metricAssignmentDetails-71"
+      class="makeStyles-metricAssignmentDetails-70"
     >
       <h5
-        class="MuiTypography-root makeStyles-dataTableHeader-75 MuiTypography-h5"
+        class="MuiTypography-root makeStyles-dataTableHeader-74 MuiTypography-h5"
       >
         Metric Assignment Settings
       </h5>
@@ -1368,14 +1364,14 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-60"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-59"
               role="cell"
               scope="row"
             >
               Attribution Window
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-61"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
             >
               1 week
             </td>
@@ -1384,19 +1380,19 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-60"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-59"
               role="cell"
               scope="row"
             >
               Minimum Practical Difference
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-61"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
             >
               
               10
               <span
-                class="makeStyles-root-76"
+                class="makeStyles-root-75"
                 title="Percentage points."
               >
                 pp
@@ -1407,14 +1403,14 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-60"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-59"
               role="cell"
               scope="row"
             >
               Change Expected
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-61"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
             >
               Yes
             </td>
@@ -1424,19 +1420,19 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
     </div>
   </div>
   <p
-    class="MuiTypography-root makeStyles-noPlotMessage-65 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-noPlotMessage-64 MuiTypography-body1"
   >
     Past values will be plotted once we have more than one day of results.
   </p>
   <p
-    class="MuiTypography-root makeStyles-analysisFinePrint-73 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-analysisFinePrint-72 MuiTypography-body1"
   >
     <strong>
       Last analyzed:
     </strong>
      
     <span
-      class="makeStyles-root-77"
+      class="makeStyles-root-76"
       title="09/05/2020, 20:00:00"
     >
       2020-05-10
@@ -1467,7 +1463,7 @@ exports[`renders correctly for 1 analysis datapoint 3`] = `
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-36",
+        "className": "makeStyles-participantsPlot-34",
         "data": Array [
           Object {
             "line": Object {
@@ -1535,13 +1531,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-78"
+    class="makeStyles-root-77"
   >
     <div
-      class="makeStyles-summary-80"
+      class="makeStyles-summary-78"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-91 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-89 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -1550,16 +1546,16 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-82"
+        class="makeStyles-summaryColumn-80"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-83 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-81 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-84"
+            class="makeStyles-summaryStatsPart-82"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-86 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-84 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               700
             </h3>
@@ -1575,10 +1571,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-84"
+            class="makeStyles-summaryStatsPart-82"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-86 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-84 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Deploy 
               test
@@ -1594,12 +1590,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-87 makeStyles-indicationSeverityError-90 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-85 makeStyles-indicationSeverityError-88 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-86 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-84 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Serious issues
             </h3>
@@ -1616,7 +1612,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-93 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-91 MuiTypography-h3"
     >
       Metric Assignment Results
     </h3>
@@ -1625,7 +1621,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-104"
+        class="Component-horizontalScrollContainer-102"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -1644,40 +1640,40 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-105 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-103 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-105 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-103 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-105 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-103 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Attribution window
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-105 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-103 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Absolute change
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-105 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-103 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Relative change (lift)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-105 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-103 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -1733,17 +1729,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       >
                         metric_1
                       </span>
-                       
-                      <div
-                        aria-disabled="true"
-                        class="MuiChip-root makeStyles-primaryChip-79 MuiChip-outlined Mui-disabled"
+                       
+                      <br />
+                      <span
+                        class="makeStyles-root-104"
                       >
-                        <span
-                          class="MuiChip-label"
-                        >
-                          Primary
-                        </span>
-                      </div>
+                        primary
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -1756,7 +1748,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
                       <span
-                        class="makeStyles-topLevelDiff-98"
+                        class="makeStyles-topLevelDiff-96"
                       >
                         -1
                          to 
@@ -1771,7 +1763,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box;"
                     >
                       <span
-                        class="makeStyles-topLevelDiff-98"
+                        class="makeStyles-topLevelDiff-96"
                       >
                         -50.00
                          to 
@@ -1832,7 +1824,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       >
                         metric_2
                       </span>
-                       
+                       
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -1900,7 +1892,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       >
                         metric_2
                       </span>
-                       
+                       
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -1968,7 +1960,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       >
                         metric_3
                       </span>
-                       
+                       
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -1981,7 +1973,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
                       <span
-                        class="makeStyles-topLevelDiff-98"
+                        class="makeStyles-topLevelDiff-96"
                       >
                         -1
                          to 
@@ -1996,7 +1988,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box;"
                     >
                       <span
-                        class="makeStyles-topLevelDiff-98"
+                        class="makeStyles-topLevelDiff-96"
                       >
                         -50.00
                          to 
@@ -2020,7 +2012,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-93 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-91 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -2102,18 +2094,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-107 makeStyles-deemphasized-108 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-114"
+                  class="makeStyles-tooltip-113"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-107 makeStyles-deemphasized-108 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
                 scope="row"
               >
                 1.0000
@@ -2125,7 +2117,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-110 makeStyles-indicationSeverityOk-111 makeStyles-monospace-107 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-109 makeStyles-indicationSeverityOk-110 makeStyles-monospace-106 makeStyles-nowrap-108"
                 scope="row"
               >
                 <span>
@@ -2133,13 +2125,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-107 makeStyles-deemphasized-108 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-107"
                 scope="row"
               >
                 <p
@@ -2163,18 +2155,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-107 makeStyles-deemphasized-108 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-114"
+                  class="makeStyles-tooltip-113"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-107 makeStyles-deemphasized-108 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
                 scope="row"
               >
                 1.0000
@@ -2186,7 +2178,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-110 makeStyles-indicationSeverityOk-111 makeStyles-monospace-107 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-109 makeStyles-indicationSeverityOk-110 makeStyles-monospace-106 makeStyles-nowrap-108"
                 scope="row"
               >
                 <span>
@@ -2194,13 +2186,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-107 makeStyles-deemphasized-108 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-107"
                 scope="row"
               >
                 <p
@@ -2224,18 +2216,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-107 makeStyles-deemphasized-108 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-114"
+                  class="makeStyles-tooltip-113"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-107 makeStyles-deemphasized-108 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
                 scope="row"
               >
                 1.0000
@@ -2247,7 +2239,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-110 makeStyles-indicationSeverityOk-111 makeStyles-monospace-107 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-109 makeStyles-indicationSeverityOk-110 makeStyles-monospace-106 makeStyles-nowrap-108"
                 scope="row"
               >
                 <span>
@@ -2255,13 +2247,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-107 makeStyles-deemphasized-108 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-107"
                 scope="row"
               >
                 <p
@@ -2285,7 +2277,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-107 makeStyles-deemphasized-108 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
                 scope="row"
               >
                 <span>
@@ -2293,7 +2285,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-107 makeStyles-deemphasized-108 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
                 scope="row"
               >
                 0.1000
@@ -2307,7 +2299,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-110 makeStyles-indicationSeverityError-113 makeStyles-monospace-107 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-109 makeStyles-indicationSeverityError-112 makeStyles-monospace-106 makeStyles-nowrap-108"
                 scope="row"
               >
                 <span>
@@ -2315,13 +2307,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-107 makeStyles-deemphasized-108 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-107"
                 scope="row"
               >
                 <p
@@ -2347,7 +2339,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-107 makeStyles-deemphasized-108 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
                 scope="row"
               >
                 <span>
@@ -2355,7 +2347,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-107 makeStyles-deemphasized-108 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
                 scope="row"
               >
                 0.1500
@@ -2369,7 +2361,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-110 makeStyles-indicationSeverityWarning-112 makeStyles-monospace-107 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-109 makeStyles-indicationSeverityWarning-111 makeStyles-monospace-106 makeStyles-nowrap-108"
                 scope="row"
               >
                 <span>
@@ -2377,13 +2369,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-107 makeStyles-deemphasized-108 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
                 scope="row"
               >
                 0.1 &lt; x ≤ 0.4
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-107"
                 scope="row"
               >
                 <p
@@ -2409,7 +2401,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-107 makeStyles-deemphasized-108 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
                 scope="row"
               >
                 <span>
@@ -2417,7 +2409,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-107 makeStyles-deemphasized-108 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
                 scope="row"
               >
                 0.1000
@@ -2429,7 +2421,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-110 makeStyles-indicationSeverityOk-111 makeStyles-monospace-107 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-109 makeStyles-indicationSeverityOk-110 makeStyles-monospace-106 makeStyles-nowrap-108"
                 scope="row"
               >
                 <span>
@@ -2437,13 +2429,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-107 makeStyles-deemphasized-108 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.8
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-107"
                 scope="row"
               >
                 <p
@@ -2467,7 +2459,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-107 makeStyles-deemphasized-108 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
                 scope="row"
               >
                 <span>
@@ -2475,7 +2467,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-107 makeStyles-deemphasized-108 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
                 scope="row"
               >
                 0.0000
@@ -2489,7 +2481,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-110 makeStyles-indicationSeverityWarning-112 makeStyles-monospace-107 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-109 makeStyles-indicationSeverityWarning-111 makeStyles-monospace-106 makeStyles-nowrap-108"
                 scope="row"
               >
                 <span>
@@ -2497,13 +2489,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-107 makeStyles-deemphasized-108 makeStyles-nowrap-109"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-107"
                 scope="row"
               >
                 <p
@@ -2518,7 +2510,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-94 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-92 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         aria-disabled="false"
@@ -2574,7 +2566,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               role="region"
             >
               <div
-                class="MuiAccordionDetails-root makeStyles-accordionDetails-95"
+                class="MuiAccordionDetails-root makeStyles-accordionDetails-93"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -2587,7 +2579,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                   This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                 </p>
                 <pre
-                  class="makeStyles-pre-97"
+                  class="makeStyles-pre-95"
                 >
                   <code>
                     with tracks_counts as (
@@ -2620,7 +2612,7 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders the condensed table with some analyses in non-debug mode for a Conversion Metric 2`] = `
 <div
-  class="MuiTableContainer-root makeStyles-root-115 analysis-detail-panel"
+  class="MuiTableContainer-root makeStyles-root-114 analysis-detail-panel"
 >
   <table
     class="MuiTable-root"
@@ -2632,14 +2624,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-116"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-115"
           role="cell"
           scope="row"
         >
           Metric Description
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-metricDescription-128"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-metricDescription-127"
         >
           This is metric 1
         </td>
@@ -2647,13 +2639,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </tbody>
   </table>
   <div
-    class="makeStyles-dataTableContainer-125"
+    class="makeStyles-dataTableContainer-124"
   >
     <div
-      class="makeStyles-latestEstimates-126"
+      class="makeStyles-latestEstimates-125"
     >
       <h5
-        class="MuiTypography-root makeStyles-dataTableHeader-131 MuiTypography-h5"
+        class="MuiTypography-root makeStyles-dataTableHeader-130 MuiTypography-h5"
       >
         Estimated 95% Credible Intervals (CIs)
          
@@ -2668,22 +2660,22 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-123 makeStyles-headerCell-116 makeStyles-credibleIntervalHeader-130"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-122 makeStyles-headerCell-115 makeStyles-credibleIntervalHeader-129"
               role="cell"
               scope="row"
             >
               Difference
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-117"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-116"
             >
               <span
-                class="makeStyles-tooltipped-124"
+                class="makeStyles-tooltipped-123"
               >
                 
                 -1
                 <span
-                  class="makeStyles-root-132"
+                  class="makeStyles-root-131"
                   title="Percentage points."
                 >
                   pp
@@ -2692,7 +2684,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 
                 1
                 <span
-                  class="makeStyles-root-132"
+                  class="makeStyles-root-131"
                   title="Percentage points."
                 >
                   pp
@@ -2704,22 +2696,22 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-123 makeStyles-headerCell-116 makeStyles-credibleIntervalHeader-130"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-122 makeStyles-headerCell-115 makeStyles-credibleIntervalHeader-129"
               role="cell"
               scope="row"
               valign="top"
             >
               <span
-                class="makeStyles-monospace-117"
+                class="makeStyles-monospace-116"
               >
                 test
               </span>
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-117"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-116"
             >
               <span
-                class="makeStyles-tooltipped-124"
+                class="makeStyles-tooltipped-123"
               >
                 
                 -112.3
@@ -2735,22 +2727,22 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-123 makeStyles-headerCell-116 makeStyles-credibleIntervalHeader-130"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-122 makeStyles-headerCell-115 makeStyles-credibleIntervalHeader-129"
               role="cell"
               scope="row"
               valign="top"
             >
               <span
-                class="makeStyles-monospace-117"
+                class="makeStyles-monospace-116"
               >
                 control
               </span>
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-117"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-116"
             >
               <span
-                class="makeStyles-tooltipped-124"
+                class="makeStyles-tooltipped-123"
               >
                 
                 0
@@ -2766,10 +2758,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </table>
     </div>
     <div
-      class="makeStyles-metricAssignmentDetails-127"
+      class="makeStyles-metricAssignmentDetails-126"
     >
       <h5
-        class="MuiTypography-root makeStyles-dataTableHeader-131 MuiTypography-h5"
+        class="MuiTypography-root makeStyles-dataTableHeader-130 MuiTypography-h5"
       >
         Metric Assignment Settings
       </h5>
@@ -2783,14 +2775,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-116"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-115"
               role="cell"
               scope="row"
             >
               Attribution Window
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-117"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-116"
             >
               1 week
             </td>
@@ -2799,19 +2791,19 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-116"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-115"
               role="cell"
               scope="row"
             >
               Minimum Practical Difference
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-117"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-116"
             >
               
               10
               <span
-                class="makeStyles-root-132"
+                class="makeStyles-root-131"
                 title="Percentage points."
               >
                 pp
@@ -2822,14 +2814,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-116"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-115"
               role="cell"
               scope="row"
             >
               Change Expected
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-117"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-116"
             >
               Yes
             </td>
@@ -2839,17 +2831,17 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </div>
   </div>
   <div
-    class="makeStyles-metricEstimatePlots-118"
+    class="makeStyles-metricEstimatePlots-117"
   />
   <p
-    class="MuiTypography-root makeStyles-analysisFinePrint-129 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-analysisFinePrint-128 MuiTypography-body1"
   >
     <strong>
       Last analyzed:
     </strong>
      
     <span
-      class="makeStyles-root-133"
+      class="makeStyles-root-132"
       title="09/05/2020, 20:00:00"
     >
       2020-05-10
@@ -2880,7 +2872,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-92",
+        "className": "makeStyles-participantsPlot-90",
         "data": Array [
           Object {
             "line": Object {
@@ -2939,7 +2931,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-119",
+        "className": "makeStyles-metricEstimatePlot-118",
         "data": Array [
           Object {
             "line": Object {
@@ -3035,7 +3027,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-119",
+        "className": "makeStyles-metricEstimatePlot-118",
         "data": Array [
           Object {
             "line": Object {
@@ -3137,7 +3129,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-119",
+        "className": "makeStyles-metricEstimatePlot-118",
         "data": Array [
           Object {
             "line": Object {
@@ -3233,7 +3225,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-119",
+        "className": "makeStyles-metricEstimatePlot-118",
         "data": Array [
           Object {
             "line": Object {
@@ -3364,13 +3356,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-134"
+    class="makeStyles-root-133"
   >
     <div
-      class="makeStyles-summary-136"
+      class="makeStyles-summary-134"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-147 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-145 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -3379,16 +3371,16 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-138"
+        class="makeStyles-summaryColumn-136"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-139 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-137 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-140"
+            class="makeStyles-summaryStatsPart-138"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-142 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-140 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               700
             </h3>
@@ -3404,10 +3396,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-140"
+            class="makeStyles-summaryStatsPart-138"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-142 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-140 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Deploy 
               test
@@ -3423,12 +3415,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-143 makeStyles-indicationSeverityError-146 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-141 makeStyles-indicationSeverityError-144 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-142 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-140 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Serious issues
             </h3>
@@ -3445,7 +3437,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-149 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-147 MuiTypography-h3"
     >
       Metric Assignment Results
     </h3>
@@ -3454,7 +3446,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-160"
+        class="Component-horizontalScrollContainer-158"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -3473,40 +3465,40 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-161 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-161 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-161 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Attribution window
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-161 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Absolute change
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-161 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Relative change (lift)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-161 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -3562,17 +3554,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       >
                         metric_1
                       </span>
-                       
-                      <div
-                        aria-disabled="true"
-                        class="MuiChip-root makeStyles-primaryChip-135 MuiChip-outlined Mui-disabled"
+                       
+                      <br />
+                      <span
+                        class="makeStyles-root-160"
                       >
-                        <span
-                          class="MuiChip-label"
-                        >
-                          Primary
-                        </span>
-                      </div>
+                        primary
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -3585,7 +3573,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
                       <span
-                        class="makeStyles-topLevelDiff-154"
+                        class="makeStyles-topLevelDiff-152"
                       >
                         -0.01
                          to 
@@ -3600,7 +3588,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box;"
                     >
                       <span
-                        class="makeStyles-topLevelDiff-154"
+                        class="makeStyles-topLevelDiff-152"
                       >
                         -50.00
                          to 
@@ -3661,7 +3649,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       >
                         metric_2
                       </span>
-                       
+                       
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -3729,7 +3717,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       >
                         metric_2
                       </span>
-                       
+                       
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -3797,7 +3785,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       >
                         metric_3
                       </span>
-                       
+                       
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -3810,7 +3798,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
                       <span
-                        class="makeStyles-topLevelDiff-154"
+                        class="makeStyles-topLevelDiff-152"
                       >
                         -0.01
                          to 
@@ -3825,7 +3813,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box;"
                     >
                       <span
-                        class="makeStyles-topLevelDiff-154"
+                        class="makeStyles-topLevelDiff-152"
                       >
                         -50.00
                          to 
@@ -3849,7 +3837,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-149 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-147 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -3931,18 +3919,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-163 makeStyles-deemphasized-164 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-170"
+                  class="makeStyles-tooltip-169"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-163 makeStyles-deemphasized-164 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
                 scope="row"
               >
                 1.0000
@@ -3954,7 +3942,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-166 makeStyles-indicationSeverityOk-167 makeStyles-monospace-163 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-165 makeStyles-indicationSeverityOk-166 makeStyles-monospace-162 makeStyles-nowrap-164"
                 scope="row"
               >
                 <span>
@@ -3962,13 +3950,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-163 makeStyles-deemphasized-164 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-163"
                 scope="row"
               >
                 <p
@@ -3992,18 +3980,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-163 makeStyles-deemphasized-164 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-170"
+                  class="makeStyles-tooltip-169"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-163 makeStyles-deemphasized-164 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
                 scope="row"
               >
                 1.0000
@@ -4015,7 +4003,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-166 makeStyles-indicationSeverityOk-167 makeStyles-monospace-163 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-165 makeStyles-indicationSeverityOk-166 makeStyles-monospace-162 makeStyles-nowrap-164"
                 scope="row"
               >
                 <span>
@@ -4023,13 +4011,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-163 makeStyles-deemphasized-164 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-163"
                 scope="row"
               >
                 <p
@@ -4053,18 +4041,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-163 makeStyles-deemphasized-164 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-170"
+                  class="makeStyles-tooltip-169"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-163 makeStyles-deemphasized-164 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
                 scope="row"
               >
                 1.0000
@@ -4076,7 +4064,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-166 makeStyles-indicationSeverityOk-167 makeStyles-monospace-163 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-165 makeStyles-indicationSeverityOk-166 makeStyles-monospace-162 makeStyles-nowrap-164"
                 scope="row"
               >
                 <span>
@@ -4084,13 +4072,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-163 makeStyles-deemphasized-164 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-163"
                 scope="row"
               >
                 <p
@@ -4114,7 +4102,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-163 makeStyles-deemphasized-164 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
                 scope="row"
               >
                 <span>
@@ -4122,7 +4110,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-163 makeStyles-deemphasized-164 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
                 scope="row"
               >
                 0.1000
@@ -4136,7 +4124,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-166 makeStyles-indicationSeverityError-169 makeStyles-monospace-163 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-165 makeStyles-indicationSeverityError-168 makeStyles-monospace-162 makeStyles-nowrap-164"
                 scope="row"
               >
                 <span>
@@ -4144,13 +4132,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-163 makeStyles-deemphasized-164 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-163"
                 scope="row"
               >
                 <p
@@ -4176,7 +4164,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-163 makeStyles-deemphasized-164 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
                 scope="row"
               >
                 <span>
@@ -4184,7 +4172,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-163 makeStyles-deemphasized-164 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
                 scope="row"
               >
                 0.1500
@@ -4198,7 +4186,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-166 makeStyles-indicationSeverityWarning-168 makeStyles-monospace-163 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-165 makeStyles-indicationSeverityWarning-167 makeStyles-monospace-162 makeStyles-nowrap-164"
                 scope="row"
               >
                 <span>
@@ -4206,13 +4194,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-163 makeStyles-deemphasized-164 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
                 scope="row"
               >
                 0.1 &lt; x ≤ 0.4
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-163"
                 scope="row"
               >
                 <p
@@ -4238,7 +4226,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-163 makeStyles-deemphasized-164 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
                 scope="row"
               >
                 <span>
@@ -4246,7 +4234,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-163 makeStyles-deemphasized-164 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
                 scope="row"
               >
                 0.1000
@@ -4258,7 +4246,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-166 makeStyles-indicationSeverityOk-167 makeStyles-monospace-163 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-165 makeStyles-indicationSeverityOk-166 makeStyles-monospace-162 makeStyles-nowrap-164"
                 scope="row"
               >
                 <span>
@@ -4266,13 +4254,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-163 makeStyles-deemphasized-164 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.8
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-163"
                 scope="row"
               >
                 <p
@@ -4296,7 +4284,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-163 makeStyles-deemphasized-164 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
                 scope="row"
               >
                 <span>
@@ -4304,7 +4292,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-163 makeStyles-deemphasized-164 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
                 scope="row"
               >
                 0.0000
@@ -4318,7 +4306,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-166 makeStyles-indicationSeverityWarning-168 makeStyles-monospace-163 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-165 makeStyles-indicationSeverityWarning-167 makeStyles-monospace-162 makeStyles-nowrap-164"
                 scope="row"
               >
                 <span>
@@ -4326,13 +4314,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-163 makeStyles-deemphasized-164 makeStyles-nowrap-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-163"
                 scope="row"
               >
                 <p
@@ -4347,7 +4335,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-150 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-148 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         aria-disabled="false"
@@ -4403,7 +4391,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               role="region"
             >
               <div
-                class="MuiAccordionDetails-root makeStyles-accordionDetails-151"
+                class="MuiAccordionDetails-root makeStyles-accordionDetails-149"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4416,7 +4404,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                   This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                 </p>
                 <pre
-                  class="makeStyles-pre-153"
+                  class="makeStyles-pre-151"
                 >
                   <code>
                     with tracks_counts as (
@@ -4449,7 +4437,7 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders the condensed table with some analyses in non-debug mode for a Revenue Metric 2`] = `
 <div
-  class="MuiTableContainer-root makeStyles-root-171 analysis-detail-panel"
+  class="MuiTableContainer-root makeStyles-root-170 analysis-detail-panel"
 >
   <table
     class="MuiTable-root"
@@ -4461,14 +4449,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-172"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-171"
           role="cell"
           scope="row"
         >
           Metric Description
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-metricDescription-184"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-metricDescription-183"
         >
           This is metric 1
         </td>
@@ -4476,13 +4464,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </tbody>
   </table>
   <div
-    class="makeStyles-dataTableContainer-181"
+    class="makeStyles-dataTableContainer-180"
   >
     <div
-      class="makeStyles-latestEstimates-182"
+      class="makeStyles-latestEstimates-181"
     >
       <h5
-        class="MuiTypography-root makeStyles-dataTableHeader-187 MuiTypography-h5"
+        class="MuiTypography-root makeStyles-dataTableHeader-186 MuiTypography-h5"
       >
         Estimated 95% Credible Intervals (CIs)
          
@@ -4497,17 +4485,17 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-179 makeStyles-headerCell-172 makeStyles-credibleIntervalHeader-186"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-178 makeStyles-headerCell-171 makeStyles-credibleIntervalHeader-185"
               role="cell"
               scope="row"
             >
               Difference
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-173"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-172"
             >
               <span
-                class="makeStyles-tooltipped-180"
+                class="makeStyles-tooltipped-179"
               >
                 USD 
                 -0.01
@@ -4523,22 +4511,22 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-179 makeStyles-headerCell-172 makeStyles-credibleIntervalHeader-186"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-178 makeStyles-headerCell-171 makeStyles-credibleIntervalHeader-185"
               role="cell"
               scope="row"
               valign="top"
             >
               <span
-                class="makeStyles-monospace-173"
+                class="makeStyles-monospace-172"
               >
                 test
               </span>
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-173"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-172"
             >
               <span
-                class="makeStyles-tooltipped-180"
+                class="makeStyles-tooltipped-179"
               >
                 USD 
                 -1.12
@@ -4554,22 +4542,22 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-179 makeStyles-headerCell-172 makeStyles-credibleIntervalHeader-186"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-178 makeStyles-headerCell-171 makeStyles-credibleIntervalHeader-185"
               role="cell"
               scope="row"
               valign="top"
             >
               <span
-                class="makeStyles-monospace-173"
+                class="makeStyles-monospace-172"
               >
                 control
               </span>
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-173"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-172"
             >
               <span
-                class="makeStyles-tooltipped-180"
+                class="makeStyles-tooltipped-179"
               >
                 USD 
                 0
@@ -4585,10 +4573,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </table>
     </div>
     <div
-      class="makeStyles-metricAssignmentDetails-183"
+      class="makeStyles-metricAssignmentDetails-182"
     >
       <h5
-        class="MuiTypography-root makeStyles-dataTableHeader-187 MuiTypography-h5"
+        class="MuiTypography-root makeStyles-dataTableHeader-186 MuiTypography-h5"
       >
         Metric Assignment Settings
       </h5>
@@ -4602,14 +4590,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-172"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-171"
               role="cell"
               scope="row"
             >
               Attribution Window
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-173"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-172"
             >
               1 week
             </td>
@@ -4618,14 +4606,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-172"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-171"
               role="cell"
               scope="row"
             >
               Minimum Practical Difference
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-173"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-172"
             >
               USD 
               0.1
@@ -4636,14 +4624,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-172"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-171"
               role="cell"
               scope="row"
             >
               Change Expected
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-173"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-172"
             >
               Yes
             </td>
@@ -4653,17 +4641,17 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </div>
   </div>
   <div
-    class="makeStyles-metricEstimatePlots-174"
+    class="makeStyles-metricEstimatePlots-173"
   />
   <p
-    class="MuiTypography-root makeStyles-analysisFinePrint-185 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-analysisFinePrint-184 MuiTypography-body1"
   >
     <strong>
       Last analyzed:
     </strong>
      
     <span
-      class="makeStyles-root-188"
+      class="makeStyles-root-187"
       title="09/05/2020, 20:00:00"
     >
       2020-05-10
@@ -4694,7 +4682,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-148",
+        "className": "makeStyles-participantsPlot-146",
         "data": Array [
           Object {
             "line": Object {
@@ -4753,7 +4741,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-175",
+        "className": "makeStyles-metricEstimatePlot-174",
         "data": Array [
           Object {
             "line": Object {
@@ -4849,7 +4837,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-175",
+        "className": "makeStyles-metricEstimatePlot-174",
         "data": Array [
           Object {
             "line": Object {
@@ -4951,7 +4939,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-175",
+        "className": "makeStyles-metricEstimatePlot-174",
         "data": Array [
           Object {
             "line": Object {
@@ -5047,7 +5035,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-175",
+        "className": "makeStyles-metricEstimatePlot-174",
         "data": Array [
           Object {
             "line": Object {

--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -149,13 +149,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-21"
+    class="makeStyles-root-22"
   >
     <div
-      class="makeStyles-summary-22"
+      class="makeStyles-summary-23"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-33 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-34 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -164,16 +164,16 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-24"
+        class="makeStyles-summaryColumn-25"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-25 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-26 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-26"
+            class="makeStyles-summaryStatsPart-27"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-28 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-29 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               1,000
             </h3>
@@ -189,10 +189,10 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-26"
+            class="makeStyles-summaryStatsPart-27"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-28 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-29 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Deploy 
               test
@@ -208,12 +208,12 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-29 makeStyles-indicationSeverityWarning-31 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-30 makeStyles-indicationSeverityWarning-32 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-28 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-29 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Potential issues
             </h3>
@@ -230,7 +230,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-35 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-36 MuiTypography-h3"
     >
       Metric Assignment Results
     </h3>
@@ -239,7 +239,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-46"
+        class="Component-horizontalScrollContainer-48"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -258,40 +258,33 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-47 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-49 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-47 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-49 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
-                      Metric
+                      Metric (attribution window)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-47 MuiTableCell-alignLeft"
-                      scope="col"
-                      style="font-weight: 700; box-sizing: border-box;"
-                    >
-                      Attribution window
-                    </th>
-                    <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-47 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-49 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Absolute change
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-47 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-49 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Relative change (lift)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-47 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-49 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -342,15 +335,21 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class=""
-                        title="This is metric 1"
+                        class="makeStyles-metricAssignmentNameLine-42"
                       >
-                        metric_1
+                        <span
+                          class=""
+                          title="This is metric 1"
+                        >
+                          metric_1
+                        </span>
+                         (
+                        1 week
+                        )
                       </span>
-                       
                       <br />
                       <span
-                        class="makeStyles-root-48"
+                        class="makeStyles-root-50"
                       >
                         primary
                       </span>
@@ -359,14 +358,8 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      1 week
-                    </td>
-                    <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
-                      style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
-                    >
                       <span
-                        class="makeStyles-topLevelDiff-40"
+                        class="makeStyles-topLevelDiff-41"
                       >
                         -1
                          to 
@@ -381,7 +374,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                       style="box-sizing: border-box;"
                     >
                       <span
-                        class="makeStyles-topLevelDiff-40"
+                        class="makeStyles-topLevelDiff-41"
                       >
                         -50.00
                          to 
@@ -437,18 +430,18 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class=""
-                        title="This is metric 2"
+                        class="makeStyles-metricAssignmentNameLine-42"
                       >
-                        metric_2
+                        <span
+                          class=""
+                          title="This is metric 2"
+                        >
+                          metric_2
+                        </span>
+                         (
+                        1 hour
+                        )
                       </span>
-                       
-                    </td>
-                    <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
-                      style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
-                    >
-                      1 hour
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -505,18 +498,18 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class=""
-                        title="This is metric 2"
+                        class="makeStyles-metricAssignmentNameLine-42"
                       >
-                        metric_2
+                        <span
+                          class=""
+                          title="This is metric 2"
+                        >
+                          metric_2
+                        </span>
+                         (
+                        4 weeks
+                        )
                       </span>
-                       
-                    </td>
-                    <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
-                      style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
-                    >
-                      4 weeks
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -573,18 +566,18 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class=""
-                        title="This is metric 3"
+                        class="makeStyles-metricAssignmentNameLine-42"
                       >
-                        metric_3
+                        <span
+                          class=""
+                          title="This is metric 3"
+                        >
+                          metric_3
+                        </span>
+                         (
+                        6 hours
+                        )
                       </span>
-                       
-                    </td>
-                    <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
-                      style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
-                    >
-                      6 hours
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -609,7 +602,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-35 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-36 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -691,18 +684,18 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-57"
+                  class="makeStyles-tooltip-59"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
                 scope="row"
               >
                 1.0000
@@ -714,7 +707,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-53 makeStyles-indicationSeverityOk-54 makeStyles-monospace-50 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-55 makeStyles-indicationSeverityOk-56 makeStyles-monospace-52 makeStyles-nowrap-54"
                 scope="row"
               >
                 <span>
@@ -722,13 +715,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-51"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-53"
                 scope="row"
               >
                 <p
@@ -752,18 +745,18 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-57"
+                  class="makeStyles-tooltip-59"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
                 scope="row"
               >
                 1.0000
@@ -775,7 +768,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-53 makeStyles-indicationSeverityOk-54 makeStyles-monospace-50 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-55 makeStyles-indicationSeverityOk-56 makeStyles-monospace-52 makeStyles-nowrap-54"
                 scope="row"
               >
                 <span>
@@ -783,13 +776,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-51"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-53"
                 scope="row"
               >
                 <p
@@ -813,18 +806,18 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-57"
+                  class="makeStyles-tooltip-59"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
                 scope="row"
               >
                 1.0000
@@ -836,7 +829,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-53 makeStyles-indicationSeverityOk-54 makeStyles-monospace-50 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-55 makeStyles-indicationSeverityOk-56 makeStyles-monospace-52 makeStyles-nowrap-54"
                 scope="row"
               >
                 <span>
@@ -844,13 +837,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-51"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-53"
                 scope="row"
               >
                 <p
@@ -874,7 +867,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
                 scope="row"
               >
                 <span>
@@ -882,7 +875,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
                 scope="row"
               >
                 0.0000
@@ -894,7 +887,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-53 makeStyles-indicationSeverityOk-54 makeStyles-monospace-50 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-55 makeStyles-indicationSeverityOk-56 makeStyles-monospace-52 makeStyles-nowrap-54"
                 scope="row"
               >
                 <span>
@@ -902,13 +895,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.01
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-51"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-53"
                 scope="row"
               >
                 <p
@@ -932,7 +925,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
                 scope="row"
               >
                 <span>
@@ -940,7 +933,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
                 scope="row"
               >
                 0.0000
@@ -952,7 +945,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-53 makeStyles-indicationSeverityOk-54 makeStyles-monospace-50 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-55 makeStyles-indicationSeverityOk-56 makeStyles-monospace-52 makeStyles-nowrap-54"
                 scope="row"
               >
                 <span>
@@ -960,13 +953,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-51"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-53"
                 scope="row"
               >
                 <p
@@ -990,7 +983,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
                 scope="row"
               >
                 <span>
@@ -998,7 +991,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
                 scope="row"
               >
                 0.1000
@@ -1010,7 +1003,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-53 makeStyles-indicationSeverityOk-54 makeStyles-monospace-50 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-55 makeStyles-indicationSeverityOk-56 makeStyles-monospace-52 makeStyles-nowrap-54"
                 scope="row"
               >
                 <span>
@@ -1018,13 +1011,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.8
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-51"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-53"
                 scope="row"
               >
                 <p
@@ -1048,7 +1041,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
                 scope="row"
               >
                 <span>
@@ -1056,7 +1049,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
                 scope="row"
               >
                 0.0000
@@ -1070,7 +1063,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-53 makeStyles-indicationSeverityWarning-55 makeStyles-monospace-50 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-55 makeStyles-indicationSeverityWarning-57 makeStyles-monospace-52 makeStyles-nowrap-54"
                 scope="row"
               >
                 <span>
@@ -1078,13 +1071,13 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-50 makeStyles-deemphasized-51 makeStyles-nowrap-52"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-51"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-53"
                 scope="row"
               >
                 <p
@@ -1099,7 +1092,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-36 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-37 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         aria-disabled="false"
@@ -1155,7 +1148,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
               role="region"
             >
               <div
-                class="MuiAccordionDetails-root makeStyles-accordionDetails-37"
+                class="MuiAccordionDetails-root makeStyles-accordionDetails-38"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -1168,7 +1161,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                   This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                 </p>
                 <pre
-                  class="makeStyles-pre-39"
+                  class="makeStyles-pre-40"
                 >
                   <code>
                     with tracks_counts as (
@@ -1201,7 +1194,7 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders correctly for 1 analysis datapoint 2`] = `
 <div
-  class="MuiTableContainer-root makeStyles-root-58 analysis-detail-panel"
+  class="MuiTableContainer-root makeStyles-root-60 analysis-detail-panel"
 >
   <table
     class="MuiTable-root"
@@ -1213,14 +1206,14 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-59"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-61"
           role="cell"
           scope="row"
         >
           Metric Description
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-metricDescription-71"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-metricDescription-73"
         >
           This is metric 1
         </td>
@@ -1228,13 +1221,13 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
     </tbody>
   </table>
   <div
-    class="makeStyles-dataTableContainer-68"
+    class="makeStyles-dataTableContainer-70"
   >
     <div
-      class="makeStyles-latestEstimates-69"
+      class="makeStyles-latestEstimates-71"
     >
       <h5
-        class="MuiTypography-root makeStyles-dataTableHeader-74 MuiTypography-h5"
+        class="MuiTypography-root makeStyles-dataTableHeader-76 MuiTypography-h5"
       >
         Estimated 95% Credible Intervals (CIs)
          
@@ -1249,22 +1242,22 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-66 makeStyles-headerCell-59 makeStyles-credibleIntervalHeader-73"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-68 makeStyles-headerCell-61 makeStyles-credibleIntervalHeader-75"
               role="cell"
               scope="row"
             >
               Difference
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-62"
             >
               <span
-                class="makeStyles-tooltipped-67"
+                class="makeStyles-tooltipped-69"
               >
                 
                 -1
                 <span
-                  class="makeStyles-root-75"
+                  class="makeStyles-root-77"
                   title="Percentage points."
                 >
                   pp
@@ -1273,7 +1266,7 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
                 
                 1
                 <span
-                  class="makeStyles-root-75"
+                  class="makeStyles-root-77"
                   title="Percentage points."
                 >
                   pp
@@ -1285,22 +1278,22 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-66 makeStyles-headerCell-59 makeStyles-credibleIntervalHeader-73"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-68 makeStyles-headerCell-61 makeStyles-credibleIntervalHeader-75"
               role="cell"
               scope="row"
               valign="top"
             >
               <span
-                class="makeStyles-monospace-60"
+                class="makeStyles-monospace-62"
               >
                 test
               </span>
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-62"
             >
               <span
-                class="makeStyles-tooltipped-67"
+                class="makeStyles-tooltipped-69"
               >
                 
                 -112.3
@@ -1316,22 +1309,22 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-66 makeStyles-headerCell-59 makeStyles-credibleIntervalHeader-73"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-68 makeStyles-headerCell-61 makeStyles-credibleIntervalHeader-75"
               role="cell"
               scope="row"
               valign="top"
             >
               <span
-                class="makeStyles-monospace-60"
+                class="makeStyles-monospace-62"
               >
                 control
               </span>
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-62"
             >
               <span
-                class="makeStyles-tooltipped-67"
+                class="makeStyles-tooltipped-69"
               >
                 
                 0
@@ -1347,10 +1340,10 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
       </table>
     </div>
     <div
-      class="makeStyles-metricAssignmentDetails-70"
+      class="makeStyles-metricAssignmentDetails-72"
     >
       <h5
-        class="MuiTypography-root makeStyles-dataTableHeader-74 MuiTypography-h5"
+        class="MuiTypography-root makeStyles-dataTableHeader-76 MuiTypography-h5"
       >
         Metric Assignment Settings
       </h5>
@@ -1364,14 +1357,14 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-59"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-61"
               role="cell"
               scope="row"
             >
               Attribution Window
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-62"
             >
               1 week
             </td>
@@ -1380,19 +1373,19 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-59"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-61"
               role="cell"
               scope="row"
             >
               Minimum Practical Difference
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-62"
             >
               
               10
               <span
-                class="makeStyles-root-75"
+                class="makeStyles-root-77"
                 title="Percentage points."
               >
                 pp
@@ -1403,14 +1396,14 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-59"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-61"
               role="cell"
               scope="row"
             >
               Change Expected
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-60"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-62"
             >
               Yes
             </td>
@@ -1420,19 +1413,19 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
     </div>
   </div>
   <p
-    class="MuiTypography-root makeStyles-noPlotMessage-64 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-noPlotMessage-66 MuiTypography-body1"
   >
     Past values will be plotted once we have more than one day of results.
   </p>
   <p
-    class="MuiTypography-root makeStyles-analysisFinePrint-72 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-analysisFinePrint-74 MuiTypography-body1"
   >
     <strong>
       Last analyzed:
     </strong>
      
     <span
-      class="makeStyles-root-76"
+      class="makeStyles-root-78"
       title="09/05/2020, 20:00:00"
     >
       2020-05-10
@@ -1463,7 +1456,7 @@ exports[`renders correctly for 1 analysis datapoint 3`] = `
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-34",
+        "className": "makeStyles-participantsPlot-35",
         "data": Array [
           Object {
             "line": Object {
@@ -1531,13 +1524,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-77"
+    class="makeStyles-root-79"
   >
     <div
-      class="makeStyles-summary-78"
+      class="makeStyles-summary-80"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-89 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-91 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -1546,16 +1539,16 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-80"
+        class="makeStyles-summaryColumn-82"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-81 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-83 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-82"
+            class="makeStyles-summaryStatsPart-84"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-84 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-86 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               700
             </h3>
@@ -1571,10 +1564,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-82"
+            class="makeStyles-summaryStatsPart-84"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-84 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-86 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Deploy 
               test
@@ -1590,12 +1583,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-85 makeStyles-indicationSeverityError-88 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-87 makeStyles-indicationSeverityError-90 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-84 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-86 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Serious issues
             </h3>
@@ -1612,7 +1605,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-91 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-93 MuiTypography-h3"
     >
       Metric Assignment Results
     </h3>
@@ -1621,7 +1614,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-102"
+        class="Component-horizontalScrollContainer-105"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -1640,40 +1633,33 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-103 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-106 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-103 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-106 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
-                      Metric
+                      Metric (attribution window)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-103 MuiTableCell-alignLeft"
-                      scope="col"
-                      style="font-weight: 700; box-sizing: border-box;"
-                    >
-                      Attribution window
-                    </th>
-                    <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-103 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-106 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Absolute change
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-103 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-106 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Relative change (lift)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-103 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-106 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -1724,15 +1710,21 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class=""
-                        title="This is metric 1"
+                        class="makeStyles-metricAssignmentNameLine-99"
                       >
-                        metric_1
+                        <span
+                          class=""
+                          title="This is metric 1"
+                        >
+                          metric_1
+                        </span>
+                         (
+                        1 week
+                        )
                       </span>
-                       
                       <br />
                       <span
-                        class="makeStyles-root-104"
+                        class="makeStyles-root-107"
                       >
                         primary
                       </span>
@@ -1741,14 +1733,8 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      1 week
-                    </td>
-                    <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
-                      style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
-                    >
                       <span
-                        class="makeStyles-topLevelDiff-96"
+                        class="makeStyles-topLevelDiff-98"
                       >
                         -1
                          to 
@@ -1763,7 +1749,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box;"
                     >
                       <span
-                        class="makeStyles-topLevelDiff-96"
+                        class="makeStyles-topLevelDiff-98"
                       >
                         -50.00
                          to 
@@ -1819,18 +1805,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class=""
-                        title="This is metric 2"
+                        class="makeStyles-metricAssignmentNameLine-99"
                       >
-                        metric_2
+                        <span
+                          class=""
+                          title="This is metric 2"
+                        >
+                          metric_2
+                        </span>
+                         (
+                        1 hour
+                        )
                       </span>
-                       
-                    </td>
-                    <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
-                      style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
-                    >
-                      1 hour
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -1887,18 +1873,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class=""
-                        title="This is metric 2"
+                        class="makeStyles-metricAssignmentNameLine-99"
                       >
-                        metric_2
+                        <span
+                          class=""
+                          title="This is metric 2"
+                        >
+                          metric_2
+                        </span>
+                         (
+                        4 weeks
+                        )
                       </span>
-                       
-                    </td>
-                    <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
-                      style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
-                    >
-                      4 weeks
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -1955,25 +1941,25 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class=""
-                        title="This is metric 3"
+                        class="makeStyles-metricAssignmentNameLine-99"
                       >
-                        metric_3
+                        <span
+                          class=""
+                          title="This is metric 3"
+                        >
+                          metric_3
+                        </span>
+                         (
+                        6 hours
+                        )
                       </span>
-                       
-                    </td>
-                    <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
-                      style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
-                    >
-                      6 hours
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
                       <span
-                        class="makeStyles-topLevelDiff-96"
+                        class="makeStyles-topLevelDiff-98"
                       >
                         -1
                          to 
@@ -1988,7 +1974,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box;"
                     >
                       <span
-                        class="makeStyles-topLevelDiff-96"
+                        class="makeStyles-topLevelDiff-98"
                       >
                         -50.00
                          to 
@@ -2012,7 +1998,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-91 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-93 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -2094,18 +2080,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-109 makeStyles-deemphasized-110 makeStyles-nowrap-111"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-113"
+                  class="makeStyles-tooltip-116"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-109 makeStyles-deemphasized-110 makeStyles-nowrap-111"
                 scope="row"
               >
                 1.0000
@@ -2117,7 +2103,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-109 makeStyles-indicationSeverityOk-110 makeStyles-monospace-106 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-112 makeStyles-indicationSeverityOk-113 makeStyles-monospace-109 makeStyles-nowrap-111"
                 scope="row"
               >
                 <span>
@@ -2125,13 +2111,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-109 makeStyles-deemphasized-110 makeStyles-nowrap-111"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-107"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-110"
                 scope="row"
               >
                 <p
@@ -2155,18 +2141,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-109 makeStyles-deemphasized-110 makeStyles-nowrap-111"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-113"
+                  class="makeStyles-tooltip-116"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-109 makeStyles-deemphasized-110 makeStyles-nowrap-111"
                 scope="row"
               >
                 1.0000
@@ -2178,7 +2164,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-109 makeStyles-indicationSeverityOk-110 makeStyles-monospace-106 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-112 makeStyles-indicationSeverityOk-113 makeStyles-monospace-109 makeStyles-nowrap-111"
                 scope="row"
               >
                 <span>
@@ -2186,13 +2172,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-109 makeStyles-deemphasized-110 makeStyles-nowrap-111"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-107"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-110"
                 scope="row"
               >
                 <p
@@ -2216,18 +2202,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-109 makeStyles-deemphasized-110 makeStyles-nowrap-111"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-113"
+                  class="makeStyles-tooltip-116"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-109 makeStyles-deemphasized-110 makeStyles-nowrap-111"
                 scope="row"
               >
                 1.0000
@@ -2239,7 +2225,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-109 makeStyles-indicationSeverityOk-110 makeStyles-monospace-106 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-112 makeStyles-indicationSeverityOk-113 makeStyles-monospace-109 makeStyles-nowrap-111"
                 scope="row"
               >
                 <span>
@@ -2247,13 +2233,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-109 makeStyles-deemphasized-110 makeStyles-nowrap-111"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-107"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-110"
                 scope="row"
               >
                 <p
@@ -2277,7 +2263,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-109 makeStyles-deemphasized-110 makeStyles-nowrap-111"
                 scope="row"
               >
                 <span>
@@ -2285,7 +2271,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-109 makeStyles-deemphasized-110 makeStyles-nowrap-111"
                 scope="row"
               >
                 0.1000
@@ -2299,7 +2285,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-109 makeStyles-indicationSeverityError-112 makeStyles-monospace-106 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-112 makeStyles-indicationSeverityError-115 makeStyles-monospace-109 makeStyles-nowrap-111"
                 scope="row"
               >
                 <span>
@@ -2307,13 +2293,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-109 makeStyles-deemphasized-110 makeStyles-nowrap-111"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-107"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-110"
                 scope="row"
               >
                 <p
@@ -2339,7 +2325,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-109 makeStyles-deemphasized-110 makeStyles-nowrap-111"
                 scope="row"
               >
                 <span>
@@ -2347,7 +2333,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-109 makeStyles-deemphasized-110 makeStyles-nowrap-111"
                 scope="row"
               >
                 0.1500
@@ -2361,7 +2347,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-109 makeStyles-indicationSeverityWarning-111 makeStyles-monospace-106 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-112 makeStyles-indicationSeverityWarning-114 makeStyles-monospace-109 makeStyles-nowrap-111"
                 scope="row"
               >
                 <span>
@@ -2369,13 +2355,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-109 makeStyles-deemphasized-110 makeStyles-nowrap-111"
                 scope="row"
               >
                 0.1 &lt; x ≤ 0.4
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-107"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-110"
                 scope="row"
               >
                 <p
@@ -2401,7 +2387,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-109 makeStyles-deemphasized-110 makeStyles-nowrap-111"
                 scope="row"
               >
                 <span>
@@ -2409,7 +2395,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-109 makeStyles-deemphasized-110 makeStyles-nowrap-111"
                 scope="row"
               >
                 0.1000
@@ -2421,7 +2407,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-109 makeStyles-indicationSeverityOk-110 makeStyles-monospace-106 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-112 makeStyles-indicationSeverityOk-113 makeStyles-monospace-109 makeStyles-nowrap-111"
                 scope="row"
               >
                 <span>
@@ -2429,13 +2415,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-109 makeStyles-deemphasized-110 makeStyles-nowrap-111"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.8
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-107"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-110"
                 scope="row"
               >
                 <p
@@ -2459,7 +2445,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-109 makeStyles-deemphasized-110 makeStyles-nowrap-111"
                 scope="row"
               >
                 <span>
@@ -2467,7 +2453,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-109 makeStyles-deemphasized-110 makeStyles-nowrap-111"
                 scope="row"
               >
                 0.0000
@@ -2481,7 +2467,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-109 makeStyles-indicationSeverityWarning-111 makeStyles-monospace-106 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-112 makeStyles-indicationSeverityWarning-114 makeStyles-monospace-109 makeStyles-nowrap-111"
                 scope="row"
               >
                 <span>
@@ -2489,13 +2475,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-106 makeStyles-deemphasized-107 makeStyles-nowrap-108"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-109 makeStyles-deemphasized-110 makeStyles-nowrap-111"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-107"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-110"
                 scope="row"
               >
                 <p
@@ -2510,7 +2496,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-92 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-94 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         aria-disabled="false"
@@ -2566,7 +2552,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               role="region"
             >
               <div
-                class="MuiAccordionDetails-root makeStyles-accordionDetails-93"
+                class="MuiAccordionDetails-root makeStyles-accordionDetails-95"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -2579,7 +2565,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                   This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                 </p>
                 <pre
-                  class="makeStyles-pre-95"
+                  class="makeStyles-pre-97"
                 >
                   <code>
                     with tracks_counts as (
@@ -2612,7 +2598,7 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders the condensed table with some analyses in non-debug mode for a Conversion Metric 2`] = `
 <div
-  class="MuiTableContainer-root makeStyles-root-114 analysis-detail-panel"
+  class="MuiTableContainer-root makeStyles-root-117 analysis-detail-panel"
 >
   <table
     class="MuiTable-root"
@@ -2624,14 +2610,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-115"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-118"
           role="cell"
           scope="row"
         >
           Metric Description
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-metricDescription-127"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-metricDescription-130"
         >
           This is metric 1
         </td>
@@ -2639,13 +2625,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </tbody>
   </table>
   <div
-    class="makeStyles-dataTableContainer-124"
+    class="makeStyles-dataTableContainer-127"
   >
     <div
-      class="makeStyles-latestEstimates-125"
+      class="makeStyles-latestEstimates-128"
     >
       <h5
-        class="MuiTypography-root makeStyles-dataTableHeader-130 MuiTypography-h5"
+        class="MuiTypography-root makeStyles-dataTableHeader-133 MuiTypography-h5"
       >
         Estimated 95% Credible Intervals (CIs)
          
@@ -2660,22 +2646,22 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-122 makeStyles-headerCell-115 makeStyles-credibleIntervalHeader-129"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-125 makeStyles-headerCell-118 makeStyles-credibleIntervalHeader-132"
               role="cell"
               scope="row"
             >
               Difference
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-116"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-119"
             >
               <span
-                class="makeStyles-tooltipped-123"
+                class="makeStyles-tooltipped-126"
               >
                 
                 -1
                 <span
-                  class="makeStyles-root-131"
+                  class="makeStyles-root-134"
                   title="Percentage points."
                 >
                   pp
@@ -2684,7 +2670,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 
                 1
                 <span
-                  class="makeStyles-root-131"
+                  class="makeStyles-root-134"
                   title="Percentage points."
                 >
                   pp
@@ -2696,22 +2682,22 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-122 makeStyles-headerCell-115 makeStyles-credibleIntervalHeader-129"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-125 makeStyles-headerCell-118 makeStyles-credibleIntervalHeader-132"
               role="cell"
               scope="row"
               valign="top"
             >
               <span
-                class="makeStyles-monospace-116"
+                class="makeStyles-monospace-119"
               >
                 test
               </span>
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-116"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-119"
             >
               <span
-                class="makeStyles-tooltipped-123"
+                class="makeStyles-tooltipped-126"
               >
                 
                 -112.3
@@ -2727,22 +2713,22 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-122 makeStyles-headerCell-115 makeStyles-credibleIntervalHeader-129"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-125 makeStyles-headerCell-118 makeStyles-credibleIntervalHeader-132"
               role="cell"
               scope="row"
               valign="top"
             >
               <span
-                class="makeStyles-monospace-116"
+                class="makeStyles-monospace-119"
               >
                 control
               </span>
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-116"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-119"
             >
               <span
-                class="makeStyles-tooltipped-123"
+                class="makeStyles-tooltipped-126"
               >
                 
                 0
@@ -2758,10 +2744,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </table>
     </div>
     <div
-      class="makeStyles-metricAssignmentDetails-126"
+      class="makeStyles-metricAssignmentDetails-129"
     >
       <h5
-        class="MuiTypography-root makeStyles-dataTableHeader-130 MuiTypography-h5"
+        class="MuiTypography-root makeStyles-dataTableHeader-133 MuiTypography-h5"
       >
         Metric Assignment Settings
       </h5>
@@ -2775,14 +2761,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-115"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-118"
               role="cell"
               scope="row"
             >
               Attribution Window
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-116"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-119"
             >
               1 week
             </td>
@@ -2791,19 +2777,19 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-115"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-118"
               role="cell"
               scope="row"
             >
               Minimum Practical Difference
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-116"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-119"
             >
               
               10
               <span
-                class="makeStyles-root-131"
+                class="makeStyles-root-134"
                 title="Percentage points."
               >
                 pp
@@ -2814,14 +2800,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-115"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-118"
               role="cell"
               scope="row"
             >
               Change Expected
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-116"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-119"
             >
               Yes
             </td>
@@ -2831,17 +2817,17 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </div>
   </div>
   <div
-    class="makeStyles-metricEstimatePlots-117"
+    class="makeStyles-metricEstimatePlots-120"
   />
   <p
-    class="MuiTypography-root makeStyles-analysisFinePrint-128 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-analysisFinePrint-131 MuiTypography-body1"
   >
     <strong>
       Last analyzed:
     </strong>
      
     <span
-      class="makeStyles-root-132"
+      class="makeStyles-root-135"
       title="09/05/2020, 20:00:00"
     >
       2020-05-10
@@ -2872,7 +2858,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-90",
+        "className": "makeStyles-participantsPlot-92",
         "data": Array [
           Object {
             "line": Object {
@@ -2931,7 +2917,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-118",
+        "className": "makeStyles-metricEstimatePlot-121",
         "data": Array [
           Object {
             "line": Object {
@@ -3027,7 +3013,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-118",
+        "className": "makeStyles-metricEstimatePlot-121",
         "data": Array [
           Object {
             "line": Object {
@@ -3129,7 +3115,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-118",
+        "className": "makeStyles-metricEstimatePlot-121",
         "data": Array [
           Object {
             "line": Object {
@@ -3225,7 +3211,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-118",
+        "className": "makeStyles-metricEstimatePlot-121",
         "data": Array [
           Object {
             "line": Object {
@@ -3356,13 +3342,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-133"
+    class="makeStyles-root-136"
   >
     <div
-      class="makeStyles-summary-134"
+      class="makeStyles-summary-137"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-145 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-148 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -3371,16 +3357,16 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-136"
+        class="makeStyles-summaryColumn-139"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-137 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-140 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-138"
+            class="makeStyles-summaryStatsPart-141"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-140 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-143 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               700
             </h3>
@@ -3396,10 +3382,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-138"
+            class="makeStyles-summaryStatsPart-141"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-140 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-143 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Deploy 
               test
@@ -3415,12 +3401,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-141 makeStyles-indicationSeverityError-144 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-144 makeStyles-indicationSeverityError-147 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-140 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-143 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Serious issues
             </h3>
@@ -3437,7 +3423,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-147 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-150 MuiTypography-h3"
     >
       Metric Assignment Results
     </h3>
@@ -3446,7 +3432,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-158"
+        class="Component-horizontalScrollContainer-162"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -3465,40 +3451,33 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-163 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-163 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
-                      Metric
+                      Metric (attribution window)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-alignLeft"
-                      scope="col"
-                      style="font-weight: 700; box-sizing: border-box;"
-                    >
-                      Attribution window
-                    </th>
-                    <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-163 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Absolute change
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-163 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Relative change (lift)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-163 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -3549,15 +3528,21 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class=""
-                        title="This is metric 1"
+                        class="makeStyles-metricAssignmentNameLine-156"
                       >
-                        metric_1
+                        <span
+                          class=""
+                          title="This is metric 1"
+                        >
+                          metric_1
+                        </span>
+                         (
+                        1 week
+                        )
                       </span>
-                       
                       <br />
                       <span
-                        class="makeStyles-root-160"
+                        class="makeStyles-root-164"
                       >
                         primary
                       </span>
@@ -3566,14 +3551,8 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      1 week
-                    </td>
-                    <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
-                      style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
-                    >
                       <span
-                        class="makeStyles-topLevelDiff-152"
+                        class="makeStyles-topLevelDiff-155"
                       >
                         -0.01
                          to 
@@ -3588,7 +3567,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box;"
                     >
                       <span
-                        class="makeStyles-topLevelDiff-152"
+                        class="makeStyles-topLevelDiff-155"
                       >
                         -50.00
                          to 
@@ -3644,18 +3623,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class=""
-                        title="This is metric 2"
+                        class="makeStyles-metricAssignmentNameLine-156"
                       >
-                        metric_2
+                        <span
+                          class=""
+                          title="This is metric 2"
+                        >
+                          metric_2
+                        </span>
+                         (
+                        1 hour
+                        )
                       </span>
-                       
-                    </td>
-                    <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
-                      style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
-                    >
-                      1 hour
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -3712,18 +3691,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class=""
-                        title="This is metric 2"
+                        class="makeStyles-metricAssignmentNameLine-156"
                       >
-                        metric_2
+                        <span
+                          class=""
+                          title="This is metric 2"
+                        >
+                          metric_2
+                        </span>
+                         (
+                        4 weeks
+                        )
                       </span>
-                       
-                    </td>
-                    <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
-                      style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
-                    >
-                      4 weeks
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -3780,25 +3759,25 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class=""
-                        title="This is metric 3"
+                        class="makeStyles-metricAssignmentNameLine-156"
                       >
-                        metric_3
+                        <span
+                          class=""
+                          title="This is metric 3"
+                        >
+                          metric_3
+                        </span>
+                         (
+                        6 hours
+                        )
                       </span>
-                       
-                    </td>
-                    <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
-                      style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
-                    >
-                      6 hours
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
                       <span
-                        class="makeStyles-topLevelDiff-152"
+                        class="makeStyles-topLevelDiff-155"
                       >
                         -0.01
                          to 
@@ -3813,7 +3792,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box;"
                     >
                       <span
-                        class="makeStyles-topLevelDiff-152"
+                        class="makeStyles-topLevelDiff-155"
                       >
                         -50.00
                          to 
@@ -3837,7 +3816,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-147 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-150 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -3919,18 +3898,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-166 makeStyles-deemphasized-167 makeStyles-nowrap-168"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-169"
+                  class="makeStyles-tooltip-173"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-166 makeStyles-deemphasized-167 makeStyles-nowrap-168"
                 scope="row"
               >
                 1.0000
@@ -3942,7 +3921,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-165 makeStyles-indicationSeverityOk-166 makeStyles-monospace-162 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-169 makeStyles-indicationSeverityOk-170 makeStyles-monospace-166 makeStyles-nowrap-168"
                 scope="row"
               >
                 <span>
@@ -3950,13 +3929,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-166 makeStyles-deemphasized-167 makeStyles-nowrap-168"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-163"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-167"
                 scope="row"
               >
                 <p
@@ -3980,18 +3959,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-166 makeStyles-deemphasized-167 makeStyles-nowrap-168"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-169"
+                  class="makeStyles-tooltip-173"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-166 makeStyles-deemphasized-167 makeStyles-nowrap-168"
                 scope="row"
               >
                 1.0000
@@ -4003,7 +3982,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-165 makeStyles-indicationSeverityOk-166 makeStyles-monospace-162 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-169 makeStyles-indicationSeverityOk-170 makeStyles-monospace-166 makeStyles-nowrap-168"
                 scope="row"
               >
                 <span>
@@ -4011,13 +3990,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-166 makeStyles-deemphasized-167 makeStyles-nowrap-168"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-163"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-167"
                 scope="row"
               >
                 <p
@@ -4041,18 +4020,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-166 makeStyles-deemphasized-167 makeStyles-nowrap-168"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-169"
+                  class="makeStyles-tooltip-173"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-166 makeStyles-deemphasized-167 makeStyles-nowrap-168"
                 scope="row"
               >
                 1.0000
@@ -4064,7 +4043,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-165 makeStyles-indicationSeverityOk-166 makeStyles-monospace-162 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-169 makeStyles-indicationSeverityOk-170 makeStyles-monospace-166 makeStyles-nowrap-168"
                 scope="row"
               >
                 <span>
@@ -4072,13 +4051,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-166 makeStyles-deemphasized-167 makeStyles-nowrap-168"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-163"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-167"
                 scope="row"
               >
                 <p
@@ -4102,7 +4081,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-166 makeStyles-deemphasized-167 makeStyles-nowrap-168"
                 scope="row"
               >
                 <span>
@@ -4110,7 +4089,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-166 makeStyles-deemphasized-167 makeStyles-nowrap-168"
                 scope="row"
               >
                 0.1000
@@ -4124,7 +4103,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-165 makeStyles-indicationSeverityError-168 makeStyles-monospace-162 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-169 makeStyles-indicationSeverityError-172 makeStyles-monospace-166 makeStyles-nowrap-168"
                 scope="row"
               >
                 <span>
@@ -4132,13 +4111,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-166 makeStyles-deemphasized-167 makeStyles-nowrap-168"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-163"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-167"
                 scope="row"
               >
                 <p
@@ -4164,7 +4143,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-166 makeStyles-deemphasized-167 makeStyles-nowrap-168"
                 scope="row"
               >
                 <span>
@@ -4172,7 +4151,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-166 makeStyles-deemphasized-167 makeStyles-nowrap-168"
                 scope="row"
               >
                 0.1500
@@ -4186,7 +4165,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-165 makeStyles-indicationSeverityWarning-167 makeStyles-monospace-162 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-169 makeStyles-indicationSeverityWarning-171 makeStyles-monospace-166 makeStyles-nowrap-168"
                 scope="row"
               >
                 <span>
@@ -4194,13 +4173,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-166 makeStyles-deemphasized-167 makeStyles-nowrap-168"
                 scope="row"
               >
                 0.1 &lt; x ≤ 0.4
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-163"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-167"
                 scope="row"
               >
                 <p
@@ -4226,7 +4205,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-166 makeStyles-deemphasized-167 makeStyles-nowrap-168"
                 scope="row"
               >
                 <span>
@@ -4234,7 +4213,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-166 makeStyles-deemphasized-167 makeStyles-nowrap-168"
                 scope="row"
               >
                 0.1000
@@ -4246,7 +4225,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-165 makeStyles-indicationSeverityOk-166 makeStyles-monospace-162 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-169 makeStyles-indicationSeverityOk-170 makeStyles-monospace-166 makeStyles-nowrap-168"
                 scope="row"
               >
                 <span>
@@ -4254,13 +4233,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-166 makeStyles-deemphasized-167 makeStyles-nowrap-168"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.8
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-163"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-167"
                 scope="row"
               >
                 <p
@@ -4284,7 +4263,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-166 makeStyles-deemphasized-167 makeStyles-nowrap-168"
                 scope="row"
               >
                 <span>
@@ -4292,7 +4271,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-166 makeStyles-deemphasized-167 makeStyles-nowrap-168"
                 scope="row"
               >
                 0.0000
@@ -4306,7 +4285,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-165 makeStyles-indicationSeverityWarning-167 makeStyles-monospace-162 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-169 makeStyles-indicationSeverityWarning-171 makeStyles-monospace-166 makeStyles-nowrap-168"
                 scope="row"
               >
                 <span>
@@ -4314,13 +4293,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 makeStyles-deemphasized-163 makeStyles-nowrap-164"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-166 makeStyles-deemphasized-167 makeStyles-nowrap-168"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-163"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-167"
                 scope="row"
               >
                 <p
@@ -4335,7 +4314,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-148 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root MuiAccordion-root makeStyles-accordion-151 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         aria-disabled="false"
@@ -4391,7 +4370,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               role="region"
             >
               <div
-                class="MuiAccordionDetails-root makeStyles-accordionDetails-149"
+                class="MuiAccordionDetails-root makeStyles-accordionDetails-152"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4404,7 +4383,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                   This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                 </p>
                 <pre
-                  class="makeStyles-pre-151"
+                  class="makeStyles-pre-154"
                 >
                   <code>
                     with tracks_counts as (
@@ -4437,7 +4416,7 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders the condensed table with some analyses in non-debug mode for a Revenue Metric 2`] = `
 <div
-  class="MuiTableContainer-root makeStyles-root-170 analysis-detail-panel"
+  class="MuiTableContainer-root makeStyles-root-174 analysis-detail-panel"
 >
   <table
     class="MuiTable-root"
@@ -4449,14 +4428,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         class="MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-171"
+          class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-175"
           role="cell"
           scope="row"
         >
           Metric Description
         </th>
         <td
-          class="MuiTableCell-root MuiTableCell-body makeStyles-metricDescription-183"
+          class="MuiTableCell-root MuiTableCell-body makeStyles-metricDescription-187"
         >
           This is metric 1
         </td>
@@ -4464,13 +4443,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </tbody>
   </table>
   <div
-    class="makeStyles-dataTableContainer-180"
+    class="makeStyles-dataTableContainer-184"
   >
     <div
-      class="makeStyles-latestEstimates-181"
+      class="makeStyles-latestEstimates-185"
     >
       <h5
-        class="MuiTypography-root makeStyles-dataTableHeader-186 MuiTypography-h5"
+        class="MuiTypography-root makeStyles-dataTableHeader-190 MuiTypography-h5"
       >
         Estimated 95% Credible Intervals (CIs)
          
@@ -4485,17 +4464,17 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-178 makeStyles-headerCell-171 makeStyles-credibleIntervalHeader-185"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-182 makeStyles-headerCell-175 makeStyles-credibleIntervalHeader-189"
               role="cell"
               scope="row"
             >
               Difference
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-172"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-176"
             >
               <span
-                class="makeStyles-tooltipped-179"
+                class="makeStyles-tooltipped-183"
               >
                 USD 
                 -0.01
@@ -4511,22 +4490,22 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-178 makeStyles-headerCell-171 makeStyles-credibleIntervalHeader-185"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-182 makeStyles-headerCell-175 makeStyles-credibleIntervalHeader-189"
               role="cell"
               scope="row"
               valign="top"
             >
               <span
-                class="makeStyles-monospace-172"
+                class="makeStyles-monospace-176"
               >
                 test
               </span>
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-172"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-176"
             >
               <span
-                class="makeStyles-tooltipped-179"
+                class="makeStyles-tooltipped-183"
               >
                 USD 
                 -1.12
@@ -4542,22 +4521,22 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-178 makeStyles-headerCell-171 makeStyles-credibleIntervalHeader-185"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-182 makeStyles-headerCell-175 makeStyles-credibleIntervalHeader-189"
               role="cell"
               scope="row"
               valign="top"
             >
               <span
-                class="makeStyles-monospace-172"
+                class="makeStyles-monospace-176"
               >
                 control
               </span>
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-172"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-176"
             >
               <span
-                class="makeStyles-tooltipped-179"
+                class="makeStyles-tooltipped-183"
               >
                 USD 
                 0
@@ -4573,10 +4552,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </table>
     </div>
     <div
-      class="makeStyles-metricAssignmentDetails-182"
+      class="makeStyles-metricAssignmentDetails-186"
     >
       <h5
-        class="MuiTypography-root makeStyles-dataTableHeader-186 MuiTypography-h5"
+        class="MuiTypography-root makeStyles-dataTableHeader-190 MuiTypography-h5"
       >
         Metric Assignment Settings
       </h5>
@@ -4590,14 +4569,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-171"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-175"
               role="cell"
               scope="row"
             >
               Attribution Window
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-172"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-176"
             >
               1 week
             </td>
@@ -4606,14 +4585,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-171"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-175"
               role="cell"
               scope="row"
             >
               Minimum Practical Difference
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-172"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-176"
             >
               USD 
               0.1
@@ -4624,14 +4603,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-171"
+              class="MuiTableCell-root MuiTableCell-head makeStyles-headerCell-175"
               role="cell"
               scope="row"
             >
               Change Expected
             </th>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-172"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-176"
             >
               Yes
             </td>
@@ -4641,17 +4620,17 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </div>
   </div>
   <div
-    class="makeStyles-metricEstimatePlots-173"
+    class="makeStyles-metricEstimatePlots-177"
   />
   <p
-    class="MuiTypography-root makeStyles-analysisFinePrint-184 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-analysisFinePrint-188 MuiTypography-body1"
   >
     <strong>
       Last analyzed:
     </strong>
      
     <span
-      class="makeStyles-root-187"
+      class="makeStyles-root-191"
       title="09/05/2020, 20:00:00"
     >
       2020-05-10
@@ -4682,7 +4661,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-146",
+        "className": "makeStyles-participantsPlot-149",
         "data": Array [
           Object {
             "line": Object {
@@ -4741,7 +4720,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-174",
+        "className": "makeStyles-metricEstimatePlot-178",
         "data": Array [
           Object {
             "line": Object {
@@ -4837,7 +4816,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-174",
+        "className": "makeStyles-metricEstimatePlot-178",
         "data": Array [
           Object {
             "line": Object {
@@ -4939,7 +4918,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-174",
+        "className": "makeStyles-metricEstimatePlot-178",
         "data": Array [
           Object {
             "line": Object {
@@ -5035,7 +5014,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-174",
+        "className": "makeStyles-metricEstimatePlot-178",
         "data": Array [
           Object {
             "line": Object {

--- a/src/components/experiments/wizard/Metrics.tsx
+++ b/src/components/experiments/wizard/Metrics.tsx
@@ -23,6 +23,7 @@ import { Select, Switch, TextField } from 'formik-material-ui'
 import React, { useState } from 'react'
 
 import { getPropNameCompletions } from 'src/api/AutocompleteApi'
+import Attribute from 'src/components/general/Attribute'
 import AbacusAutocomplete, { autocompleteInputProps } from 'src/components/general/Autocomplete'
 import MetricDifferenceField from 'src/components/general/MetricDifferenceField'
 import MoreMenu from 'src/components/general/MoreMenu'
@@ -45,6 +46,9 @@ const useStyles = makeStyles((theme: Theme) =>
     attributionWindowSelect: {
       minWidth: '8rem',
     },
+    monospaced: {
+      fontFamily: theme.custom.fonts.monospace,
+    },
     metricName: {
       fontFamily: theme.custom.fonts.monospace,
       fontWeight: theme.custom.fontWeights.monospaceBold,
@@ -53,10 +57,6 @@ const useStyles = makeStyles((theme: Theme) =>
       borderBottomWidth: 1,
       borderBottomStyle: 'dashed',
       borderBottomColor: theme.palette.grey[500],
-    },
-    primary: {
-      fontFamily: theme.custom.fonts.monospace,
-      opacity: 0.5,
     },
     minDifferenceField: {
       maxWidth: '14rem',
@@ -360,7 +360,7 @@ const Metrics = ({
                               </span>
                             </Tooltip>
                             <br />
-                            {metricAssignment.isPrimary && <span className={classes.primary}>Primary</span>}
+                            {metricAssignment.isPrimary && <Attribute name='primary' className={classes.monospaced} />}
                           </TableCell>
                           <TableCell>
                             <Field

--- a/src/components/experiments/wizard/__snapshots__/Metrics.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/Metrics.test.tsx.snap
@@ -732,16 +732,16 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                class="makeStyles-metricName-20 makeStyles-tooltipped-21"
+                class="makeStyles-metricName-21 makeStyles-tooltipped-22"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-primary-22"
+                class="makeStyles-root-31 makeStyles-monospaced-20"
               >
-                Primary
+                primary
               </span>
             </td>
             <td
@@ -780,11 +780,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-31 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-32 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-32"
+                    class="PrivateNotchedOutline-legend-33"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -803,14 +803,14 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-35 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-36 MuiSwitch-switchBase MuiSwitch-colorSecondary"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-38 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-39 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -860,11 +860,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-31 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-32 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-32"
+                      class="PrivateNotchedOutline-legend-33"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -1238,16 +1238,16 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                class="makeStyles-metricName-20 makeStyles-tooltipped-21"
+                class="makeStyles-metricName-21 makeStyles-tooltipped-22"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-primary-22"
+                class="makeStyles-root-31 makeStyles-monospaced-20"
               >
-                Primary
+                primary
               </span>
             </td>
             <td
@@ -1286,11 +1286,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-31 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-32 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-32"
+                    class="PrivateNotchedOutline-legend-33"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -1309,14 +1309,14 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-35 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-36 MuiSwitch-switchBase MuiSwitch-colorSecondary"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-38 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-39 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -1366,11 +1366,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-31 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-32 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-32"
+                      class="PrivateNotchedOutline-legend-33"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -1742,16 +1742,16 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                class="makeStyles-metricName-20 makeStyles-tooltipped-21"
+                class="makeStyles-metricName-21 makeStyles-tooltipped-22"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-primary-22"
+                class="makeStyles-root-31 makeStyles-monospaced-20"
               >
-                Primary
+                primary
               </span>
             </td>
             <td
@@ -1790,11 +1790,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-31 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-32 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-32"
+                    class="PrivateNotchedOutline-legend-33"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -1813,14 +1813,14 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-35 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-36 MuiSwitch-switchBase MuiSwitch-colorSecondary"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-38 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-39 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -1870,11 +1870,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-31 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-32 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-32"
+                      class="PrivateNotchedOutline-legend-33"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -2581,16 +2581,16 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                class="makeStyles-metricName-20 makeStyles-tooltipped-21"
+                class="makeStyles-metricName-21 makeStyles-tooltipped-22"
                 title="string"
               >
                 registration_start
               </span>
               <br />
               <span
-                class="makeStyles-primary-22"
+                class="makeStyles-root-41 makeStyles-monospaced-20"
               >
-                Primary
+                primary
               </span>
             </td>
             <td
@@ -2629,11 +2629,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-40 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-42 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-41"
+                    class="PrivateNotchedOutline-legend-43"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -2652,14 +2652,14 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-44 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-46 MuiSwitch-switchBase MuiSwitch-colorSecondary"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-47 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-49 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -2703,7 +2703,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                     class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
                   >
                     <p
-                      class="MuiTypography-root makeStyles-tooltipped-48 MuiTypography-body1 MuiTypography-colorTextSecondary"
+                      class="MuiTypography-root makeStyles-tooltipped-50 MuiTypography-body1 MuiTypography-colorTextSecondary"
                       title="Percentage Points"
                     >
                       pp
@@ -2711,11 +2711,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                   </div>
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-40 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-42 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-41"
+                      class="PrivateNotchedOutline-legend-43"
                       style="width: 0.01px;"
                     >
                       <span>

--- a/src/components/general/Attribute.tsx
+++ b/src/components/general/Attribute.tsx
@@ -17,7 +17,16 @@ const useStyles = makeStyles((theme: Theme) =>
  *
  * e.g. "default", "primary", "excluded"
  */
-export default function Attribute({ name, className }: { name: string; className?: string }): JSX.Element {
+export default function Attribute({
+  name,
+  className,
+}: {
+  /**
+   * Name of the attribute.
+   */
+  name: string
+  className?: string
+}): JSX.Element {
   const classes = useStyles()
 
   return <span className={clsx(classes.root, className)}>{name}</span>

--- a/src/components/general/Attribute.tsx
+++ b/src/components/general/Attribute.tsx
@@ -11,6 +11,12 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 )
 
+/**
+ * Attribute is a UI element to indicate another element has a certain state.
+ * Similar to chips but low profile.
+ *
+ * e.g. "default", "primary", "excluded"
+ */
 export default function Attribute({ name, className }: { name: string; className?: string }): JSX.Element {
   const classes = useStyles()
 

--- a/src/components/general/Attribute.tsx
+++ b/src/components/general/Attribute.tsx
@@ -1,0 +1,18 @@
+import { createStyles, makeStyles, Theme } from '@material-ui/core'
+import clsx from 'clsx'
+import React from 'react'
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      color: theme.palette.grey[500],
+      fontWeight: 'normal',
+    },
+  }),
+)
+
+export default function Attribute({ name, className }: { name: string; className?: string }) {
+  const classes = useStyles()
+
+  return <span className={clsx(classes.root, className)}>{name}</span>
+}


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR:**
- Moves attribution window to the name column as part of #524 
- While I am there changes the "default" styling roughly as discussed in p1620399093020400-slack-G01BQ5WMR8Q
- Does the above by adding an `Attribute` component.
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Screenshots in slack

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
