### PR TITLE
Fix up the wizard metric assignments

### DIFF
--- a/src/components/experiments/wizard/ExperimentForm.test.tsx
+++ b/src/components/experiments/wizard/ExperimentForm.test.tsx
@@ -553,7 +553,7 @@ test('form submits with valid fields', async () => {
       metricAssignments: [
         {
           attributionWindowSeconds: '86400',
-          changeExpected: false,
+          changeExpected: true,
           isPrimary: true,
           metricId: 10,
           minDifference: 0.01,

--- a/src/components/experiments/wizard/Metrics.tsx
+++ b/src/components/experiments/wizard/Metrics.tsx
@@ -126,7 +126,7 @@ const createMetricAssignment = (metric: Metric) => {
   return {
     metricId: metric.metricId,
     attributionWindowSeconds: '',
-    isPrimary: false,
+    isPrimary: true,
     changeExpected: false,
     minDifference: '',
   }

--- a/src/components/experiments/wizard/Metrics.tsx
+++ b/src/components/experiments/wizard/Metrics.tsx
@@ -49,6 +49,11 @@ const useStyles = makeStyles((theme: Theme) =>
     monospaced: {
       fontFamily: theme.custom.fonts.monospace,
     },
+    metricNameCell: {
+      maxWidth: '24rem',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+    },
     metricName: {
       fontFamily: theme.custom.fonts.monospace,
       fontWeight: theme.custom.fontWeights.monospaceBold,
@@ -337,7 +342,7 @@ const Metrics = ({
                       <TableCell>Metric</TableCell>
                       <TableCell>Attribution Window</TableCell>
                       <TableCell>Change Expected?</TableCell>
-                      <TableCell>Minimum Difference</TableCell>
+                      <TableCell>Minimum Practical Difference</TableCell>
                       <TableCell />
                     </TableRow>
                   </TableHead>
@@ -353,7 +358,7 @@ const Metrics = ({
 
                       return (
                         <TableRow key={index}>
-                          <TableCell>
+                          <TableCell className={classes.metricNameCell}>
                             <Tooltip arrow title={indexedMetrics[metricAssignment.metricId].description}>
                               <span className={clsx(classes.metricName, classes.tooltipped)}>
                                 {indexedMetrics[metricAssignment.metricId].name}

--- a/src/components/experiments/wizard/Metrics.tsx
+++ b/src/components/experiments/wizard/Metrics.tsx
@@ -126,8 +126,8 @@ const createMetricAssignment = (metric: Metric) => {
   return {
     metricId: metric.metricId,
     attributionWindowSeconds: '',
-    isPrimary: true,
-    changeExpected: false,
+    isPrimary: false,
+    changeExpected: true,
     minDifference: '',
   }
 }

--- a/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
@@ -415,10 +415,10 @@ exports[`renders as expected 1`] = `
 exports[`sections should be browsable by the section buttons 1`] = `
 <div>
   <div
-    class="makeStyles-root-119"
+    class="makeStyles-root-121"
   >
     <div
-      class="makeStyles-navigation-120"
+      class="makeStyles-navigation-122"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -705,17 +705,17 @@ exports[`sections should be browsable by the section buttons 1`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-121"
+        class="makeStyles-form-123"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-122"
+          class="makeStyles-formPart-124"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-124 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-126 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-125"
+              class="makeStyles-root-127"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -761,7 +761,7 @@ exports[`sections should be browsable by the section buttons 1`] = `
                 </div>
               </div>
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-p2EntryField-126"
+                class="MuiFormControl-root MuiTextField-root makeStyles-p2EntryField-128"
               >
                 <label
                   class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
@@ -785,10 +785,10 @@ exports[`sections should be browsable by the section buttons 1`] = `
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-128 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-130 MuiOutlinedInput-notchedOutline"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legendLabelled-130 PrivateNotchedOutline-legendNotched-131"
+                      class="PrivateNotchedOutline-legendLabelled-132 PrivateNotchedOutline-legendNotched-133"
                     >
                       <span>
                         Your Post's URL
@@ -800,7 +800,7 @@ exports[`sections should be browsable by the section buttons 1`] = `
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-123"
+            class="makeStyles-formPartActions-125"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -827,10 +827,10 @@ exports[`sections should be browsable by the section buttons 1`] = `
 exports[`sections should be browsable by the section buttons 2`] = `
 <div>
   <div
-    class="makeStyles-root-119"
+    class="makeStyles-root-121"
   >
     <div
-      class="makeStyles-navigation-120"
+      class="makeStyles-navigation-122"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -1107,17 +1107,17 @@ exports[`sections should be browsable by the section buttons 2`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-121"
+        class="makeStyles-form-123"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-122"
+          class="makeStyles-formPart-124"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-124 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-126 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-132"
+              class="makeStyles-root-134"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1125,7 +1125,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
                 Basic Info
               </h4>
               <div
-                class="makeStyles-row-133"
+                class="makeStyles-row-135"
               >
                 <div
                   class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -1161,10 +1161,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-128 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-130 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-130 PrivateNotchedOutline-legendNotched-131"
+                        class="PrivateNotchedOutline-legendLabelled-132 PrivateNotchedOutline-legendNotched-133"
                       >
                         <span>
                           Experiment name
@@ -1182,7 +1182,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-row-133"
+                class="makeStyles-row-135"
               >
                 <div
                   class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -1217,10 +1217,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-128 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-130 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-130 PrivateNotchedOutline-legendNotched-131"
+                        class="PrivateNotchedOutline-legendLabelled-132 PrivateNotchedOutline-legendNotched-133"
                       >
                         <span>
                           Experiment description
@@ -1238,10 +1238,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-row-133"
+                class="makeStyles-row-135"
               >
                 <div
-                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-135"
+                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-137"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
@@ -1274,10 +1274,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-128 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-130 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-130 PrivateNotchedOutline-legendNotched-131"
+                        class="PrivateNotchedOutline-legendLabelled-132 PrivateNotchedOutline-legendNotched-133"
                       >
                         <span>
                           Start date (UTC)
@@ -1288,12 +1288,12 @@ exports[`sections should be browsable by the section buttons 2`] = `
                   </div>
                 </div>
                 <span
-                  class="makeStyles-through-134"
+                  class="makeStyles-through-136"
                 >
                    through 
                 </span>
                 <div
-                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-135"
+                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-137"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
@@ -1324,10 +1324,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-128 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-130 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-130 PrivateNotchedOutline-legendNotched-131"
+                        class="PrivateNotchedOutline-legendLabelled-132 PrivateNotchedOutline-legendNotched-133"
                       >
                         <span>
                           End date (UTC)
@@ -1367,7 +1367,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-row-133"
+                class="makeStyles-row-135"
               >
                 <div
                   aria-expanded="false"
@@ -1475,10 +1475,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
                       </div>
                       <fieldset
                         aria-hidden="true"
-                        class="PrivateNotchedOutline-root-128 MuiOutlinedInput-notchedOutline"
+                        class="PrivateNotchedOutline-root-130 MuiOutlinedInput-notchedOutline"
                       >
                         <legend
-                          class="PrivateNotchedOutline-legendLabelled-130 PrivateNotchedOutline-legendNotched-131"
+                          class="PrivateNotchedOutline-legendLabelled-132 PrivateNotchedOutline-legendNotched-133"
                         >
                           <span>
                             Owner
@@ -1499,7 +1499,7 @@ exports[`sections should be browsable by the section buttons 2`] = `
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-123"
+            class="makeStyles-formPartActions-125"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -1540,10 +1540,10 @@ exports[`sections should be browsable by the section buttons 2`] = `
 exports[`sections should be browsable by the section buttons 3`] = `
 <div>
   <div
-    class="makeStyles-root-119"
+    class="makeStyles-root-121"
   >
     <div
-      class="makeStyles-navigation-120"
+      class="makeStyles-navigation-122"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -1790,14 +1790,14 @@ exports[`sections should be browsable by the section buttons 3`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-121"
+        class="makeStyles-form-123"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-122"
+          class="makeStyles-formPart-124"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-124 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-126 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <h4
               class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1833,7 +1833,7 @@ exports[`sections should be browsable by the section buttons 3`] = `
             </p>
           </div>
           <div
-            class="makeStyles-formPartActions-123"
+            class="makeStyles-formPartActions-125"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -1850,7 +1850,7 @@ exports[`sections should be browsable by the section buttons 3`] = `
               />
             </button>
             <div
-              class="makeStyles-root-137"
+              class="makeStyles-root-139"
             >
               <button
                 class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary Mui-disabled Mui-disabled"
@@ -1876,10 +1876,10 @@ exports[`sections should be browsable by the section buttons 3`] = `
 exports[`sections should be browsable by the section buttons 4`] = `
 <div>
   <div
-    class="makeStyles-root-119"
+    class="makeStyles-root-121"
   >
     <div
-      class="makeStyles-navigation-120"
+      class="makeStyles-navigation-122"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -2136,17 +2136,17 @@ exports[`sections should be browsable by the section buttons 4`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-121"
+        class="makeStyles-form-123"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-122"
+          class="makeStyles-formPart-124"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-124 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-126 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-139"
+              class="makeStyles-root-141"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -2187,7 +2187,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
                         class="MuiTableCell-root MuiTableCell-head"
                         scope="col"
                       >
-                        Minimum Difference
+                        Minimum Practical Difference
                       </th>
                       <th
                         class="MuiTableCell-root MuiTableCell-head"
@@ -2216,11 +2216,11 @@ exports[`sections should be browsable by the section buttons 4`] = `
                 </table>
               </div>
               <div
-                class="makeStyles-addMetric-152"
+                class="makeStyles-addMetric-155"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-153"
+                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-156"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -2229,7 +2229,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
                   />
                 </svg>
                 <div
-                  class="MuiFormControl-root makeStyles-addMetricSelect-141"
+                  class="MuiFormControl-root makeStyles-addMetricSelect-143"
                 >
                   <div
                     aria-expanded="false"
@@ -2331,7 +2331,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
                 </button>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-148 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-151 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -2385,7 +2385,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
                 </div>
               </div>
               <h4
-                class="MuiTypography-root makeStyles-exposureEventsTitle-149 MuiTypography-h4"
+                class="MuiTypography-root makeStyles-exposureEventsTitle-152 MuiTypography-h4"
               >
                 Exposure Events (Optional)
               </h4>
@@ -2416,11 +2416,11 @@ exports[`sections should be browsable by the section buttons 4`] = `
                 </table>
               </div>
               <div
-                class="makeStyles-addMetric-152"
+                class="makeStyles-addMetric-155"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-153"
+                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-156"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -2445,7 +2445,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
                 </button>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-150 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-153 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -2477,7 +2477,7 @@ exports[`sections should be browsable by the section buttons 4`] = `
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-123"
+            class="makeStyles-formPartActions-125"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -2518,10 +2518,10 @@ exports[`sections should be browsable by the section buttons 4`] = `
 exports[`skipping to submit should check all sections 1`] = `
 <div>
   <div
-    class="makeStyles-root-178"
+    class="makeStyles-root-181"
   >
     <div
-      class="makeStyles-navigation-179"
+      class="makeStyles-navigation-182"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-vertical MuiPaper-elevation0"
@@ -2768,14 +2768,14 @@ exports[`skipping to submit should check all sections 1`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-180"
+        class="makeStyles-form-183"
         novalidate=""
       >
         <div
-          class="makeStyles-formPart-181"
+          class="makeStyles-formPart-184"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-183 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-186 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <h4
               class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -2811,7 +2811,7 @@ exports[`skipping to submit should check all sections 1`] = `
             </p>
           </div>
           <div
-            class="makeStyles-formPartActions-182"
+            class="makeStyles-formPartActions-185"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -2828,7 +2828,7 @@ exports[`skipping to submit should check all sections 1`] = `
               />
             </button>
             <div
-              class="makeStyles-root-192"
+              class="makeStyles-root-195"
             >
               <button
                 class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary Mui-disabled Mui-disabled"

--- a/src/components/experiments/wizard/__snapshots__/Metrics.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/Metrics.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`allows adding, editing and removing a Metric Assignment 1`] = `
 <div>
   <div
-    class="makeStyles-root-16"
+    class="makeStyles-root-17"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -44,7 +44,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
               class="MuiTableCell-root MuiTableCell-head"
               scope="col"
             >
-              Minimum Difference
+              Minimum Practical Difference
             </th>
             <th
               class="MuiTableCell-root MuiTableCell-head"
@@ -73,11 +73,11 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-29"
+      class="makeStyles-addMetric-31"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-32"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -86,7 +86,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-18"
+        class="MuiFormControl-root makeStyles-addMetricSelect-19"
       >
         <div
           aria-expanded="false"
@@ -188,7 +188,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-25 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-27 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -242,7 +242,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-26 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-28 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -273,11 +273,11 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-29"
+      class="makeStyles-addMetric-31"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-32"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -302,7 +302,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-27 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-29 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -338,7 +338,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
 exports[`allows adding, editing and removing a Metric Assignment 2`] = `
 <div>
   <div
-    class="makeStyles-root-16"
+    class="makeStyles-root-17"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -379,7 +379,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
               class="MuiTableCell-root MuiTableCell-head"
               scope="col"
             >
-              Minimum Difference
+              Minimum Practical Difference
             </th>
             <th
               class="MuiTableCell-root MuiTableCell-head"
@@ -408,11 +408,11 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-29"
+      class="makeStyles-addMetric-31"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-32"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -421,7 +421,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-18"
+        class="MuiFormControl-root makeStyles-addMetricSelect-19"
       >
         <div
           aria-expanded="false"
@@ -523,7 +523,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-25 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-27 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -577,7 +577,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-26 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-28 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -608,11 +608,11 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-29"
+      class="makeStyles-addMetric-31"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-32"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -637,7 +637,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-27 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-29 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -673,7 +673,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
 exports[`allows adding, editing and removing a Metric Assignment 3`] = `
 <div>
   <div
-    class="makeStyles-root-16"
+    class="makeStyles-root-17"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -714,7 +714,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               class="MuiTableCell-root MuiTableCell-head"
               scope="col"
             >
-              Minimum Difference
+              Minimum Practical Difference
             </th>
             <th
               class="MuiTableCell-root MuiTableCell-head"
@@ -729,17 +729,17 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
             class="MuiTableRow-root"
           >
             <td
-              class="MuiTableCell-root MuiTableCell-body"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-22"
             >
               <span
-                class="makeStyles-metricName-21 makeStyles-tooltipped-22"
+                class="makeStyles-metricName-23 makeStyles-tooltipped-24"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-root-31 makeStyles-monospaced-20"
+                class="makeStyles-root-33 makeStyles-monospaced-21"
               >
                 primary
               </span>
@@ -748,7 +748,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-19"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-20"
               >
                 <div
                   aria-haspopup="listbox"
@@ -780,11 +780,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-32 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-34 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-33"
+                    class="PrivateNotchedOutline-legend-35"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -795,7 +795,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-24"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-26"
             >
               <span
                 class="MuiSwitch-root"
@@ -803,18 +803,19 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-36 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-38 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-39 Mui-checked"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-39 MuiSwitch-input"
+                      checked=""
+                      class="PrivateSwitchBase-input-41 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
-                      value="false"
+                      value="true"
                     />
                     <span
                       class="MuiSwitch-thumb"
@@ -833,24 +834,15 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-root-40 makeStyles-minDifferenceField-23"
+                class="MuiFormControl-root MuiTextField-root makeStyles-root-42 makeStyles-minDifferenceField-25"
               >
                 <div
-                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
                 >
-                  <div
-                    class="MuiInputAdornment-root MuiInputAdornment-positionStart"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
-                    >
-                      USD
-                    </p>
-                  </div>
                   <input
                     aria-invalid="false"
                     aria-label="Minimum Difference"
-                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
+                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
                     id="experiment.metricAssignments[0].minDifference"
                     min="0"
                     name="experiment.metricAssignments[0].minDifference"
@@ -858,13 +850,22 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                     type="number"
                     value=""
                   />
+                  <div
+                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
+                    >
+                      USD
+                    </p>
+                  </div>
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-32 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-34 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-33"
+                      class="PrivateNotchedOutline-legend-35"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -912,11 +913,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-29"
+      class="makeStyles-addMetric-31"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-32"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -925,7 +926,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-18"
+        class="MuiFormControl-root makeStyles-addMetricSelect-19"
       >
         <div
           aria-expanded="false"
@@ -1027,7 +1028,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-25 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-27 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1081,7 +1082,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-26 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-28 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -1112,11 +1113,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-29"
+      class="makeStyles-addMetric-31"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-32"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1141,7 +1142,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-27 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-29 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1179,7 +1180,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
   aria-hidden="true"
 >
   <div
-    class="makeStyles-root-16"
+    class="makeStyles-root-17"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1220,7 +1221,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               class="MuiTableCell-root MuiTableCell-head"
               scope="col"
             >
-              Minimum Difference
+              Minimum Practical Difference
             </th>
             <th
               class="MuiTableCell-root MuiTableCell-head"
@@ -1235,17 +1236,17 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
             class="MuiTableRow-root"
           >
             <td
-              class="MuiTableCell-root MuiTableCell-body"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-22"
             >
               <span
-                class="makeStyles-metricName-21 makeStyles-tooltipped-22"
+                class="makeStyles-metricName-23 makeStyles-tooltipped-24"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-root-31 makeStyles-monospaced-20"
+                class="makeStyles-root-33 makeStyles-monospaced-21"
               >
                 primary
               </span>
@@ -1254,7 +1255,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-19"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-20"
               >
                 <div
                   aria-haspopup="listbox"
@@ -1286,11 +1287,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-32 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-34 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-33"
+                    class="PrivateNotchedOutline-legend-35"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -1301,7 +1302,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-24"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-26"
             >
               <span
                 class="MuiSwitch-root"
@@ -1309,18 +1310,19 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-36 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-38 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-39 Mui-checked"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-39 MuiSwitch-input"
+                      checked=""
+                      class="PrivateSwitchBase-input-41 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
-                      value="false"
+                      value="true"
                     />
                     <span
                       class="MuiSwitch-thumb"
@@ -1339,24 +1341,15 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-root-40 makeStyles-minDifferenceField-23"
+                class="MuiFormControl-root MuiTextField-root makeStyles-root-42 makeStyles-minDifferenceField-25"
               >
                 <div
-                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
                 >
-                  <div
-                    class="MuiInputAdornment-root MuiInputAdornment-positionStart"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
-                    >
-                      USD
-                    </p>
-                  </div>
                   <input
                     aria-invalid="false"
                     aria-label="Minimum Difference"
-                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
+                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
                     id="experiment.metricAssignments[0].minDifference"
                     min="0"
                     name="experiment.metricAssignments[0].minDifference"
@@ -1364,13 +1357,22 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                     type="number"
                     value="0.01"
                   />
+                  <div
+                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
+                    >
+                      USD
+                    </p>
+                  </div>
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-32 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-34 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-33"
+                      class="PrivateNotchedOutline-legend-35"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -1418,11 +1420,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-29"
+      class="makeStyles-addMetric-31"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-32"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1431,7 +1433,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-18"
+        class="MuiFormControl-root makeStyles-addMetricSelect-19"
       >
         <div
           aria-expanded="false"
@@ -1533,7 +1535,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-25 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-27 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1587,7 +1589,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-26 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-28 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -1618,11 +1620,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-29"
+      class="makeStyles-addMetric-31"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-32"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1647,7 +1649,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-27 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-29 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1683,7 +1685,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
 exports[`allows adding, editing and removing a Metric Assignment 5`] = `
 <div>
   <div
-    class="makeStyles-root-16"
+    class="makeStyles-root-17"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1724,7 +1726,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               class="MuiTableCell-root MuiTableCell-head"
               scope="col"
             >
-              Minimum Difference
+              Minimum Practical Difference
             </th>
             <th
               class="MuiTableCell-root MuiTableCell-head"
@@ -1739,17 +1741,17 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
             class="MuiTableRow-root"
           >
             <td
-              class="MuiTableCell-root MuiTableCell-body"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-22"
             >
               <span
-                class="makeStyles-metricName-21 makeStyles-tooltipped-22"
+                class="makeStyles-metricName-23 makeStyles-tooltipped-24"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-root-31 makeStyles-monospaced-20"
+                class="makeStyles-root-33 makeStyles-monospaced-21"
               >
                 primary
               </span>
@@ -1758,7 +1760,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-19"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-20"
               >
                 <div
                   aria-haspopup="listbox"
@@ -1790,11 +1792,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-32 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-34 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-33"
+                    class="PrivateNotchedOutline-legend-35"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -1805,7 +1807,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-24"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-26"
             >
               <span
                 class="MuiSwitch-root"
@@ -1813,18 +1815,19 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-36 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-38 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-39 Mui-checked"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-39 MuiSwitch-input"
+                      checked=""
+                      class="PrivateSwitchBase-input-41 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
-                      value="false"
+                      value="true"
                     />
                     <span
                       class="MuiSwitch-thumb"
@@ -1843,24 +1846,15 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-root-40 makeStyles-minDifferenceField-23"
+                class="MuiFormControl-root MuiTextField-root makeStyles-root-42 makeStyles-minDifferenceField-25"
               >
                 <div
-                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
                 >
-                  <div
-                    class="MuiInputAdornment-root MuiInputAdornment-positionStart"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
-                    >
-                      USD
-                    </p>
-                  </div>
                   <input
                     aria-invalid="false"
                     aria-label="Minimum Difference"
-                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
+                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
                     id="experiment.metricAssignments[0].minDifference"
                     min="0"
                     name="experiment.metricAssignments[0].minDifference"
@@ -1868,13 +1862,22 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                     type="number"
                     value="0.01"
                   />
+                  <div
+                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
+                    >
+                      USD
+                    </p>
+                  </div>
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-32 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-34 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-33"
+                      class="PrivateNotchedOutline-legend-35"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -1922,11 +1925,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-29"
+      class="makeStyles-addMetric-31"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-32"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1935,7 +1938,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-18"
+        class="MuiFormControl-root makeStyles-addMetricSelect-19"
       >
         <div
           aria-expanded="false"
@@ -2037,7 +2040,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-25 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-27 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -2091,7 +2094,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-26 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-28 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -2122,11 +2125,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-29"
+      class="makeStyles-addMetric-31"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-32"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -2151,7 +2154,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-27 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-29 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -2187,7 +2190,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
 exports[`allows adding, editing and removing a Metric Assignment 6`] = `
 <div>
   <div
-    class="makeStyles-root-16"
+    class="makeStyles-root-17"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -2228,7 +2231,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
               class="MuiTableCell-root MuiTableCell-head"
               scope="col"
             >
-              Minimum Difference
+              Minimum Practical Difference
             </th>
             <th
               class="MuiTableCell-root MuiTableCell-head"
@@ -2257,11 +2260,11 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-29"
+      class="makeStyles-addMetric-31"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-32"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -2270,7 +2273,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-18"
+        class="MuiFormControl-root makeStyles-addMetricSelect-19"
       >
         <div
           aria-expanded="false"
@@ -2372,7 +2375,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-25 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-27 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -2426,7 +2429,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-26 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-28 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -2457,11 +2460,11 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-29"
+      class="makeStyles-addMetric-31"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-32"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -2486,7 +2489,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-27 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-29 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -2522,7 +2525,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
 exports[`allows adding, editing and removing a Metric Assignment 7`] = `
 <div>
   <div
-    class="makeStyles-root-16"
+    class="makeStyles-root-17"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -2563,7 +2566,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               class="MuiTableCell-root MuiTableCell-head"
               scope="col"
             >
-              Minimum Difference
+              Minimum Practical Difference
             </th>
             <th
               class="MuiTableCell-root MuiTableCell-head"
@@ -2578,17 +2581,17 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
             class="MuiTableRow-root"
           >
             <td
-              class="MuiTableCell-root MuiTableCell-body"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-22"
             >
               <span
-                class="makeStyles-metricName-21 makeStyles-tooltipped-22"
+                class="makeStyles-metricName-23 makeStyles-tooltipped-24"
                 title="string"
               >
                 registration_start
               </span>
               <br />
               <span
-                class="makeStyles-root-43 makeStyles-monospaced-20"
+                class="makeStyles-root-44 makeStyles-monospaced-21"
               >
                 primary
               </span>
@@ -2597,7 +2600,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-19"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-20"
               >
                 <div
                   aria-haspopup="listbox"
@@ -2629,11 +2632,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-44 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-45 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-45"
+                    class="PrivateNotchedOutline-legend-46"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -2644,7 +2647,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-24"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-26"
             >
               <span
                 class="MuiSwitch-root"
@@ -2652,18 +2655,19 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-48 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-49 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-50 Mui-checked"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-51 MuiSwitch-input"
+                      checked=""
+                      class="PrivateSwitchBase-input-52 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
-                      value="false"
+                      value="true"
                     />
                     <span
                       class="MuiSwitch-thumb"
@@ -2682,7 +2686,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-root-52 makeStyles-minDifferenceField-23"
+                class="MuiFormControl-root MuiTextField-root makeStyles-root-53 makeStyles-minDifferenceField-25"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
@@ -2703,7 +2707,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                     class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
                   >
                     <p
-                      class="MuiTypography-root makeStyles-tooltipped-53 MuiTypography-body1 MuiTypography-colorTextSecondary"
+                      class="MuiTypography-root makeStyles-tooltipped-54 MuiTypography-body1 MuiTypography-colorTextSecondary"
                       title="Percentage Points"
                     >
                       pp
@@ -2711,11 +2715,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                   </div>
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-44 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-45 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-45"
+                      class="PrivateNotchedOutline-legend-46"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -2763,11 +2767,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-29"
+      class="makeStyles-addMetric-31"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-32"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -2776,7 +2780,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
         />
       </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-18"
+        class="MuiFormControl-root makeStyles-addMetricSelect-19"
       >
         <div
           aria-expanded="false"
@@ -2878,7 +2882,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-25 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-27 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -2932,7 +2936,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-26 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-28 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -2963,11 +2967,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-29"
+      class="makeStyles-addMetric-31"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-30"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-32"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -2992,7 +2996,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-27 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-29 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -3069,7 +3073,7 @@ exports[`renders as expected 1`] = `
               class="MuiTableCell-root MuiTableCell-head"
               scope="col"
             >
-              Minimum Difference
+              Minimum Practical Difference
             </th>
             <th
               class="MuiTableCell-root MuiTableCell-head"
@@ -3098,11 +3102,11 @@ exports[`renders as expected 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-14"
+      class="makeStyles-addMetric-15"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-15"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-16"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -3213,7 +3217,7 @@ exports[`renders as expected 1`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-10 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-11 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -3267,7 +3271,7 @@ exports[`renders as expected 1`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-11 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-12 MuiTypography-h4"
     >
       Exposure Events (Optional)
     </h4>
@@ -3298,11 +3302,11 @@ exports[`renders as expected 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-14"
+      class="makeStyles-addMetric-15"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-15"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-16"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -3327,7 +3331,7 @@ exports[`renders as expected 1`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-12 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-13 MuiPaper-elevation0"
       role="alert"
     >
       <div

--- a/src/components/experiments/wizard/__snapshots__/Metrics.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/Metrics.test.tsx.snap
@@ -833,7 +833,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-23"
+                class="MuiFormControl-root MuiTextField-root makeStyles-root-40 makeStyles-minDifferenceField-23"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
@@ -1339,7 +1339,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-23"
+                class="MuiFormControl-root MuiTextField-root makeStyles-root-40 makeStyles-minDifferenceField-23"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
@@ -1843,7 +1843,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-23"
+                class="MuiFormControl-root MuiTextField-root makeStyles-root-40 makeStyles-minDifferenceField-23"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
@@ -2588,7 +2588,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               </span>
               <br />
               <span
-                class="makeStyles-root-41 makeStyles-monospaced-20"
+                class="makeStyles-root-43 makeStyles-monospaced-20"
               >
                 primary
               </span>
@@ -2629,11 +2629,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-42 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-44 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-43"
+                    class="PrivateNotchedOutline-legend-45"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -2652,14 +2652,14 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-46 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-48 MuiSwitch-switchBase MuiSwitch-colorSecondary"
                   variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <input
-                      class="PrivateSwitchBase-input-49 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-51 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -2682,7 +2682,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-minDifferenceField-23"
+                class="MuiFormControl-root MuiTextField-root makeStyles-root-52 makeStyles-minDifferenceField-23"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
@@ -2703,7 +2703,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                     class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
                   >
                     <p
-                      class="MuiTypography-root makeStyles-tooltipped-50 MuiTypography-body1 MuiTypography-colorTextSecondary"
+                      class="MuiTypography-root makeStyles-tooltipped-53 MuiTypography-body1 MuiTypography-colorTextSecondary"
                       title="Percentage Points"
                     >
                       pp
@@ -2711,11 +2711,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                   </div>
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-42 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-44 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-43"
+                      class="PrivateNotchedOutline-legend-45"
                       style="width: 0.01px;"
                     >
                       <span>

--- a/src/components/general/MetricDifferenceField.tsx
+++ b/src/components/general/MetricDifferenceField.tsx
@@ -1,4 +1,5 @@
 import { createStyles, InputAdornment, makeStyles, Theme, Tooltip, Typography } from '@material-ui/core'
+import clsx from 'clsx'
 import { Field } from 'formik'
 import { TextField } from 'formik-material-ui'
 import React from 'react'
@@ -14,10 +15,17 @@ const ConversionMetricTextField = formikFieldTransformer(
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
+    root: {
+      minWidth: '8rem',
+    },
     tooltipped: {
       borderBottomWidth: 1,
       borderBottomStyle: 'dashed',
       borderBottomColor: theme.palette.grey[500],
+    },
+    // We hide the helper text shown in errors as the error is obvious and there is limited space as is.
+    helperText: {
+      display: 'none',
     },
   }),
 )
@@ -34,7 +42,7 @@ export default function MetricDifferenceField(props: {
   if (props.metricParameterType === MetricParameterType.Conversion) {
     return (
       <Field
-        className={props.className}
+        className={clsx(classes.root, props.className)}
         component={ConversionMetricTextField}
         name={props.name}
         id={props.id}
@@ -57,12 +65,13 @@ export default function MetricDifferenceField(props: {
             </InputAdornment>
           ),
         }}
+        FormHelperTextProps={{ className: classes.helperText }}
       />
     )
   } else if (props.metricParameterType === MetricParameterType.Revenue) {
     return (
       <Field
-        className={props.className}
+        className={clsx(classes.root, props.className)}
         component={TextField}
         name={props.name}
         id={props.id}
@@ -76,6 +85,7 @@ export default function MetricDifferenceField(props: {
         InputProps={{
           startAdornment: <InputAdornment position='start'>USD</InputAdornment>,
         }}
+        FormHelperTextProps={{ className: classes.helperText }}
       />
     )
   } else {

--- a/src/components/general/MetricDifferenceField.tsx
+++ b/src/components/general/MetricDifferenceField.tsx
@@ -16,16 +16,12 @@ const ConversionMetricTextField = formikFieldTransformer(
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
-      minWidth: '8rem',
+      minWidth: '7rem',
     },
     tooltipped: {
       borderBottomWidth: 1,
       borderBottomStyle: 'dashed',
       borderBottomColor: theme.palette.grey[500],
-    },
-    // We hide the helper text shown in errors as the error is obvious and there is limited space as is.
-    helperText: {
-      display: 'none',
     },
   }),
 )
@@ -65,7 +61,6 @@ export default function MetricDifferenceField(props: {
             </InputAdornment>
           ),
         }}
-        FormHelperTextProps={{ className: classes.helperText }}
       />
     )
   } else if (props.metricParameterType === MetricParameterType.Revenue) {
@@ -83,9 +78,8 @@ export default function MetricDifferenceField(props: {
           min: '0',
         }}
         InputProps={{
-          startAdornment: <InputAdornment position='start'>USD</InputAdornment>,
+          endAdornment: <InputAdornment position='end'>USD</InputAdornment>,
         }}
-        FormHelperTextProps={{ className: classes.helperText }}
       />
     )
   } else {

--- a/src/lib/schemas.test.ts
+++ b/src/lib/schemas.test.ts
@@ -67,10 +67,10 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.errors).toMatchInlineSnapshot(`
           Array [
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
+            "This field is required",
+            "This field is required",
+            "This field is required",
+            "This field is required",
             "Event Params is required and must be valid JSON.",
             "Exactly one of eventParams or revenueParams must be defined.",
           ]
@@ -89,10 +89,10 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.errors).toMatchInlineSnapshot(`
           Array [
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
+            "This field is required",
+            "This field is required",
+            "This field is required",
+            "This field is required",
             "Revenue Params is required and must be valid JSON.",
             "Exactly one of eventParams or revenueParams must be defined.",
           ]
@@ -111,10 +111,10 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.errors).toMatchInlineSnapshot(`
           Array [
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
+            "This field is required",
+            "This field is required",
+            "This field is required",
+            "This field is required",
           ]
         `)
       }
@@ -131,10 +131,10 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.errors).toMatchInlineSnapshot(`
           Array [
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
+            "This field is required",
+            "This field is required",
+            "This field is required",
+            "This field is required",
             "This field must be one of the following values: ",
             "Revenue Params is required and must be valid JSON.",
           ]
@@ -153,10 +153,10 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.errors).toMatchInlineSnapshot(`
           Array [
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
+            "This field is required",
+            "This field is required",
+            "This field is required",
+            "This field is required",
             "This field must be one of the following values: ",
             "Event Params is required and must be valid JSON.",
           ]
@@ -175,13 +175,13 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.errors).toMatchInlineSnapshot(`
           Array [
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
+            "This field is required",
+            "This field is required",
+            "This field is required",
+            "This field is required",
+            "This field is required",
+            "This field is required",
+            "This field is required",
           ]
         `)
       }
@@ -201,11 +201,11 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.errors).toMatchInlineSnapshot(`
           Array [
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
+            "This field is required",
+            "This field is required",
+            "This field is required",
+            "This field is required",
+            "This field is required",
             "This field must be one of the following values: ",
             "This field must be one of the following values: ",
             "Exactly one of eventParams or revenueParams must be defined.",
@@ -224,11 +224,11 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.errors).toMatchInlineSnapshot(`
           Array [
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
+            "This field is required",
+            "This field is required",
+            "This field is required",
+            "This field is required",
+            "This field is required",
             "Exactly one of eventParams or revenueParams must be defined.",
           ]
         `)
@@ -246,10 +246,10 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.errors).toMatchInlineSnapshot(`
           Array [
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
+            "This field is required",
+            "This field is required",
+            "This field is required",
+            "This field is required",
           ]
         `)
       }
@@ -266,13 +266,13 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.errors).toMatchInlineSnapshot(`
           Array [
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
-            "This field must be defined",
+            "This field is required",
+            "This field is required",
+            "This field is required",
+            "This field is required",
+            "This field is required",
+            "This field is required",
+            "This field is required",
           ]
         `)
       }
@@ -293,17 +293,17 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.inner).toMatchInlineSnapshot(`
           Array [
-            [ValidationError: This field must be defined],
+            [ValidationError: This field is required],
             [ValidationError: Start date (UTC) must be in the future.],
             [ValidationError: End date must be after start date.],
-            [ValidationError: This field must be defined],
-            [ValidationError: This field must be defined],
-            [ValidationError: This field must be defined],
-            [ValidationError: This field must be defined],
-            [ValidationError: This field must be defined],
-            [ValidationError: This field must be defined],
-            [ValidationError: This field must be defined],
-            [ValidationError: This field must be defined],
+            [ValidationError: This field is required],
+            [ValidationError: This field is required],
+            [ValidationError: This field is required],
+            [ValidationError: This field is required],
+            [ValidationError: This field is required],
+            [ValidationError: This field is required],
+            [ValidationError: This field is required],
+            [ValidationError: This field is required],
           ]
         `)
       }
@@ -322,17 +322,17 @@ describe('lib/schemas.ts module', () => {
       } catch (e) {
         expect(e.inner).toMatchInlineSnapshot(`
           Array [
-            [ValidationError: This field must be defined],
+            [ValidationError: This field is required],
             [ValidationError: Start date (UTC) must be in the future.],
             [ValidationError: End date must be within 12 months of start date.],
-            [ValidationError: This field must be defined],
-            [ValidationError: This field must be defined],
-            [ValidationError: This field must be defined],
-            [ValidationError: This field must be defined],
-            [ValidationError: This field must be defined],
-            [ValidationError: This field must be defined],
-            [ValidationError: This field must be defined],
-            [ValidationError: This field must be defined],
+            [ValidationError: This field is required],
+            [ValidationError: This field is required],
+            [ValidationError: This field is required],
+            [ValidationError: This field is required],
+            [ValidationError: This field is required],
+            [ValidationError: This field is required],
+            [ValidationError: This field is required],
+            [ValidationError: This field is required],
           ]
         `)
       }
@@ -379,7 +379,7 @@ describe('lib/schemas.ts module', () => {
     it('should respect undefined', () => {
       expect(Schemas.extendedNumberSchema.validateSync(undefined)).toBe(undefined)
       expect(() => Schemas.extendedNumberSchema.defined().validateSync(undefined)).toThrowErrorMatchingInlineSnapshot(
-        `"This field must be defined"`,
+        `"This field is required"`,
       )
     })
   })

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -28,7 +28,7 @@ const yupLocale = {
     required: 'This field is a required field',
     oneOf: 'This field must be one of the following values: ${values}',
     notOneOf: 'This field must not be one of the following values: ${values}',
-    defined: 'This field must be defined',
+    defined: 'This field is required',
   },
   string: {
     length: 'This field must be exactly ${length} characters',
@@ -428,7 +428,10 @@ export const experimentFullNewSchema = experimentFullSchema.shape({
       (date) => dateFns.isBefore(date, dateFns.addMonths(now, MAX_DISTANCE_BETWEEN_NOW_AND_START_DATE_IN_MONTHS)),
     ),
   exposureEvents: yup.array(eventNewSchema).notRequired(),
-  metricAssignments: yup.array(metricAssignmentNewSchema).defined().min(1),
+  metricAssignments: yup
+    .array(metricAssignmentNewSchema)
+    .defined()
+    .min(1, 'At least one metric assignment is required'),
   segmentAssignments: yup.array(segmentAssignmentNewSchema).defined(),
   variations: yup.array<VariationNew>(variationNewSchema).defined().min(2),
 })

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -39,6 +39,16 @@ const theme = createMuiTheme({
     MuiInputBase: {
       root: {
         fontFamily: monospaceFontStack,
+
+        // Removes spinners from number inputs
+        // From: https://stackoverflow.com/a/4298216
+        '& input::-webkit-outer-spin-button, input::-webkit-inner-spin-button': {
+          '-webkit-appearance': 'none',
+          margin: 0,
+        },
+        '& input[type=number]': {
+          '-moz-appearance': 'textfield',
+        },
       },
     },
     MuiCssBaseline: {


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR makes misc life improvements for metric assignment:**
- Makes `changeExpected` true by default.
- Removes helper text from `minDifference` errors that were throwing the design out.

   <img width="971" alt="Screen Shot 2021-07-05 at 10 21 51 pm" src="https://user-images.githubusercontent.com/971886/124485684-695bc700-dddf-11eb-88ca-de06f2ad096a.png">
- Makes minDiff wide enough to see plenty decimal places.

   <img width="968" alt="Screen Shot 2021-07-05 at 10 23 17 pm" src="https://user-images.githubusercontent.com/971886/124485927-a45dfa80-dddf-11eb-8fe9-dfe88f5c91e9.png">
- Also improves general error messages

<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
