### PR TITLE
Temporarily disable integration-e2e CI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,4 +101,5 @@ workflows:
     jobs:
       - static-checks
       - unit-tests
-      - integration-e2e
+      # Disabled until the SwaggerHub issue is fixed. See https://github.com/Automattic/abacus/issues/506.
+      # - integration-e2e


### PR DESCRIPTION
As it's taking a long time for SwaggerHub to fix the issue behind #506, disable the CI step to make things less noisy and greener.

## How has this been tested?
CircleCI run should excluded `integration-e2e`.