### PR TITLE
Improve CircleCI build times

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       name: node/default
       tag: '12.18.4'
     steps:
-      - checkout
+      - run: git clone --depth 1 "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
       - node/install-packages
       - run:
           name: Format Checking
@@ -23,7 +23,7 @@ jobs:
       name: node/default
       tag: '12.18.4'
     steps:
-      - checkout
+      - run: git clone --depth 1 "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
       - node/install-packages
       - run:
           name: Unit Testing
@@ -34,7 +34,7 @@ jobs:
       name: node/default
       tag: '12.18.4'
     steps:
-      - checkout
+      - run: git clone --depth 1 "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
       - node/install-packages
       # Adapted from https://circleci.com/orbs/registry/orb/threetreeslight/puppeteer. Not using this Orb directly to
       # prevent re-downloading Chromium which was already done in the build step.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,7 @@ version: 2.1
 
 orbs:
   node: circleci/node@4.0.1
-  
-  
+
 references:
   custom_checkout: &custom_checkout
     name: Custom checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,16 @@ version: 2.1
 
 orbs:
   node: circleci/node@4.0.1
+  
+  
+references:
+  custom_checkout: &custom_checkout
+    name: Custom checkout
+    command: |
+      # Add GitHub to known hosts.
+      mkdir -p ~/.ssh
+      echo 'github.com,13.250.177.223 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' >> ~/.ssh/known_hosts
+      git clone --depth 1 "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH" .
 
 jobs:
   static-checks:
@@ -9,7 +19,7 @@ jobs:
       name: node/default
       tag: '12.18.4'
     steps:
-      - run: git clone --depth 1 "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
+      - run: *custom_checkout
       - node/install-packages
       - run:
           name: Format Checking
@@ -23,7 +33,7 @@ jobs:
       name: node/default
       tag: '12.18.4'
     steps:
-      - run: git clone --depth 1 "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
+      - run: *custom_checkout
       - node/install-packages
       - run:
           name: Unit Testing
@@ -34,7 +44,7 @@ jobs:
       name: node/default
       tag: '12.18.4'
     steps:
-      - run: git clone --depth 1 "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
+      - run: *custom_checkout
       - node/install-packages
       # Adapted from https://circleci.com/orbs/registry/orb/threetreeslight/puppeteer. Not using this Orb directly to
       # prevent re-downloading Chromium which was already done in the build step.


### PR DESCRIPTION
See 15-gh-Automattic/a8cds

By shallow cloning we can improve build performance.

<!-- Describe your changes in detail. -->
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
- Manual testing with mock data (locally or on Vercel)
- Additional manual testing instructions (please specify):
