### PR TITLE
Fix unit consistency

### DIFF
--- a/src/components/experiments/single-view/overview/MetricAssignmentsPanel.test.tsx
+++ b/src/components/experiments/single-view/overview/MetricAssignmentsPanel.test.tsx
@@ -181,9 +181,9 @@ test('renders as expected with all metrics resolvable', () => {
               <td
                 class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-2"
               >
-                USD 
-                0.5
                 
+                0.50
+                 USD
               </td>
             </tr>
             <tr
@@ -218,9 +218,9 @@ test('renders as expected with all metrics resolvable', () => {
               <td
                 class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-2"
               >
-                USD 
-                10.5
                 
+                10.50
+                 USD
               </td>
             </tr>
             <tr

--- a/src/components/experiments/single-view/overview/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/src/components/experiments/single-view/overview/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -723,9 +723,9 @@ exports[`renders as expected at large width 1`] = `
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-31"
           >
-            USD 
-            0.5
             
+            0.50
+             USD
           </td>
         </tr>
         <tr
@@ -760,9 +760,9 @@ exports[`renders as expected at large width 1`] = `
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-31"
           >
-            USD 
-            10.5
             
+            10.50
+             USD
           </td>
         </tr>
         <tr
@@ -1536,9 +1536,9 @@ exports[`renders as expected at small width 1`] = `
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-67"
           >
-            USD 
-            0.5
             
+            0.50
+             USD
           </td>
         </tr>
         <tr
@@ -1573,9 +1573,9 @@ exports[`renders as expected at small width 1`] = `
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-67"
           >
-            USD 
-            10.5
             
+            10.50
+             USD
           </td>
         </tr>
         <tr
@@ -2453,9 +2453,9 @@ exports[`renders as expected with conclusion data 1`] = `
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-105"
           >
-            USD 
-            0.5
             
+            0.50
+             USD
           </td>
         </tr>
         <tr
@@ -2490,9 +2490,9 @@ exports[`renders as expected with conclusion data 1`] = `
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-105"
           >
-            USD 
-            10.5
             
+            10.50
+             USD
           </td>
         </tr>
         <tr
@@ -3266,9 +3266,9 @@ exports[`renders as expected without conclusion data 1`] = `
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-141"
           >
-            USD 
-            0.5
             
+            0.50
+             USD
           </td>
         </tr>
         <tr
@@ -3303,9 +3303,9 @@ exports[`renders as expected without conclusion data 1`] = `
           <td
             class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-141"
           >
-            USD 
-            10.5
             
+            10.50
+             USD
           </td>
         </tr>
         <tr

--- a/src/components/experiments/single-view/results/ActualExperimentResults.tsx
+++ b/src/components/experiments/single-view/results/ActualExperimentResults.tsx
@@ -308,6 +308,7 @@ export default function ActualExperimentResults({
         return (
           <MetricValueInterval
             intervalName={'the absolute change between variations'}
+            isDifference={true}
             metricParameterType={metric.parameterType}
             bottomValue={latestEstimates.diff.bottom}
             topValue={latestEstimates.diff.top}

--- a/src/components/experiments/single-view/results/MetricAssignmentResults.tsx
+++ b/src/components/experiments/single-view/results/MetricAssignmentResults.tsx
@@ -325,6 +325,7 @@ export default function MetricAssignmentResults({
                       <MetricValueInterval
                         intervalName={'the absolute change between variations'}
                         metricParameterType={metric.parameterType}
+                        isDifference={true}
                         bottomValue={latestEstimates.diff.bottom}
                         topValue={latestEstimates.diff.top}
                       />

--- a/src/components/experiments/single-view/results/MetricAssignmentResults.tsx
+++ b/src/components/experiments/single-view/results/MetricAssignmentResults.tsx
@@ -316,6 +316,7 @@ export default function MetricAssignmentResults({
                       metricParameterType={metric.parameterType}
                       bottomValue={latestEstimates[`variation_${variation.variationId}`].bottom}
                       topValue={latestEstimates[`variation_${variation.variationId}`].top}
+                      displayPositiveSign={false}
                     />
                   </TableCell>
                   <TableCell className={classes.monospace} align='right'>

--- a/src/components/experiments/single-view/results/MetricAssignmentResults.tsx
+++ b/src/components/experiments/single-view/results/MetricAssignmentResults.tsx
@@ -406,11 +406,11 @@ export default function MetricAssignmentResults({
                 <TableCell>Variant</TableCell>
                 <TableCell align='right'>Users</TableCell>
                 <TableCell align='right'>
-                  {metric.parameterType === MetricParameterType.Revenue ? 'Revenue (USD)' : 'Conversions'}
+                  {metric.parameterType === MetricParameterType.Revenue ? 'Revenue' : 'Conversions'}
                 </TableCell>
                 <TableCell align='right'>
                   {metric.parameterType === MetricParameterType.Revenue
-                    ? 'Average revenue per user (USD)'
+                    ? 'Average revenue per user (ARPU)'
                     : 'Conversion rate'}
                 </TableCell>
               </TableRow>
@@ -432,13 +432,19 @@ export default function MetricAssignmentResults({
                       {latestAnalysis.participantStats[`variation_${variation.variationId}`].toLocaleString()}
                     </TableCell>
                     <TableCell className={classes.monospace} align='right'>
-                      {(
-                        latestAnalysis.participantStats[`variation_${variation.variationId}`] *
-                        latestEstimates[`variation_${variation.variationId}`].estimate
-                      ).toLocaleString()}
+                      <MetricValue
+                        value={
+                          latestAnalysis.participantStats[`variation_${variation.variationId}`] *
+                          latestEstimates[`variation_${variation.variationId}`].estimate
+                        }
+                        metricParameterType={metric.parameterType}
+                      />
                     </TableCell>
                     <TableCell className={classes.monospace} align='right'>
-                      {latestEstimates[`variation_${variation.variationId}`].estimate.toLocaleString()}
+                      <MetricValue
+                        value={latestEstimates[`variation_${variation.variationId}`].estimate}
+                        metricParameterType={metric.parameterType}
+                      />
                     </TableCell>
                   </TableRow>
                 </React.Fragment>

--- a/src/components/experiments/single-view/results/MetricAssignmentResults.tsx
+++ b/src/components/experiments/single-view/results/MetricAssignmentResults.tsx
@@ -438,7 +438,11 @@ export default function MetricAssignmentResults({
                           latestAnalysis.participantStats[`variation_${variation.variationId}`] *
                           latestEstimates[`variation_${variation.variationId}`].estimate
                         }
-                        metricParameterType={metric.parameterType}
+                        metricParameterType={
+                          metric.parameterType === MetricParameterType.Conversion
+                            ? MetricParameterType.Count
+                            : metric.parameterType
+                        }
                       />
                     </TableCell>
                     <TableCell className={classes.monospace} align='right'>

--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -223,7 +223,7 @@ exports[`allows you to change analysis strategy 1`] = `
                           +
                           1
                            
-                          %
+                          pp
                         </span>
                       </td>
                       <td
@@ -1672,7 +1672,7 @@ exports[`renders correctly for 1 analysis datapoint 1`] = `
                         +
                         1
                          
-                        %
+                        pp
                       </span>
                     </td>
                     <td
@@ -2792,7 +2792,6 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
             >
               -112.3
                to 
-              +
               100
                
               %
@@ -2809,7 +2808,7 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
               +
               1
                
-              %
+              pp
             </span>
           </td>
           <td
@@ -2848,10 +2847,8 @@ exports[`renders correctly for 1 analysis datapoint 2`] = `
             <span
               class="makeStyles-tooltipped-73"
             >
-              +
               0
                to 
-              +
               1000
                
               %
@@ -3203,7 +3200,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                         +
                         1
                          
-                        %
+                        pp
                       </span>
                     </td>
                     <td
@@ -3430,7 +3427,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                         +
                         1
                          
-                        %
+                        pp
                       </span>
                     </td>
                     <td
@@ -4354,7 +4351,6 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             >
               -112.3
                to 
-              +
               100
                
               %
@@ -4371,7 +4367,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               +
               1
                
-              %
+              pp
             </span>
           </td>
           <td
@@ -4410,10 +4406,8 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             <span
               class="makeStyles-tooltipped-133"
             >
-              +
               0
                to 
-              +
               1000
                
               %
@@ -6330,8 +6324,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             >
               -1.12
                to 
-              +
-              1
+              1.00
                
               USD
             </span>
@@ -6386,11 +6379,9 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             <span
               class="makeStyles-tooltipped-193"
             >
-              +
-              0
+              0.00
                to 
-              +
-              10
+              10.00
                
               USD
             </span>
@@ -6417,9 +6408,9 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
        Experimenter-set minimum practical difference: 
     </strong>
      
-    USD 
-    0.1
     
+    0.10
+     USD
     .
   </p>
   <div

--- a/src/components/general/MetricValue.test.tsx
+++ b/src/components/general/MetricValue.test.tsx
@@ -80,34 +80,34 @@ test('renders metric values', () => {
   expect(render(<MetricValue value={1} metricParameterType={MetricParameterType.Revenue} />).container)
     .toMatchInlineSnapshot(`
     <div>
-      USD 
-      1
       
+      1.00
+       USD
     </div>
   `)
   expect(render(<MetricValue value={0.01} metricParameterType={MetricParameterType.Revenue} />).container)
     .toMatchInlineSnapshot(`
     <div>
-      USD 
-      0.01
       
+      0.01
+       USD
     </div>
   `)
   expect(render(<MetricValue value={0.123456789} metricParameterType={MetricParameterType.Revenue} />).container)
     .toMatchInlineSnapshot(`
     <div>
-      USD 
-      0.12
       
+      0.12
+       USD
     </div>
   `)
   expect(
     render(<MetricValue value={1} metricParameterType={MetricParameterType.Revenue} isDifference={true} />).container,
   ).toMatchInlineSnapshot(`
     <div>
-      USD 
-      1
       
+      1.00
+       USD
     </div>
   `)
   expect(
@@ -115,9 +115,9 @@ test('renders metric values', () => {
       .container,
   ).toMatchInlineSnapshot(`
     <div>
-      USD 
-      0.01
       
+      0.01
+       USD
     </div>
   `)
   expect(
@@ -125,9 +125,9 @@ test('renders metric values', () => {
       .container,
   ).toMatchInlineSnapshot(`
     <div>
-      USD 
-      0.12
       
+      0.12
+       USD
     </div>
   `)
 })

--- a/src/components/general/MetricValue.tsx
+++ b/src/components/general/MetricValue.tsx
@@ -25,13 +25,17 @@ function DashedTooltip(props: Parameters<typeof Tooltip>[0]) {
  */
 const metricValueFormatPrecision = 2
 
+interface MetricValueFormat {
+  unit: React.ReactNode
+  prefix: React.ReactNode
+  postfix: React.ReactNode
+  transform: (v: number) => number
+}
+
 /**
  * Metric Formatting Data
  */
-export const metricValueFormatData: Record<
-  string,
-  { unit: React.ReactNode; prefix: React.ReactNode; postfix: React.ReactNode; transform: (v: number) => number }
-> = {
+export const metricValueFormatData: Record<string, MetricValueFormat> = {
   conversion: {
     unit: '%',
     prefix: '',
@@ -62,6 +66,13 @@ export const metricValueFormatData: Record<
   },
 }
 
+export function getMetricValueFormatData(
+  metricParameterType: MetricParameterType,
+  isDifference = false,
+): MetricValueFormat {
+  return metricValueFormatData[`${metricParameterType}${isDifference ? '_difference' : ''}`]
+}
+
 /**
  * Format a metric value to be used outside of a graph context.
  * @param value The metric value
@@ -83,7 +94,7 @@ export default function MetricValue({
   displayUnit?: boolean
   displayPositiveSign?: boolean
 }): JSX.Element {
-  const format = metricValueFormatData[`${metricParameterType}${isDifference ? '_difference' : ''}`]
+  const format = getMetricValueFormatData(metricParameterType, isDifference)
   return (
     <>
       {displayPositiveSign && 0 <= value && '+'}

--- a/src/components/general/MetricValue.tsx
+++ b/src/components/general/MetricValue.tsx
@@ -76,16 +76,19 @@ export const metricValueFormatData: Record<string, MetricValueFormat> = {
   revenue_difference: {
     unit: 'USD',
     prefix: '',
-    postfix: <>&nbsp;USD;</>,
+    postfix: <>&nbsp;USD</>,
     transform: identity,
     formatter: usdFormatter,
   },
 }
 
-export function getMetricValueFormatData(
-  metricParameterType: MetricParameterType,
-  isDifference = false,
-): MetricValueFormat {
+export function getMetricValueFormatData({
+  metricParameterType,
+  isDifference,
+}: {
+  metricParameterType: MetricParameterType
+  isDifference: boolean
+}): MetricValueFormat {
   return metricValueFormatData[`${metricParameterType}${isDifference ? '_difference' : ''}`]
 }
 
@@ -110,7 +113,7 @@ export default function MetricValue({
   displayUnit?: boolean
   displayPositiveSign?: boolean
 }): JSX.Element {
-  const format = getMetricValueFormatData(metricParameterType, isDifference)
+  const format = getMetricValueFormatData({ metricParameterType, isDifference })
   return (
     <>
       {displayPositiveSign && 0 <= value && '+'}

--- a/src/components/general/MetricValue.tsx
+++ b/src/components/general/MetricValue.tsx
@@ -46,7 +46,7 @@ export const metricValueFormatData: Record<string, MetricValueFormat> = {
     prefix: '',
     postfix: '',
     transform: identity,
-    formatter: (n) => n.toLocaleString(undefined),
+    formatter: (n: number): string => n.toLocaleString(undefined),
   },
   conversion: {
     unit: '%',

--- a/src/components/general/MetricValue.tsx
+++ b/src/components/general/MetricValue.tsx
@@ -29,18 +29,31 @@ interface MetricValueFormat {
   unit: React.ReactNode
   prefix: React.ReactNode
   postfix: React.ReactNode
-  transform: (v: number) => number
+  transform: (n: number) => number
+  formatter: (n: number) => string
 }
+
+const standardNumberFormatter = (n: number): string => `${_.round(n, metricValueFormatPrecision)}`
+const usdFormatter = (n: number): string =>
+  n.toLocaleString(undefined, { maximumFractionDigits: 2, minimumFractionDigits: 2 })
 
 /**
  * Metric Formatting Data
  */
 export const metricValueFormatData: Record<string, MetricValueFormat> = {
+  count: {
+    unit: '',
+    prefix: '',
+    postfix: '',
+    transform: identity,
+    formatter: (n) => n.toLocaleString(undefined),
+  },
   conversion: {
     unit: '%',
     prefix: '',
     postfix: '%',
     transform: (x: number): number => x * 100,
+    formatter: standardNumberFormatter,
   },
   conversion_difference: {
     unit: 'pp',
@@ -51,18 +64,21 @@ export const metricValueFormatData: Record<string, MetricValueFormat> = {
       </DashedTooltip>
     ),
     transform: (x: number): number => x * 100,
+    formatter: standardNumberFormatter,
   },
   revenue: {
     unit: 'USD',
-    prefix: <>USD&nbsp;</>,
-    postfix: '',
+    prefix: '',
+    postfix: <>&nbsp;USD</>,
     transform: identity,
+    formatter: usdFormatter,
   },
   revenue_difference: {
     unit: 'USD',
-    prefix: <>USD&nbsp;</>,
-    postfix: '',
+    prefix: '',
+    postfix: <>&nbsp;USD;</>,
     transform: identity,
+    formatter: usdFormatter,
   },
 }
 
@@ -99,7 +115,7 @@ export default function MetricValue({
     <>
       {displayPositiveSign && 0 <= value && '+'}
       {displayUnit && format.prefix}
-      {_.round(format.transform(value), metricValueFormatPrecision)}
+      {format.formatter(format.transform(value))}
       {displayUnit && format.postfix}
     </>
   )

--- a/src/components/general/MetricValueInterval.tsx
+++ b/src/components/general/MetricValueInterval.tsx
@@ -26,6 +26,7 @@ export default function MetricValueInterval({
   bottomValue,
   topValue,
   displayTooltipHint = true,
+  displayPositiveSign = true,
 }: {
   intervalName: string
   metricParameterType: MetricParameterType
@@ -33,6 +34,7 @@ export default function MetricValueInterval({
   bottomValue: number
   topValue: number
   displayTooltipHint?: boolean
+  displayPositiveSign?: boolean
 }): JSX.Element {
   const classes = useStyles()
   const metricValueFormat = getMetricValueFormatData(metricParameterType, isDifference)
@@ -43,8 +45,20 @@ export default function MetricValueInterval({
           <strong>Interpretation:</strong>
           <br />
           There is a 95% probability that {intervalName} is between{' '}
-          <MetricValue value={bottomValue} metricParameterType={metricParameterType} isDifference={isDifference} /> and{' '}
-          <MetricValue value={topValue} metricParameterType={metricParameterType} isDifference={isDifference} />.
+          <MetricValue
+            value={bottomValue}
+            metricParameterType={metricParameterType}
+            isDifference={isDifference}
+            displayPositiveSign={displayPositiveSign}
+          />{' '}
+          and{' '}
+          <MetricValue
+            value={topValue}
+            metricParameterType={metricParameterType}
+            isDifference={isDifference}
+            displayPositiveSign={displayPositiveSign}
+          />
+          .
         </>
       }
     >
@@ -54,7 +68,7 @@ export default function MetricValueInterval({
           metricParameterType={metricParameterType}
           isDifference={isDifference}
           displayUnit={false}
-          displayPositiveSign
+          displayPositiveSign={displayPositiveSign}
         />
         &nbsp;to&nbsp;
         <MetricValue
@@ -62,7 +76,7 @@ export default function MetricValueInterval({
           metricParameterType={metricParameterType}
           isDifference={isDifference}
           displayUnit={false}
-          displayPositiveSign
+          displayPositiveSign={displayPositiveSign}
         />
         &nbsp;{metricValueFormat.unit}
       </span>

--- a/src/components/general/MetricValueInterval.tsx
+++ b/src/components/general/MetricValueInterval.tsx
@@ -2,7 +2,7 @@ import { createStyles, makeStyles, Theme, Tooltip } from '@material-ui/core'
 import clsx from 'clsx'
 import React from 'react'
 
-import MetricValue, { metricValueFormatData } from 'src/components/general/MetricValue'
+import MetricValue, { getMetricValueFormatData } from 'src/components/general/MetricValue'
 import { MetricParameterType } from 'src/lib/schemas'
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -22,17 +22,20 @@ const useStyles = makeStyles((theme: Theme) =>
 export default function MetricValueInterval({
   intervalName,
   metricParameterType,
+  isDifference = false,
   bottomValue,
   topValue,
   displayTooltipHint = true,
 }: {
   intervalName: string
   metricParameterType: MetricParameterType
+  isDifference?: boolean
   bottomValue: number
   topValue: number
   displayTooltipHint?: boolean
 }): JSX.Element {
   const classes = useStyles()
+  const metricValueFormat = getMetricValueFormatData(metricParameterType, isDifference)
   return (
     <Tooltip
       title={
@@ -40,8 +43,8 @@ export default function MetricValueInterval({
           <strong>Interpretation:</strong>
           <br />
           There is a 95% probability that {intervalName} is between{' '}
-          <MetricValue value={bottomValue} metricParameterType={metricParameterType} isDifference={true} /> and{' '}
-          <MetricValue value={topValue} metricParameterType={metricParameterType} isDifference={true} />.
+          <MetricValue value={bottomValue} metricParameterType={metricParameterType} isDifference={isDifference} /> and{' '}
+          <MetricValue value={topValue} metricParameterType={metricParameterType} isDifference={isDifference} />.
         </>
       }
     >
@@ -49,7 +52,7 @@ export default function MetricValueInterval({
         <MetricValue
           value={bottomValue}
           metricParameterType={metricParameterType}
-          isDifference={true}
+          isDifference={isDifference}
           displayUnit={false}
           displayPositiveSign
         />
@@ -57,11 +60,11 @@ export default function MetricValueInterval({
         <MetricValue
           value={topValue}
           metricParameterType={metricParameterType}
-          isDifference={true}
+          isDifference={isDifference}
           displayUnit={false}
           displayPositiveSign
         />
-        &nbsp;{metricValueFormatData[metricParameterType].unit}
+        &nbsp;{metricValueFormat.unit}
       </span>
     </Tooltip>
   )

--- a/src/components/general/MetricValueInterval.tsx
+++ b/src/components/general/MetricValueInterval.tsx
@@ -37,7 +37,7 @@ export default function MetricValueInterval({
   displayPositiveSign?: boolean
 }): JSX.Element {
   const classes = useStyles()
-  const metricValueFormat = getMetricValueFormatData(metricParameterType, isDifference)
+  const metricValueFormat = getMetricValueFormatData({ metricParameterType, isDifference })
   return (
     <Tooltip
       title={

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -100,6 +100,8 @@ export interface MetricRevenueParams extends yup.InferType<typeof metricRevenueP
 export enum MetricParameterType {
   Conversion = 'conversion',
   Revenue = 'revenue',
+  // Used in UI only:
+  Count = 'count',
 }
 
 export const metricBareSchema = yup


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR fixes some unit consistency issues mentioned in p1624506676009300-slack-G01BQ5WMR8Q:**
- Use correct units for non-different values
- Use MetricValue in Observations table
- Don't display signs for values that aren't signed
- Improve currency display
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

I am not too happy with MetricValue as an abstraction, might have a think about it.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
