### PR TITLE
Fix client validation error messages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,8 @@
-/* eslint-disable no-template-curly-in-string */
 import { makeStyles } from '@material-ui/core/styles'
 import debugFactory from 'debug'
 import { SnackbarProvider } from 'notistack'
 import qs from 'querystring'
 import React from 'react'
-import * as yup from 'yup'
 
 import RenderErrorBoundary from 'src/components/page-parts/RenderErrorBoundary'
 import RenderErrorView from 'src/components/page-parts/RenderErrorView'
@@ -15,65 +13,6 @@ import { getExperimentsAuthInfo } from 'src/utils/auth'
 import Routes from './Routes'
 
 const debug = debugFactory('abacus:pages/_app.tsx')
-
-/**
- * Setup Yup UI Validation messages
- *
- * I have taken the defaults (see below) and removed the '${path}' references.
- * Should not be run with tests as we want that extra information.
- *
- * An unfortunate downside to this is that we get less information on run-time errors.
- * If we do want better run-time errors we simply need to wrap the schema in an object
- * before we validate: yup.object({ x: schemaT  }).validate({ x })
- * Then the validation error will have an inner property with both path's and errors.
- *
- * The defaults:
- * https://github.com/jquense/yup/blob/master/src/locale.js
- */
-const yupLocale = {
-  mixed: {
-    default: 'This field is invalid',
-    required: 'This field is a required field',
-    oneOf: 'This field must be one of the following values: ${values}',
-    notOneOf: 'This field must not be one of the following values: ${values}',
-    defined: 'This field must be defined',
-  },
-  string: {
-    length: 'This field must be exactly ${length} characters',
-    min: 'This field must be at least ${min} characters',
-    max: 'This field must be at most ${max} characters',
-    matches: 'This field must match the following: "${regex}"',
-    email: 'This field must be a valid email',
-    url: 'This field must be a valid URL',
-    uuid: 'This field must be a valid UUID',
-    trim: 'This field must be a trimmed string',
-    lowercase: 'This field must be a lowercase string',
-    uppercase: 'This field must be a upper case string',
-  },
-  number: {
-    min: 'This field must be greater than or equal to ${min}',
-    max: 'This field must be less than or equal to ${max}',
-    lessThan: 'This field must be less than ${less}',
-    moreThan: 'This field must be greater than ${more}',
-    notEqual: 'This field must be not equal to ${notEqual}',
-    positive: 'This field must be a positive number',
-    negative: 'This field must be a negative number',
-    integer: 'This field must be an integer',
-  },
-  date: {
-    min: 'This field must be later than ${min}',
-    max: 'This field must be at earlier than ${max}',
-  },
-  boolean: {},
-  object: {
-    noUnknown: 'This field has unspecified keys: ${unknown}',
-  },
-  array: {
-    min: 'This field must have at least ${min} items',
-    max: 'This field must have less than or equal to ${max} items',
-  },
-}
-yup.setLocale(yupLocale as yup.LocaleObject)
 
 const useStyles = makeStyles({
   app: {

--- a/src/lib/schemas.test.ts
+++ b/src/lib/schemas.test.ts
@@ -67,10 +67,10 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.errors).toMatchInlineSnapshot(`
           Array [
-            "metricId must be defined",
-            "name must be defined",
-            "description must be defined",
-            "higherIsBetter must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
             "Event Params is required and must be valid JSON.",
             "Exactly one of eventParams or revenueParams must be defined.",
           ]
@@ -89,10 +89,10 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.errors).toMatchInlineSnapshot(`
           Array [
-            "metricId must be defined",
-            "name must be defined",
-            "description must be defined",
-            "higherIsBetter must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
             "Revenue Params is required and must be valid JSON.",
             "Exactly one of eventParams or revenueParams must be defined.",
           ]
@@ -111,10 +111,10 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.errors).toMatchInlineSnapshot(`
           Array [
-            "metricId must be defined",
-            "name must be defined",
-            "description must be defined",
-            "higherIsBetter must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
           ]
         `)
       }
@@ -131,11 +131,11 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.errors).toMatchInlineSnapshot(`
           Array [
-            "metricId must be defined",
-            "name must be defined",
-            "description must be defined",
-            "higherIsBetter must be defined",
-            "eventParams must be one of the following values: ",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be one of the following values: ",
             "Revenue Params is required and must be valid JSON.",
           ]
         `)
@@ -153,11 +153,11 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.errors).toMatchInlineSnapshot(`
           Array [
-            "metricId must be defined",
-            "name must be defined",
-            "description must be defined",
-            "higherIsBetter must be defined",
-            "revenueParams must be one of the following values: ",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be one of the following values: ",
             "Event Params is required and must be valid JSON.",
           ]
         `)
@@ -175,13 +175,13 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.errors).toMatchInlineSnapshot(`
           Array [
-            "metricId must be defined",
-            "name must be defined",
-            "description must be defined",
-            "higherIsBetter must be defined",
-            "revenueParams.refundDays must be defined",
-            "revenueParams.productSlugs must be defined",
-            "revenueParams.transactionTypes must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
           ]
         `)
       }
@@ -201,13 +201,13 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.errors).toMatchInlineSnapshot(`
           Array [
-            "metricId must be defined",
-            "name must be defined",
-            "description must be defined",
-            "parameterType must be defined",
-            "higherIsBetter must be defined",
-            "eventParams must be one of the following values: ",
-            "revenueParams must be one of the following values: ",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be one of the following values: ",
+            "This field must be one of the following values: ",
             "Exactly one of eventParams or revenueParams must be defined.",
           ]
         `)
@@ -224,11 +224,11 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.errors).toMatchInlineSnapshot(`
           Array [
-            "metricId must be defined",
-            "name must be defined",
-            "description must be defined",
-            "parameterType must be defined",
-            "higherIsBetter must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
             "Exactly one of eventParams or revenueParams must be defined.",
           ]
         `)
@@ -246,10 +246,10 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.errors).toMatchInlineSnapshot(`
           Array [
-            "metricId must be defined",
-            "name must be defined",
-            "description must be defined",
-            "higherIsBetter must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
           ]
         `)
       }
@@ -266,13 +266,13 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.errors).toMatchInlineSnapshot(`
           Array [
-            "metricId must be defined",
-            "name must be defined",
-            "description must be defined",
-            "higherIsBetter must be defined",
-            "revenueParams.refundDays must be defined",
-            "revenueParams.productSlugs must be defined",
-            "revenueParams.transactionTypes must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
+            "This field must be defined",
           ]
         `)
       }
@@ -293,17 +293,17 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.inner).toMatchInlineSnapshot(`
           Array [
-            [ValidationError: name must be defined],
+            [ValidationError: This field must be defined],
             [ValidationError: Start date (UTC) must be in the future.],
             [ValidationError: End date must be after start date.],
-            [ValidationError: platform must be defined],
-            [ValidationError: ownerLogin must be defined],
-            [ValidationError: description must be defined],
-            [ValidationError: existingUsersAllowed must be defined],
-            [ValidationError: p2Url must be defined],
-            [ValidationError: metricAssignments must be defined],
-            [ValidationError: segmentAssignments must be defined],
-            [ValidationError: variations must be defined],
+            [ValidationError: This field must be defined],
+            [ValidationError: This field must be defined],
+            [ValidationError: This field must be defined],
+            [ValidationError: This field must be defined],
+            [ValidationError: This field must be defined],
+            [ValidationError: This field must be defined],
+            [ValidationError: This field must be defined],
+            [ValidationError: This field must be defined],
           ]
         `)
       }
@@ -322,17 +322,17 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.inner).toMatchInlineSnapshot(`
           Array [
-            [ValidationError: name must be defined],
+            [ValidationError: This field must be defined],
             [ValidationError: Start date (UTC) must be in the future.],
             [ValidationError: End date must be within 12 months of start date.],
-            [ValidationError: platform must be defined],
-            [ValidationError: ownerLogin must be defined],
-            [ValidationError: description must be defined],
-            [ValidationError: existingUsersAllowed must be defined],
-            [ValidationError: p2Url must be defined],
-            [ValidationError: metricAssignments must be defined],
-            [ValidationError: segmentAssignments must be defined],
-            [ValidationError: variations must be defined],
+            [ValidationError: This field must be defined],
+            [ValidationError: This field must be defined],
+            [ValidationError: This field must be defined],
+            [ValidationError: This field must be defined],
+            [ValidationError: This field must be defined],
+            [ValidationError: This field must be defined],
+            [ValidationError: This field must be defined],
+            [ValidationError: This field must be defined],
           ]
         `)
       }
@@ -379,7 +379,7 @@ describe('lib/schemas.ts module', () => {
     it('should respect undefined', () => {
       expect(Schemas.extendedNumberSchema.validateSync(undefined)).toBe(undefined)
       expect(() => Schemas.extendedNumberSchema.defined().validateSync(undefined)).toThrowErrorMatchingInlineSnapshot(
-        `"this must be defined"`,
+        `"This field must be defined"`,
       )
     })
   })

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-empty-interface */
+/* eslint-disable @typescript-eslint/no-empty-interface,no-template-curly-in-string */
 
 // Schema documentation lives at:
 // https://app.swaggerhub.com/apis/yanir/experiments/0.1.0
@@ -7,6 +7,65 @@ import * as dateFns from 'date-fns'
 import _ from 'lodash'
 import * as yup from 'yup'
 import { ObjectSchema } from 'yup'
+
+/**
+ * Setup Yup UI Validation messages
+ *
+ * I have taken the defaults (see below) and removed the '${path}' references.
+ * Should not be run with tests as we want that extra information.
+ *
+ * An unfortunate downside to this is that we get less information on run-time errors.
+ * If we do want better run-time errors we simply need to wrap the schema in an object
+ * before we validate: yup.object({ x: schemaT  }).validate({ x })
+ * Then the validation error will have an inner property with both path's and errors.
+ *
+ * The defaults:
+ * https://github.com/jquense/yup/blob/master/src/locale.js
+ */
+const yupLocale = {
+  mixed: {
+    default: 'This field is invalid',
+    required: 'This field is a required field',
+    oneOf: 'This field must be one of the following values: ${values}',
+    notOneOf: 'This field must not be one of the following values: ${values}',
+    defined: 'This field must be defined',
+  },
+  string: {
+    length: 'This field must be exactly ${length} characters',
+    min: 'This field must be at least ${min} characters',
+    max: 'This field must be at most ${max} characters',
+    matches: 'This field must match the following: "${regex}"',
+    email: 'This field must be a valid email',
+    url: 'This field must be a valid URL',
+    uuid: 'This field must be a valid UUID',
+    trim: 'This field must be a trimmed string',
+    lowercase: 'This field must be a lowercase string',
+    uppercase: 'This field must be a upper case string',
+  },
+  number: {
+    min: 'This field must be greater than or equal to ${min}',
+    max: 'This field must be less than or equal to ${max}',
+    lessThan: 'This field must be less than ${less}',
+    moreThan: 'This field must be greater than ${more}',
+    notEqual: 'This field must be not equal to ${notEqual}',
+    positive: 'This field must be a positive number',
+    negative: 'This field must be a negative number',
+    integer: 'This field must be an integer',
+  },
+  date: {
+    min: 'This field must be later than ${min}',
+    max: 'This field must be at earlier than ${max}',
+  },
+  boolean: {},
+  object: {
+    noUnknown: 'This field has unspecified keys: ${unknown}',
+  },
+  array: {
+    min: 'This field must have at least ${min} items',
+    max: 'This field must have less than or equal to ${max} items',
+  },
+}
+yup.setLocale(yupLocale as yup.LocaleObject)
 
 export const idSchema = yup.number().integer().positive()
 export const nameSchema = yup


### PR DESCRIPTION
**This PR makes validation errors say "This" instead of the qualified name of the input.** 
- Fixed by moving the messages to the start of schemas so they can
be applied.

**Before:**
<img width="679" alt="Screen Shot 2021-07-05 at 6 17 28 pm" src="https://user-images.githubusercontent.com/971886/124456438-44565c80-ddbd-11eb-845f-f910c522dd64.png">

**After:**
<img width="681" alt="Screen Shot 2021-07-05 at 6 15 49 pm" src="https://user-images.githubusercontent.com/971886/124456347-2c7ed880-ddbd-11eb-8e7b-46d27ed9ca64.png">


<!-- Describe your changes in detail. -->
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
