### PR TITLE
Implement metric autocomplete for metricAssignment panel

### DIFF
--- a/src/components/experiments/single-view/overview/MetricAssignmentsPanel.test.tsx
+++ b/src/components/experiments/single-view/overview/MetricAssignmentsPanel.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/require-await, no-irregular-whitespace */
-import { act, fireEvent, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react'
+import { act, fireEvent, getByRole, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react'
 import { noop } from 'lodash'
 import React from 'react'
 
@@ -311,17 +311,10 @@ test('opens, submits and cancels assign metric dialog', async () => {
   // We click it now to test the validation state
   fireEvent.click(assignButton)
 
-  const metricSearchField = screen.getByRole('button', { name: /Select a Metric/ })
-  await act(async () => {
-    fireEvent.focus(metricSearchField)
-  })
-  await act(async () => {
-    fireEvent.keyDown(metricSearchField, { key: 'Enter' })
-  })
-  const metricOption = await screen.findByRole('option', { name: /metric_3/ })
-  await act(async () => {
-    fireEvent.click(metricOption)
-  })
+  const metricSearchField = screen.getByRole('combobox', { name: /Select a metric/ })
+  const metricSearchFieldMoreButton = getByRole(metricSearchField, 'button', { name: 'Open' })
+  fireEvent.click(metricSearchFieldMoreButton)
+  fireEvent.click(await screen.findByRole('option', { name: /metric_3/ }))
 
   const attributionWindowField = await screen.findByLabelText(/Attribution Window/)
   await act(async () => {

--- a/src/components/experiments/wizard/Metrics.tsx
+++ b/src/components/experiments/wizard/Metrics.tsx
@@ -17,7 +17,7 @@ import {
 } from '@material-ui/core'
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import { Add, Clear } from '@material-ui/icons'
-import { Alert, Autocomplete, AutocompleteRenderInputParams } from '@material-ui/lab'
+import { Alert, AutocompleteRenderInputParams } from '@material-ui/lab'
 import clsx from 'clsx'
 import { Field, FieldArray, FormikProps, useField } from 'formik'
 import { Select, Switch, TextField } from 'formik-material-ui'
@@ -27,6 +27,7 @@ import React, { useState } from 'react'
 import { getPropNameCompletions } from 'src/api/AutocompleteApi'
 import Attribute from 'src/components/general/Attribute'
 import AbacusAutocomplete, { autocompleteInputProps } from 'src/components/general/Autocomplete'
+import MetricAutocomplete from 'src/components/general/MetricAutocomplete'
 import MetricDifferenceField from 'src/components/general/MetricDifferenceField'
 import MoreMenu from 'src/components/general/MoreMenu'
 import { ExperimentFormData } from 'src/lib/form-data'
@@ -458,40 +459,13 @@ const Metrics = ({
               <div className={metricEditorClasses.addMetric}>
                 <Add className={metricEditorClasses.addMetricAddSymbol} />
                 <FormControl className={classes.addMetricSelect}>
-                  <Autocomplete
+                  <MetricAutocomplete
                     id='add-metric-select'
-                    aria-label='Select a metric'
                     value={selectedMetric}
                     onChange={onChangeSelectedMetricOption}
-                    fullWidth
                     options={Object.values(indexedMetrics)}
-                    noOptionsText='No metrics found'
-                    getOptionLabel={(metric: Metric) => metric.name}
-                    renderOption={(option) => (
-                      <div>
-                        <Typography variant='body1'>
-                          <strong>{option.name}</strong>
-                        </Typography>
-                        <Typography variant='body1'>
-                          <small>{option.description}</small>
-                        </Typography>
-                      </div>
-                    )}
-                    renderInput={(params: AutocompleteRenderInputParams) => (
-                      <MuiTextField
-                        {...params}
-                        placeholder='Select a metric'
-                        error={!!metricAssignmentsError}
-                        helperText={_.isString(metricAssignmentsError) ? metricAssignmentsError : undefined}
-                        required
-                        InputProps={{
-                          ...autocompleteInputProps(params, false),
-                        }}
-                        InputLabelProps={{
-                          shrink: true,
-                        }}
-                      />
-                    )}
+                    error={metricAssignmentsError}
+                    fullWidth
                   />
                 </FormControl>
                 <Button variant='contained' disableElevation size='small' onClick={onAddMetric} aria-label='Add metric'>

--- a/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
@@ -1522,6 +1522,7 @@ exports[`sections should be browsable by the section buttons and show validation
                     aria-expanded="false"
                     aria-label="Select a metric"
                     class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+                    error="At least one metric assignment is required"
                     role="combobox"
                   >
                     <div

--- a/src/components/general/MetricAutocomplete.tsx
+++ b/src/components/general/MetricAutocomplete.tsx
@@ -16,13 +16,16 @@ export default function MetricAutocomplete<
 >(
   props: Omit<AutocompleteProps<Metric, Multiple, DisableClearable, FreeSolo>, 'renderInput'> & {
     error?: string | false
-    options: Metric[]
   },
 ): ReturnType<typeof Autocomplete> {
+  const processedOptions = props.options
+    .filter((a) => !a.name.startsWith('archived_'))
+    .sort((a, b) => a.name.localeCompare(b.name, 'en'))
   return (
     <Autocomplete<Metric, Multiple, DisableClearable, FreeSolo>
       aria-label='Select a metric'
       fullWidth
+      options={processedOptions}
       noOptionsText='No metrics found'
       getOptionLabel={(metric: Metric) => metric.name}
       getOptionSelected={(metricA: Metric, metricB: Metric) => metricA.metricId === metricB.metricId}
@@ -51,7 +54,7 @@ export default function MetricAutocomplete<
           }}
         />
       )}
-      {...props}
+      {..._.omit(props, 'options')}
     />
   )
 }

--- a/src/components/general/MetricAutocomplete.tsx
+++ b/src/components/general/MetricAutocomplete.tsx
@@ -1,0 +1,57 @@
+import { TextField, Typography } from '@material-ui/core'
+import { Autocomplete, AutocompleteProps, AutocompleteRenderInputParams } from '@material-ui/lab'
+import _ from 'lodash'
+import React from 'react'
+
+import { autocompleteInputProps } from 'src/components/general/Autocomplete'
+import { Metric } from 'src/lib/schemas'
+
+/**
+ * An Autocomplete just for Metrics
+ */
+export default function MetricAutocomplete<
+  Multiple extends boolean | undefined = undefined,
+  DisableClearable extends boolean | undefined = undefined,
+  FreeSolo extends boolean | undefined = undefined
+>(
+  props: Omit<AutocompleteProps<Metric, Multiple, DisableClearable, FreeSolo>, 'renderInput'> & {
+    error?: string | false
+    options: Metric[]
+  },
+): ReturnType<typeof Autocomplete> {
+  return (
+    <Autocomplete<Metric, Multiple, DisableClearable, FreeSolo>
+      aria-label='Select a metric'
+      fullWidth
+      noOptionsText='No metrics found'
+      getOptionLabel={(metric: Metric) => metric.name}
+      getOptionSelected={(metricA: Metric, metricB: Metric) => metricA.metricId === metricB.metricId}
+      renderOption={(option: Metric) => (
+        <div>
+          <Typography variant='body1'>
+            <strong>{option.name}</strong>
+          </Typography>
+          <Typography variant='body1'>
+            <small>{option.description}</small>
+          </Typography>
+        </div>
+      )}
+      renderInput={(params: AutocompleteRenderInputParams) => (
+        <TextField
+          {...params}
+          placeholder='Select a metric'
+          error={!!props.error}
+          helperText={_.isString(props.error) ? props.error : undefined}
+          required
+          InputProps={{
+            ...autocompleteInputProps(params, false),
+          }}
+          InputLabelProps={{
+            shrink: true,
+          }}
+        />
+      )}
+      {...props}
+    />
+  )
+}


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR implements refactors metric autocomplete and adds it into the metric assignments panel.**
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

I originally tried refactoring `AbacusAutocomplete` but ended up deciding against it.

Resolves https://github.com/Automattic/abacus/issues/381

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)

