### PR TITLE
Re-enable and fix integration & e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,5 +101,4 @@ workflows:
     jobs:
       - static-checks
       - unit-tests
-      # Disabled until the SwaggerHub issue is fixed. See https://github.com/Automattic/abacus/issues/506.
-      # - integration-e2e
+      - integration-e2e

--- a/e2e/navigation.test.tsx
+++ b/e2e/navigation.test.tsx
@@ -28,12 +28,12 @@ describe('Experiments', () => {
     it('should navigate to experiment details page on row click', async () => {
       // Rendering of the table is dynamic. That is, it is not rendered until the
       // experiment data loads, hence the reason for the wait.
-      await page.waitForSelector('.MuiTableHead-root')
+      await page.waitForSelector('.ag-root-wrapper')
 
       // Click an experiment row.
-      const $tableRows = await page.$$('.MuiTableBody-root .MuiTableRow-root')
-      expect($tableRows.length).toBeGreaterThan(0)
-      await Promise.all([page.waitForNavigation(), $tableRows[0].click()])
+      const $tableRowLinks = await page.$$('.ag-root-wrapper .ag-row a')
+      expect($tableRowLinks.length).toBeGreaterThan(0)
+      await Promise.all([page.waitForNavigation(), $tableRowLinks[0].click()])
 
       // Assert clicking a row navigated to the details page of that experiment.
       expect(page.url()).toMatch(/^http:\/\/a8c-abacus-local:3001\/experiments\/\d+/)


### PR DESCRIPTION
Resolve #506 (!!) by re-enabling the `integration-e2e` checks on CircleCI and fixing a failing navigation test.

Also depends on the metric example fixes in 655-gh-Automattic/experimentation-platform, which I already deployed to Swagger.

## How has this been tested?

- Automated tests that cover added/changed functionality
- Manual testing with mock data (locally or on Vercel)