### PR TITLE
Change font styles for metric assignment results based on significance.

### DIFF
--- a/src/components/experiments/single-view/results/RecommendationDisplay.test.tsx
+++ b/src/components/experiments/single-view/results/RecommendationDisplay.test.tsx
@@ -19,7 +19,9 @@ test('renders MissingAnalysis correctly', () => {
   )
   expect(container).toMatchInlineSnapshot(`
     <div>
-      Not analyzed yet
+      <span>
+        Not analyzed yet
+      </span>
     </div>
   `)
 })
@@ -58,7 +60,9 @@ test('renders Inconclusive correctly', () => {
   )
   expect(container).toMatchInlineSnapshot(`
     <div>
-      Inconclusive
+      <span>
+        Inconclusive
+      </span>
     </div>
   `)
 })
@@ -75,7 +79,9 @@ test('renders DeployAnyVariation correctly', () => {
   )
   expect(container).toMatchInlineSnapshot(`
     <div>
-      Deploy either variation
+      <span>
+        Deploy either variation
+      </span>
     </div>
   `)
 })
@@ -102,8 +108,10 @@ test('renders DeployChosenVariation correctly', () => {
   )
   expect(container).toMatchInlineSnapshot(`
     <div>
-      Deploy 
-      variation_name_123
+      <span>
+        Deploy 
+        variation_name_123
+      </span>
     </div>
   `)
 })

--- a/src/components/experiments/single-view/results/RecommendationDisplay.tsx
+++ b/src/components/experiments/single-view/results/RecommendationDisplay.tsx
@@ -1,4 +1,5 @@
 import { createStyles, makeStyles, Theme, Tooltip } from '@material-ui/core'
+import clsx from 'clsx'
 import React from 'react'
 
 import { Decision, Recommendation } from 'src/lib/recommendations'
@@ -18,9 +19,11 @@ const useStyles = makeStyles((theme: Theme) =>
  * Displays a Recommendation.
  */
 export default function RecommendationDisplay({
+  className,
   recommendation,
   experiment,
 }: {
+  className?: string
   recommendation: Recommendation
   experiment: ExperimentFull
 }): JSX.Element {
@@ -29,15 +32,15 @@ export default function RecommendationDisplay({
     case Decision.ManualAnalysisRequired:
       return (
         <Tooltip title='Contact @experimentation-review on #a8c-experiments'>
-          <span className={classes.tooltipped}>Manual analysis required</span>
+          <span className={clsx(className, classes.tooltipped)}>Manual analysis required</span>
         </Tooltip>
       )
     case Decision.MissingAnalysis:
-      return <>Not analyzed yet</>
+      return <span className={className}>Not analyzed yet</span>
     case Decision.Inconclusive:
-      return <>Inconclusive</>
+      return <span className={className}>Inconclusive</span>
     case Decision.DeployAnyVariation:
-      return <>Deploy either variation</>
+      return <span className={className}>Deploy either variation</span>
     case Decision.DeployChosenVariation: {
       const chosenVariation = experiment.variations.find(
         (variation) => variation.variationId === recommendation.chosenVariationId,
@@ -46,7 +49,7 @@ export default function RecommendationDisplay({
         throw new Error('No match for chosenVariationId among variations in experiment.')
       }
 
-      return <>Deploy {chosenVariation.name}</>
+      return <span className={className}>Deploy {chosenVariation.name}</span>
     }
     default:
       throw new Error('Missing Decision.')

--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentDebug.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentDebug.test.tsx.snap
@@ -459,7 +459,9 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy either variation
+                      <span>
+                        Deploy either variation
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -502,7 +504,9 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy either variation
+                      <span>
+                        Deploy either variation
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -538,7 +542,9 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy either variation
+                      <span>
+                        Deploy either variation
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -574,7 +580,9 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy either variation
+                      <span>
+                        Deploy either variation
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -617,7 +625,9 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy either variation
+                      <span>
+                        Deploy either variation
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -843,7 +853,9 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Not analyzed yet
+                      <span>
+                        Not analyzed yet
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -975,7 +987,9 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy either variation
+                      <span>
+                        Deploy either variation
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -1018,7 +1032,9 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy either variation
+                      <span>
+                        Deploy either variation
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -1061,7 +1077,9 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy either variation
+                      <span>
+                        Deploy either variation
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -1104,7 +1122,9 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy either variation
+                      <span>
+                        Deploy either variation
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
@@ -1147,7 +1167,9 @@ exports[`renders the full tables with some analyses in debug mode 2`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box;"
                     >
-                      Deploy either variation
+                      <span>
+                        Deploy either variation
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"

--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`allows you to change analysis strategy 1`] = `
     class="analysis-latest-results"
   >
     <div
-      class="makeStyles-root-380"
+      class="makeStyles-root-373"
     >
       <div
-        class="makeStyles-summary-381"
+        class="makeStyles-summary-374"
       >
         <div
-          class="MuiPaper-root makeStyles-participantsPlotPaper-392 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-participantsPlotPaper-385 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <h3
             class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -21,16 +21,16 @@ exports[`allows you to change analysis strategy 1`] = `
           </h3>
         </div>
         <div
-          class="makeStyles-summaryColumn-383"
+          class="makeStyles-summaryColumn-376"
         >
           <div
-            class="MuiPaper-root makeStyles-summaryStatsPaper-384 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-summaryStatsPaper-377 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-summaryStatsPart-385"
+              class="makeStyles-summaryStatsPart-378"
             >
               <h3
-                class="MuiTypography-root makeStyles-summaryStatsStat-387 MuiTypography-h3 MuiTypography-colorPrimary"
+                class="MuiTypography-root makeStyles-summaryStatsStat-380 MuiTypography-h3 MuiTypography-colorPrimary"
               >
                 1,000
               </h3>
@@ -46,12 +46,14 @@ exports[`allows you to change analysis strategy 1`] = `
               </h6>
             </div>
             <div
-              class="makeStyles-summaryStatsPart-385"
+              class="makeStyles-summaryStatsPart-378"
             >
               <h3
-                class="MuiTypography-root makeStyles-summaryStatsStat-387 MuiTypography-h3 MuiTypography-colorPrimary"
+                class="MuiTypography-root makeStyles-summaryStatsStat-380 MuiTypography-h3 MuiTypography-colorPrimary"
               >
-                Deploy either variation
+                <span>
+                  Deploy either variation
+                </span>
               </h3>
               <h6
                 class="MuiTypography-root MuiTypography-subtitle1"
@@ -64,12 +66,12 @@ exports[`allows you to change analysis strategy 1`] = `
             </div>
           </div>
           <a
-            class="MuiPaper-root makeStyles-summaryHealthPaper-388 makeStyles-indicationSeverityWarning-390 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-summaryHealthPaper-381 makeStyles-indicationSeverityWarning-383 MuiPaper-elevation1 MuiPaper-rounded"
             href="#health-report"
           >
             <div>
               <h3
-                class="MuiTypography-root makeStyles-summaryStatsStat-387 MuiTypography-h3 MuiTypography-colorPrimary"
+                class="MuiTypography-root makeStyles-summaryStatsStat-380 MuiTypography-h3 MuiTypography-colorPrimary"
               >
                 Potential issues
               </h3>
@@ -86,30 +88,16 @@ exports[`allows you to change analysis strategy 1`] = `
         </div>
       </div>
       <h3
-        class="MuiTypography-root makeStyles-tableTitle-394 MuiTypography-h3"
+        class="MuiTypography-root makeStyles-tableTitle-387 MuiTypography-h3"
       >
-        <span>
-          Metric Assignment Results
-        </span>
-         
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root makeStyles-infoIcon-403"
-          focusable="false"
-          title="Results that are both practically and statistically significant are indicated in bold.  Insignificant results are indicated by a lighter grey."
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
-          />
-        </svg>
+        Metric Assignment Results
       </h3>
       <div
         class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
         style="position: relative;"
       >
         <div
-          class="Component-horizontalScrollContainer-409"
+          class="Component-horizontalScrollContainer-401"
           style="overflow-x: auto; position: relative;"
         >
           <div>
@@ -128,33 +116,33 @@ exports[`allows you to change analysis strategy 1`] = `
                       class="MuiTableRow-root MuiTableRow-head"
                     >
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-410 MuiTableCell-paddingNone"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-402 MuiTableCell-paddingNone"
                         scope="col"
                         style="font-weight: 700;"
                       />
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-410 MuiTableCell-alignLeft"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-402 MuiTableCell-alignLeft"
                         scope="col"
                         style="font-weight: 700; box-sizing: border-box;"
                       >
                         Metric (attribution window)
                       </th>
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-410 MuiTableCell-alignLeft"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-402 MuiTableCell-alignLeft"
                         scope="col"
                         style="font-weight: 700; box-sizing: border-box;"
                       >
                         Absolute change
                       </th>
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-410 MuiTableCell-alignLeft"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-402 MuiTableCell-alignLeft"
                         scope="col"
                         style="font-weight: 700; box-sizing: border-box;"
                       >
                         Relative change (lift)
                       </th>
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-410 MuiTableCell-alignLeft"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-402 MuiTableCell-alignLeft"
                         scope="col"
                         style="font-weight: 700; box-sizing: border-box;"
                       >
@@ -205,7 +193,7 @@ exports[`allows you to change analysis strategy 1`] = `
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                       >
                         <span
-                          class="makeStyles-metricAssignmentNameLine-400"
+                          class="makeStyles-metricAssignmentNameLine-393"
                         >
                           <span
                             class=""
@@ -219,7 +207,7 @@ exports[`allows you to change analysis strategy 1`] = `
                         </span>
                         <br />
                         <span
-                          class="makeStyles-root-411"
+                          class="makeStyles-root-403"
                         >
                           primary
                         </span>
@@ -228,49 +216,41 @@ exports[`allows you to change analysis strategy 1`] = `
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                       >
-                        <div
-                          class="makeStyles-significanceStatusNo-402"
+                        <span
+                          class=""
                         >
-                          <span
-                            class=""
-                          >
-                            -1
-                             to 
-                            +
-                            1
-                             
-                            pp
-                          </span>
-                        </div>
+                          -1
+                           to 
+                          +
+                          1
+                           
+                          pp
+                        </span>
                       </td>
                       <td
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                       >
-                        <div
-                          class="makeStyles-significanceStatusNo-402"
+                        <span
+                          class=""
                         >
-                          <span
-                            class=""
-                          >
-                            -50
-                             to 
-                            +
-                            50
-                             
-                            %
-                          </span>
-                        </div>
+                          -50
+                           to 
+                          +
+                          50
+                           
+                          %
+                        </span>
                       </td>
                       <td
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                       >
-                        <div
-                          class="makeStyles-significanceStatusNo-402"
+                        <span
+                          class=""
                         >
                           Deploy either variation
-                        </div>
+                        </span>
                       </td>
                     </tr>
                     <tr
@@ -313,7 +293,7 @@ exports[`allows you to change analysis strategy 1`] = `
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                       >
                         <span
-                          class="makeStyles-metricAssignmentNameLine-400"
+                          class="makeStyles-metricAssignmentNameLine-393"
                         >
                           <span
                             class=""
@@ -338,11 +318,11 @@ exports[`allows you to change analysis strategy 1`] = `
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                       >
-                        <div
-                          class="makeStyles-significanceStatusNo-402"
+                        <span
+                          class=""
                         >
                           Not analyzed yet
-                        </div>
+                        </span>
                       </td>
                     </tr>
                     <tr
@@ -385,7 +365,7 @@ exports[`allows you to change analysis strategy 1`] = `
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                       >
                         <span
-                          class="makeStyles-metricAssignmentNameLine-400"
+                          class="makeStyles-metricAssignmentNameLine-393"
                         >
                           <span
                             class=""
@@ -410,11 +390,11 @@ exports[`allows you to change analysis strategy 1`] = `
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                       >
-                        <div
-                          class="makeStyles-significanceStatusNo-402"
+                        <span
+                          class=""
                         >
                           Not analyzed yet
-                        </div>
+                        </span>
                       </td>
                     </tr>
                     <tr
@@ -457,7 +437,7 @@ exports[`allows you to change analysis strategy 1`] = `
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                       >
                         <span
-                          class="makeStyles-metricAssignmentNameLine-400"
+                          class="makeStyles-metricAssignmentNameLine-393"
                         >
                           <span
                             class=""
@@ -482,11 +462,11 @@ exports[`allows you to change analysis strategy 1`] = `
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                       >
-                        <div
-                          class="makeStyles-significanceStatusNo-402"
+                        <span
+                          class=""
                         >
                           Not analyzed yet
-                        </div>
+                        </span>
                       </td>
                     </tr>
                   </tbody>
@@ -497,7 +477,7 @@ exports[`allows you to change analysis strategy 1`] = `
         </div>
       </div>
       <h3
-        class="MuiTypography-root makeStyles-tableTitle-394 MuiTypography-h3"
+        class="MuiTypography-root makeStyles-tableTitle-387 MuiTypography-h3"
       >
         Health Report
       </h3>
@@ -579,18 +559,18 @@ exports[`allows you to change analysis strategy 1`] = `
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-407 makeStyles-deemphasized-408 makeStyles-nowrap-409"
                   scope="row"
                 >
                   <span
-                    class="makeStyles-tooltip-422"
+                    class="makeStyles-tooltip-414"
                     title="The smaller the p-value the more likely there is an issue."
                   >
                     p-value
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-407 makeStyles-deemphasized-408 makeStyles-nowrap-409"
                   scope="row"
                 >
                   1.0000
@@ -602,7 +582,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   <span />
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-418 makeStyles-indicationSeverityOk-419 makeStyles-monospace-415 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-410 makeStyles-indicationSeverityOk-411 makeStyles-monospace-407 makeStyles-nowrap-409"
                   scope="row"
                 >
                   <span>
@@ -610,13 +590,13 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-407 makeStyles-deemphasized-408 makeStyles-nowrap-409"
                   scope="row"
                 >
                   0.05 &lt; x ≤ 1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-416"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-408"
                   scope="row"
                 >
                   <p
@@ -640,18 +620,18 @@ exports[`allows you to change analysis strategy 1`] = `
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-407 makeStyles-deemphasized-408 makeStyles-nowrap-409"
                   scope="row"
                 >
                   <span
-                    class="makeStyles-tooltip-422"
+                    class="makeStyles-tooltip-414"
                     title="The smaller the p-value the more likely there is an issue."
                   >
                     p-value
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-407 makeStyles-deemphasized-408 makeStyles-nowrap-409"
                   scope="row"
                 >
                   1.0000
@@ -663,7 +643,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   <span />
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-418 makeStyles-indicationSeverityOk-419 makeStyles-monospace-415 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-410 makeStyles-indicationSeverityOk-411 makeStyles-monospace-407 makeStyles-nowrap-409"
                   scope="row"
                 >
                   <span>
@@ -671,13 +651,13 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-407 makeStyles-deemphasized-408 makeStyles-nowrap-409"
                   scope="row"
                 >
                   0.05 &lt; x ≤ 1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-416"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-408"
                   scope="row"
                 >
                   <p
@@ -701,7 +681,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-407 makeStyles-deemphasized-408 makeStyles-nowrap-409"
                   scope="row"
                 >
                   <span>
@@ -709,7 +689,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-407 makeStyles-deemphasized-408 makeStyles-nowrap-409"
                   scope="row"
                 >
                   0.0000
@@ -721,7 +701,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   <span />
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-418 makeStyles-indicationSeverityOk-419 makeStyles-monospace-415 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-410 makeStyles-indicationSeverityOk-411 makeStyles-monospace-407 makeStyles-nowrap-409"
                   scope="row"
                 >
                   <span>
@@ -729,13 +709,13 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-407 makeStyles-deemphasized-408 makeStyles-nowrap-409"
                   scope="row"
                 >
                   −∞ &lt; x ≤ 0.01
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-416"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-408"
                   scope="row"
                 >
                   <p
@@ -759,7 +739,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-407 makeStyles-deemphasized-408 makeStyles-nowrap-409"
                   scope="row"
                 >
                   <span>
@@ -767,7 +747,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-407 makeStyles-deemphasized-408 makeStyles-nowrap-409"
                   scope="row"
                 >
                   0.0000
@@ -779,7 +759,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   <span />
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-418 makeStyles-indicationSeverityOk-419 makeStyles-monospace-415 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-410 makeStyles-indicationSeverityOk-411 makeStyles-monospace-407 makeStyles-nowrap-409"
                   scope="row"
                 >
                   <span>
@@ -787,13 +767,13 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-407 makeStyles-deemphasized-408 makeStyles-nowrap-409"
                   scope="row"
                 >
                   −∞ &lt; x ≤ 0.1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-416"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-408"
                   scope="row"
                 >
                   <p
@@ -817,7 +797,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-407 makeStyles-deemphasized-408 makeStyles-nowrap-409"
                   scope="row"
                 >
                   <span>
@@ -825,7 +805,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-407 makeStyles-deemphasized-408 makeStyles-nowrap-409"
                   scope="row"
                 >
                   0.1000
@@ -837,7 +817,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   <span />
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-418 makeStyles-indicationSeverityOk-419 makeStyles-monospace-415 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-410 makeStyles-indicationSeverityOk-411 makeStyles-monospace-407 makeStyles-nowrap-409"
                   scope="row"
                 >
                   <span>
@@ -845,13 +825,13 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-407 makeStyles-deemphasized-408 makeStyles-nowrap-409"
                   scope="row"
                 >
                   −∞ &lt; x ≤ 0.8
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-416"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-408"
                   scope="row"
                 >
                   <p
@@ -875,7 +855,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-407 makeStyles-deemphasized-408 makeStyles-nowrap-409"
                   scope="row"
                 >
                   <span>
@@ -883,7 +863,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-407 makeStyles-deemphasized-408 makeStyles-nowrap-409"
                   scope="row"
                 >
                   0.0000
@@ -897,7 +877,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-418 makeStyles-indicationSeverityWarning-420 makeStyles-monospace-415 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-410 makeStyles-indicationSeverityWarning-412 makeStyles-monospace-407 makeStyles-nowrap-409"
                   scope="row"
                 >
                   <span>
@@ -905,13 +885,13 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-407 makeStyles-deemphasized-408 makeStyles-nowrap-409"
                   scope="row"
                 >
                   −∞ &lt; x ≤ 3
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-416"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-408"
                   scope="row"
                 >
                   <p
@@ -926,7 +906,7 @@ exports[`allows you to change analysis strategy 1`] = `
         </div>
       </div>
       <div
-        class="makeStyles-accordions-395"
+        class="makeStyles-accordions-388"
       >
         <div
           class="MuiPaper-root MuiAccordion-root Mui-expanded MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -985,7 +965,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   role="region"
                 >
                   <div
-                    class="MuiAccordionDetails-root makeStyles-accordionDetails-396"
+                    class="MuiAccordionDetails-root makeStyles-accordionDetails-389"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -1144,7 +1124,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   role="region"
                 >
                   <div
-                    class="MuiAccordionDetails-root makeStyles-accordionDetails-396"
+                    class="MuiAccordionDetails-root makeStyles-accordionDetails-389"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -1157,7 +1137,7 @@ exports[`allows you to change analysis strategy 1`] = `
                       This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                     </p>
                     <pre
-                      class="makeStyles-pre-398"
+                      class="makeStyles-pre-391"
                     >
                       <code>
                         with tracks_counts as (
@@ -1196,13 +1176,13 @@ exports[`renders an appropriate message for analyses missing analysis data due t
     class="analysis-latest-results"
   >
     <div
-      class="makeStyles-root-25"
+      class="makeStyles-root-24"
     >
       <div
-        class="makeStyles-summary-26"
+        class="makeStyles-summary-25"
       >
         <div
-          class="MuiPaper-root makeStyles-participantsPlotPaper-37 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-participantsPlotPaper-36 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <h3
             class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -1211,16 +1191,16 @@ exports[`renders an appropriate message for analyses missing analysis data due t
           </h3>
         </div>
         <div
-          class="makeStyles-summaryColumn-28"
+          class="makeStyles-summaryColumn-27"
         >
           <div
-            class="MuiPaper-root makeStyles-summaryStatsPaper-29 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-summaryStatsPaper-28 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-summaryStatsPart-30"
+              class="makeStyles-summaryStatsPart-29"
             >
               <h3
-                class="MuiTypography-root makeStyles-summaryStatsStat-32 MuiTypography-h3 MuiTypography-colorPrimary"
+                class="MuiTypography-root makeStyles-summaryStatsStat-31 MuiTypography-h3 MuiTypography-colorPrimary"
               >
                 1,000
               </h3>
@@ -1236,12 +1216,14 @@ exports[`renders an appropriate message for analyses missing analysis data due t
               </h6>
             </div>
             <div
-              class="makeStyles-summaryStatsPart-30"
+              class="makeStyles-summaryStatsPart-29"
             >
               <h3
-                class="MuiTypography-root makeStyles-summaryStatsStat-32 MuiTypography-h3 MuiTypography-colorPrimary"
+                class="MuiTypography-root makeStyles-summaryStatsStat-31 MuiTypography-h3 MuiTypography-colorPrimary"
               >
-                Not analyzed yet
+                <span>
+                  Not analyzed yet
+                </span>
               </h3>
               <h6
                 class="MuiTypography-root MuiTypography-subtitle1"
@@ -1254,12 +1236,12 @@ exports[`renders an appropriate message for analyses missing analysis data due t
             </div>
           </div>
           <a
-            class="MuiPaper-root makeStyles-summaryHealthPaper-33 makeStyles-indicationSeverityError-36 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-summaryHealthPaper-32 makeStyles-indicationSeverityError-35 MuiPaper-elevation1 MuiPaper-rounded"
             href="#health-report"
           >
             <div>
               <h3
-                class="MuiTypography-root makeStyles-summaryStatsStat-32 MuiTypography-h3 MuiTypography-colorPrimary"
+                class="MuiTypography-root makeStyles-summaryStatsStat-31 MuiTypography-h3 MuiTypography-colorPrimary"
               >
                 Serious issues
               </h3>
@@ -1276,30 +1258,16 @@ exports[`renders an appropriate message for analyses missing analysis data due t
         </div>
       </div>
       <h3
-        class="MuiTypography-root makeStyles-tableTitle-39 MuiTypography-h3"
+        class="MuiTypography-root makeStyles-tableTitle-38 MuiTypography-h3"
       >
-        <span>
-          Metric Assignment Results
-        </span>
-         
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root makeStyles-infoIcon-48"
-          focusable="false"
-          title="Results that are both practically and statistically significant are indicated in bold.  Insignificant results are indicated by a lighter grey."
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
-          />
-        </svg>
+        Metric Assignment Results
       </h3>
       <div
         class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
         style="position: relative;"
       >
         <div
-          class="Component-horizontalScrollContainer-54"
+          class="Component-horizontalScrollContainer-52"
           style="overflow-x: auto; position: relative;"
         >
           <div>
@@ -1318,33 +1286,33 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                       class="MuiTableRow-root MuiTableRow-head"
                     >
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-55 MuiTableCell-paddingNone"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-53 MuiTableCell-paddingNone"
                         scope="col"
                         style="font-weight: 700;"
                       />
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-55 MuiTableCell-alignLeft"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-53 MuiTableCell-alignLeft"
                         scope="col"
                         style="font-weight: 700; box-sizing: border-box;"
                       >
                         Metric (attribution window)
                       </th>
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-55 MuiTableCell-alignLeft"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-53 MuiTableCell-alignLeft"
                         scope="col"
                         style="font-weight: 700; box-sizing: border-box;"
                       >
                         Absolute change
                       </th>
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-55 MuiTableCell-alignLeft"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-53 MuiTableCell-alignLeft"
                         scope="col"
                         style="font-weight: 700; box-sizing: border-box;"
                       >
                         Relative change (lift)
                       </th>
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-55 MuiTableCell-alignLeft"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-53 MuiTableCell-alignLeft"
                         scope="col"
                         style="font-weight: 700; box-sizing: border-box;"
                       >
@@ -1395,7 +1363,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                       >
                         <span
-                          class="makeStyles-metricAssignmentNameLine-45"
+                          class="makeStyles-metricAssignmentNameLine-44"
                         >
                           <span
                             class=""
@@ -1409,7 +1377,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                         </span>
                         <br />
                         <span
-                          class="makeStyles-root-56"
+                          class="makeStyles-root-54"
                         >
                           primary
                         </span>
@@ -1426,11 +1394,11 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                       >
-                        <div
-                          class="makeStyles-significanceStatusNo-47"
+                        <span
+                          class=""
                         >
                           Not analyzed yet
-                        </div>
+                        </span>
                       </td>
                     </tr>
                     <tr
@@ -1473,7 +1441,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                       >
                         <span
-                          class="makeStyles-metricAssignmentNameLine-45"
+                          class="makeStyles-metricAssignmentNameLine-44"
                         >
                           <span
                             class=""
@@ -1498,11 +1466,11 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                       >
-                        <div
-                          class="makeStyles-significanceStatusNo-47"
+                        <span
+                          class=""
                         >
                           Not analyzed yet
-                        </div>
+                        </span>
                       </td>
                     </tr>
                     <tr
@@ -1545,7 +1513,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                       >
                         <span
-                          class="makeStyles-metricAssignmentNameLine-45"
+                          class="makeStyles-metricAssignmentNameLine-44"
                         >
                           <span
                             class=""
@@ -1570,11 +1538,11 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                       >
-                        <div
-                          class="makeStyles-significanceStatusNo-47"
+                        <span
+                          class=""
                         >
                           Not analyzed yet
-                        </div>
+                        </span>
                       </td>
                     </tr>
                     <tr
@@ -1617,7 +1585,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                       >
                         <span
-                          class="makeStyles-metricAssignmentNameLine-45"
+                          class="makeStyles-metricAssignmentNameLine-44"
                         >
                           <span
                             class=""
@@ -1642,11 +1610,11 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                       >
-                        <div
-                          class="makeStyles-significanceStatusNo-47"
+                        <span
+                          class=""
                         >
                           Not analyzed yet
-                        </div>
+                        </span>
                       </td>
                     </tr>
                   </tbody>
@@ -1657,7 +1625,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
         </div>
       </div>
       <h3
-        class="MuiTypography-root makeStyles-tableTitle-39 MuiTypography-h3"
+        class="MuiTypography-root makeStyles-tableTitle-38 MuiTypography-h3"
       >
         Health Report
       </h3>
@@ -1739,18 +1707,18 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56 makeStyles-deemphasized-57 makeStyles-nowrap-58"
                   scope="row"
                 >
                   <span
-                    class="makeStyles-tooltip-65"
+                    class="makeStyles-tooltip-63"
                     title="The smaller the p-value the more likely there is an issue."
                   >
                     p-value
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56 makeStyles-deemphasized-57 makeStyles-nowrap-58"
                   scope="row"
                 >
                   1.0000
@@ -1762,7 +1730,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   <span />
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-61 makeStyles-indicationSeverityOk-62 makeStyles-monospace-58 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-59 makeStyles-indicationSeverityOk-60 makeStyles-monospace-56 makeStyles-nowrap-58"
                   scope="row"
                 >
                   <span>
@@ -1770,13 +1738,13 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56 makeStyles-deemphasized-57 makeStyles-nowrap-58"
                   scope="row"
                 >
                   0.05 &lt; x ≤ 1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-59"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-57"
                   scope="row"
                 >
                   <p
@@ -1800,18 +1768,18 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56 makeStyles-deemphasized-57 makeStyles-nowrap-58"
                   scope="row"
                 >
                   <span
-                    class="makeStyles-tooltip-65"
+                    class="makeStyles-tooltip-63"
                     title="The smaller the p-value the more likely there is an issue."
                   >
                     p-value
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56 makeStyles-deemphasized-57 makeStyles-nowrap-58"
                   scope="row"
                 >
                   1.0000
@@ -1823,7 +1791,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   <span />
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-61 makeStyles-indicationSeverityOk-62 makeStyles-monospace-58 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-59 makeStyles-indicationSeverityOk-60 makeStyles-monospace-56 makeStyles-nowrap-58"
                   scope="row"
                 >
                   <span>
@@ -1831,13 +1799,13 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56 makeStyles-deemphasized-57 makeStyles-nowrap-58"
                   scope="row"
                 >
                   0.05 &lt; x ≤ 1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-59"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-57"
                   scope="row"
                 >
                   <p
@@ -1861,18 +1829,18 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56 makeStyles-deemphasized-57 makeStyles-nowrap-58"
                   scope="row"
                 >
                   <span
-                    class="makeStyles-tooltip-65"
+                    class="makeStyles-tooltip-63"
                     title="The smaller the p-value the more likely there is an issue."
                   >
                     p-value
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56 makeStyles-deemphasized-57 makeStyles-nowrap-58"
                   scope="row"
                 >
                   1.0000
@@ -1884,7 +1852,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   <span />
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-61 makeStyles-indicationSeverityOk-62 makeStyles-monospace-58 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-59 makeStyles-indicationSeverityOk-60 makeStyles-monospace-56 makeStyles-nowrap-58"
                   scope="row"
                 >
                   <span>
@@ -1892,13 +1860,13 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56 makeStyles-deemphasized-57 makeStyles-nowrap-58"
                   scope="row"
                 >
                   0.05 &lt; x ≤ 1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-59"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-57"
                   scope="row"
                 >
                   <p
@@ -1922,7 +1890,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56 makeStyles-deemphasized-57 makeStyles-nowrap-58"
                   scope="row"
                 >
                   <span>
@@ -1930,7 +1898,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56 makeStyles-deemphasized-57 makeStyles-nowrap-58"
                   scope="row"
                 >
                   NaN
@@ -1944,7 +1912,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-61 makeStyles-indicationSeverityError-64 makeStyles-monospace-58 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-59 makeStyles-indicationSeverityError-62 makeStyles-monospace-56 makeStyles-nowrap-58"
                   scope="row"
                 >
                   <span>
@@ -1952,13 +1920,13 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56 makeStyles-deemphasized-57 makeStyles-nowrap-58"
                   scope="row"
                 >
                   Unexpected value
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-59"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-57"
                   scope="row"
                 >
                   <p
@@ -1984,7 +1952,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56 makeStyles-deemphasized-57 makeStyles-nowrap-58"
                   scope="row"
                 >
                   <span>
@@ -1992,7 +1960,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56 makeStyles-deemphasized-57 makeStyles-nowrap-58"
                   scope="row"
                 >
                   NaN
@@ -2006,7 +1974,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-61 makeStyles-indicationSeverityError-64 makeStyles-monospace-58 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-59 makeStyles-indicationSeverityError-62 makeStyles-monospace-56 makeStyles-nowrap-58"
                   scope="row"
                 >
                   <span>
@@ -2014,13 +1982,13 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56 makeStyles-deemphasized-57 makeStyles-nowrap-58"
                   scope="row"
                 >
                   Unexpected value
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-59"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-57"
                   scope="row"
                 >
                   <p
@@ -2046,7 +2014,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56 makeStyles-deemphasized-57 makeStyles-nowrap-58"
                   scope="row"
                 >
                   <span>
@@ -2054,7 +2022,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56 makeStyles-deemphasized-57 makeStyles-nowrap-58"
                   scope="row"
                 >
                   0.0000
@@ -2068,7 +2036,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-61 makeStyles-indicationSeverityWarning-63 makeStyles-monospace-58 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-59 makeStyles-indicationSeverityWarning-61 makeStyles-monospace-56 makeStyles-nowrap-58"
                   scope="row"
                 >
                   <span>
@@ -2076,13 +2044,13 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-56 makeStyles-deemphasized-57 makeStyles-nowrap-58"
                   scope="row"
                 >
                   −∞ &lt; x ≤ 3
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-59"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-57"
                   scope="row"
                 >
                   <p
@@ -2097,7 +2065,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
         </div>
       </div>
       <div
-        class="makeStyles-accordions-40"
+        class="makeStyles-accordions-39"
       >
         <div
           class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -2156,7 +2124,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   role="region"
                 >
                   <div
-                    class="MuiAccordionDetails-root makeStyles-accordionDetails-41"
+                    class="MuiAccordionDetails-root makeStyles-accordionDetails-40"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -2316,7 +2284,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   role="region"
                 >
                   <div
-                    class="MuiAccordionDetails-root makeStyles-accordionDetails-41"
+                    class="MuiAccordionDetails-root makeStyles-accordionDetails-40"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -2329,7 +2297,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                       This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                     </p>
                     <pre
-                      class="makeStyles-pre-43"
+                      class="makeStyles-pre-42"
                     >
                       <code>
                         with tracks_counts as (
@@ -2515,13 +2483,13 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-66"
+    class="makeStyles-root-64"
   >
     <div
-      class="makeStyles-summary-67"
+      class="makeStyles-summary-65"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-78 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-76 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -2530,16 +2498,16 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-69"
+        class="makeStyles-summaryColumn-67"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-70 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-68 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-71"
+            class="makeStyles-summaryStatsPart-69"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-73 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-71 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               1,000
             </h3>
@@ -2555,12 +2523,14 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-71"
+            class="makeStyles-summaryStatsPart-69"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-73 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-71 MuiTypography-h3 MuiTypography-colorPrimary"
             >
-              Inconclusive
+              <span>
+                Inconclusive
+              </span>
             </h3>
             <h6
               class="MuiTypography-root MuiTypography-subtitle1"
@@ -2573,12 +2543,12 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-74 makeStyles-indicationSeverityWarning-76 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-72 makeStyles-indicationSeverityWarning-74 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-73 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-71 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Potential issues
             </h3>
@@ -2595,30 +2565,16 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-80 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-78 MuiTypography-h3"
     >
-      <span>
-        Metric Assignment Results
-      </span>
-       
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-infoIcon-89"
-        focusable="false"
-        title="Results that are both practically and statistically significant are indicated in bold.  Insignificant results are indicated by a lighter grey."
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
-        />
-      </svg>
+      Metric Assignment Results
     </h3>
     <div
       class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-95"
+        class="Component-horizontalScrollContainer-92"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -2637,33 +2593,33 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-96 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-93 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-96 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-93 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric (attribution window)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-96 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-93 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Absolute change
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-96 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-93 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Relative change (lift)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-96 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-93 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -2714,7 +2670,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-86"
+                        class="makeStyles-metricAssignmentNameLine-84"
                       >
                         <span
                           class=""
@@ -2728,7 +2684,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                       </span>
                       <br />
                       <span
-                        class="makeStyles-root-97"
+                        class="makeStyles-root-94"
                       >
                         primary
                       </span>
@@ -2737,49 +2693,41 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-88"
+                      <span
+                        class=""
                       >
-                        <span
-                          class=""
-                        >
-                          -100
-                           to 
-                          +
-                          100
-                           
-                          pp
-                        </span>
-                      </div>
+                        -100
+                         to 
+                        +
+                        100
+                         
+                        pp
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-88"
+                      <span
+                        class=""
                       >
-                        <span
-                          class=""
-                        >
-                          -50
-                           to 
-                          +
-                          0
-                           
-                          %
-                        </span>
-                      </div>
+                        -50
+                         to 
+                        +
+                        0
+                         
+                        %
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-88"
+                      <span
+                        class=""
                       >
                         Inconclusive
-                      </div>
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -2822,7 +2770,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-86"
+                        class="makeStyles-metricAssignmentNameLine-84"
                       >
                         <span
                           class=""
@@ -2847,11 +2795,11 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-88"
+                      <span
+                        class=""
                       >
                         Not analyzed yet
-                      </div>
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -2894,7 +2842,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-86"
+                        class="makeStyles-metricAssignmentNameLine-84"
                       >
                         <span
                           class=""
@@ -2919,11 +2867,11 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-88"
+                      <span
+                        class=""
                       >
                         Not analyzed yet
-                      </div>
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -2966,7 +2914,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-86"
+                        class="makeStyles-metricAssignmentNameLine-84"
                       >
                         <span
                           class=""
@@ -2991,11 +2939,11 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-88"
+                      <span
+                        class=""
                       >
                         Not analyzed yet
-                      </div>
+                      </span>
                     </td>
                   </tr>
                 </tbody>
@@ -3006,7 +2954,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-80 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-78 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -3088,18 +3036,18 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98 makeStyles-deemphasized-99 makeStyles-nowrap-100"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-108"
+                  class="makeStyles-tooltip-105"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98 makeStyles-deemphasized-99 makeStyles-nowrap-100"
                 scope="row"
               >
                 1.0000
@@ -3111,7 +3059,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-104 makeStyles-indicationSeverityOk-105 makeStyles-monospace-101 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-101 makeStyles-indicationSeverityOk-102 makeStyles-monospace-98 makeStyles-nowrap-100"
                 scope="row"
               >
                 <span>
@@ -3119,13 +3067,13 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98 makeStyles-deemphasized-99 makeStyles-nowrap-100"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-102"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-99"
                 scope="row"
               >
                 <p
@@ -3149,18 +3097,18 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98 makeStyles-deemphasized-99 makeStyles-nowrap-100"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-108"
+                  class="makeStyles-tooltip-105"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98 makeStyles-deemphasized-99 makeStyles-nowrap-100"
                 scope="row"
               >
                 1.0000
@@ -3172,7 +3120,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-104 makeStyles-indicationSeverityOk-105 makeStyles-monospace-101 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-101 makeStyles-indicationSeverityOk-102 makeStyles-monospace-98 makeStyles-nowrap-100"
                 scope="row"
               >
                 <span>
@@ -3180,13 +3128,13 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98 makeStyles-deemphasized-99 makeStyles-nowrap-100"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-102"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-99"
                 scope="row"
               >
                 <p
@@ -3210,18 +3158,18 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98 makeStyles-deemphasized-99 makeStyles-nowrap-100"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-108"
+                  class="makeStyles-tooltip-105"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98 makeStyles-deemphasized-99 makeStyles-nowrap-100"
                 scope="row"
               >
                 1.0000
@@ -3233,7 +3181,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-104 makeStyles-indicationSeverityOk-105 makeStyles-monospace-101 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-101 makeStyles-indicationSeverityOk-102 makeStyles-monospace-98 makeStyles-nowrap-100"
                 scope="row"
               >
                 <span>
@@ -3241,13 +3189,13 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98 makeStyles-deemphasized-99 makeStyles-nowrap-100"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-102"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-99"
                 scope="row"
               >
                 <p
@@ -3271,7 +3219,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98 makeStyles-deemphasized-99 makeStyles-nowrap-100"
                 scope="row"
               >
                 <span>
@@ -3279,7 +3227,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98 makeStyles-deemphasized-99 makeStyles-nowrap-100"
                 scope="row"
               >
                 0.0000
@@ -3291,7 +3239,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-104 makeStyles-indicationSeverityOk-105 makeStyles-monospace-101 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-101 makeStyles-indicationSeverityOk-102 makeStyles-monospace-98 makeStyles-nowrap-100"
                 scope="row"
               >
                 <span>
@@ -3299,13 +3247,13 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98 makeStyles-deemphasized-99 makeStyles-nowrap-100"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.01
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-102"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-99"
                 scope="row"
               >
                 <p
@@ -3329,7 +3277,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98 makeStyles-deemphasized-99 makeStyles-nowrap-100"
                 scope="row"
               >
                 <span>
@@ -3337,7 +3285,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98 makeStyles-deemphasized-99 makeStyles-nowrap-100"
                 scope="row"
               >
                 0.0000
@@ -3349,7 +3297,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-104 makeStyles-indicationSeverityOk-105 makeStyles-monospace-101 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-101 makeStyles-indicationSeverityOk-102 makeStyles-monospace-98 makeStyles-nowrap-100"
                 scope="row"
               >
                 <span>
@@ -3357,13 +3305,13 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98 makeStyles-deemphasized-99 makeStyles-nowrap-100"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-102"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-99"
                 scope="row"
               >
                 <p
@@ -3387,7 +3335,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98 makeStyles-deemphasized-99 makeStyles-nowrap-100"
                 scope="row"
               >
                 <span>
@@ -3395,7 +3343,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98 makeStyles-deemphasized-99 makeStyles-nowrap-100"
                 scope="row"
               >
                 10.0000
@@ -3409,7 +3357,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-104 makeStyles-indicationSeverityWarning-106 makeStyles-monospace-101 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-101 makeStyles-indicationSeverityWarning-103 makeStyles-monospace-98 makeStyles-nowrap-100"
                 scope="row"
               >
                 <span>
@@ -3417,13 +3365,13 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98 makeStyles-deemphasized-99 makeStyles-nowrap-100"
                 scope="row"
               >
                 1.5 &lt; x ≤ ∞
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-102"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-99"
                 scope="row"
               >
                 <p
@@ -3449,7 +3397,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98 makeStyles-deemphasized-99 makeStyles-nowrap-100"
                 scope="row"
               >
                 <span>
@@ -3457,7 +3405,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98 makeStyles-deemphasized-99 makeStyles-nowrap-100"
                 scope="row"
               >
                 0.0000
@@ -3471,7 +3419,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-104 makeStyles-indicationSeverityWarning-106 makeStyles-monospace-101 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-101 makeStyles-indicationSeverityWarning-103 makeStyles-monospace-98 makeStyles-nowrap-100"
                 scope="row"
               >
                 <span>
@@ -3479,13 +3427,13 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-98 makeStyles-deemphasized-99 makeStyles-nowrap-100"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-102"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-99"
                 scope="row"
               >
                 <p
@@ -3500,7 +3448,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
       </div>
     </div>
     <div
-      class="makeStyles-accordions-81"
+      class="makeStyles-accordions-79"
     >
       <div
         class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -3559,7 +3507,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-82"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-80"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -3719,7 +3667,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-82"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-80"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -3732,7 +3680,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                     This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                   </p>
                   <pre
-                    class="makeStyles-pre-84"
+                    class="makeStyles-pre-82"
                   >
                     <code>
                       with tracks_counts as (
@@ -3766,10 +3714,10 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders correctly for 1 analysis datapoint, not statistically significant 2`] = `
 <div
-  class="makeStyles-root-109 analysis-detail-panel"
+  class="makeStyles-root-106 analysis-detail-panel"
 >
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-123 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-120 MuiTypography-body1"
   >
     Summary
   </p>
@@ -3789,9 +3737,11 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
             class="MuiTableCell-root MuiTableCell-body"
           >
             <h5
-              class="MuiTypography-root makeStyles-recommendation-122 MuiTypography-h5 MuiTypography-gutterBottom"
+              class="MuiTypography-root makeStyles-recommendation-119 MuiTypography-h5 MuiTypography-gutterBottom"
             >
-              Inconclusive
+              <span>
+                Inconclusive
+              </span>
             </h5>
             <p
               class="MuiTypography-root MuiTypography-body1"
@@ -3829,7 +3779,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
               
               100
               <span
-                class="makeStyles-root-127"
+                class="makeStyles-root-124"
                 title="Percentage points."
               >
                 pp
@@ -3850,7 +3800,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
               
               10
               <span
-                class="makeStyles-root-127"
+                class="makeStyles-root-124"
                 title="Percentage points."
               >
                 pp
@@ -3862,7 +3812,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
             </strong>
              
             <span
-              class="makeStyles-root-128"
+              class="makeStyles-root-125"
               title="09/05/2020, 20:00:00"
             >
               2020-05-10
@@ -3887,7 +3837,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-123 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-120 MuiTypography-body1"
   >
     Analysis
   </p>
@@ -3895,7 +3845,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
     class="MuiPaper-root MuiTableContainer-root MuiPaper-elevation1 MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-coolTable-124"
+      class="MuiTable-root makeStyles-coolTable-121"
     >
       <thead
         class="MuiTableHead-root"
@@ -3936,22 +3886,22 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-117 makeStyles-headerCell-110 makeStyles-credibleIntervalHeader-121"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-114 makeStyles-headerCell-107 makeStyles-credibleIntervalHeader-118"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-111"
+              class="makeStyles-monospace-108"
             >
               test
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-108 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-99"
+              class="makeStyles-tooltipped-96"
             >
               50
                to 
@@ -3961,10 +3911,10 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-108 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-99"
+              class="makeStyles-tooltipped-96"
             >
               -100
                to 
@@ -3975,10 +3925,10 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-108 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-99"
+              class="makeStyles-tooltipped-96"
             >
               -50
                to 
@@ -3993,22 +3943,22 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-117 makeStyles-headerCell-110 makeStyles-credibleIntervalHeader-121"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-114 makeStyles-headerCell-107 makeStyles-credibleIntervalHeader-118"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-111"
+              class="makeStyles-monospace-108"
             >
               control
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-108 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-99"
+              class="makeStyles-tooltipped-96"
             >
               50
                to 
@@ -4018,12 +3968,12 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-108 MuiTableCell-alignRight"
           >
             Baseline
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-108 MuiTableCell-alignRight"
           >
             Baseline
           </td>
@@ -4032,7 +3982,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-analysisFinePrint-120 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-analysisFinePrint-117 MuiTypography-body1"
   >
     95% Credible Intervals (CIs). 
     <strong>
@@ -4042,7 +3992,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
     
     10
     <span
-      class="makeStyles-root-127"
+      class="makeStyles-root-124"
       title="Percentage points."
     >
       pp
@@ -4050,17 +4000,17 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
     .
   </p>
   <p
-    class="MuiTypography-root makeStyles-noPlotMessage-115 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-noPlotMessage-112 MuiTypography-body1"
   >
     Past values will be plotted once we have more than one day of results.
   </p>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-123 makeStyles-clickable-125 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-120 makeStyles-clickable-122 MuiTypography-body1"
     role="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-126"
+      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-123"
       focusable="false"
       viewBox="0 0 24 24"
     >
@@ -4078,7 +4028,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-79",
+        "className": "makeStyles-participantsPlot-77",
         "data": Array [
           Object {
             "line": Object {
@@ -4146,13 +4096,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-129"
+    class="makeStyles-root-126"
   >
     <div
-      class="makeStyles-summary-130"
+      class="makeStyles-summary-127"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-141 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-138 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -4161,16 +4111,16 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-132"
+        class="makeStyles-summaryColumn-129"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-133 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-130 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-134"
+            class="makeStyles-summaryStatsPart-131"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-136 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-133 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               1,000
             </h3>
@@ -4186,13 +4136,15 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-134"
+            class="makeStyles-summaryStatsPart-131"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-136 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-133 MuiTypography-h3 MuiTypography-colorPrimary"
             >
-              Deploy 
-              control
+              <span>
+                Deploy 
+                control
+              </span>
             </h3>
             <h6
               class="MuiTypography-root MuiTypography-subtitle1"
@@ -4205,12 +4157,12 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-137 makeStyles-indicationSeverityWarning-139 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-134 makeStyles-indicationSeverityWarning-136 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-136 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-133 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Potential issues
             </h3>
@@ -4227,30 +4179,16 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-143 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-140 MuiTypography-h3"
     >
-      <span>
-        Metric Assignment Results
-      </span>
-       
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-infoIcon-152"
-        focusable="false"
-        title="Results that are both practically and statistically significant are indicated in bold.  Insignificant results are indicated by a lighter grey."
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
-        />
-      </svg>
+      Metric Assignment Results
     </h3>
     <div
       class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-158"
+        class="Component-horizontalScrollContainer-154"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -4269,33 +4207,33 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-155 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-155 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric (attribution window)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-155 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Absolute change
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-155 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Relative change (lift)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-155 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -4346,7 +4284,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-149"
+                        class="makeStyles-metricAssignmentNameLine-146"
                       >
                         <span
                           class=""
@@ -4360,7 +4298,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       </span>
                       <br />
                       <span
-                        class="makeStyles-root-160"
+                        class="makeStyles-root-156"
                       >
                         primary
                       </span>
@@ -4369,51 +4307,43 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusYes-150"
+                      <span
+                        class="makeStyles-isSignificant-147"
                       >
-                        <span
-                          class=""
-                        >
-                          +
-                          50
-                           to 
-                          +
-                          100
-                           
-                          pp
-                        </span>
-                      </div>
+                        +
+                        50
+                         to 
+                        +
+                        100
+                         
+                        pp
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusYes-150"
+                      <span
+                        class="makeStyles-isSignificant-147"
                       >
-                        <span
-                          class=""
-                        >
-                          -50
-                           to 
-                          +
-                          0
-                           
-                          %
-                        </span>
-                      </div>
+                        -50
+                         to 
+                        +
+                        0
+                         
+                        %
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusYes-150"
+                      <span
+                        class="makeStyles-isSignificant-147"
                       >
                         Deploy 
                         control
-                      </div>
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -4456,7 +4386,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-149"
+                        class="makeStyles-metricAssignmentNameLine-146"
                       >
                         <span
                           class=""
@@ -4481,11 +4411,11 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-151"
+                      <span
+                        class=""
                       >
                         Not analyzed yet
-                      </div>
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -4528,7 +4458,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-149"
+                        class="makeStyles-metricAssignmentNameLine-146"
                       >
                         <span
                           class=""
@@ -4553,11 +4483,11 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-151"
+                      <span
+                        class=""
                       >
                         Not analyzed yet
-                      </div>
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -4600,7 +4530,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-149"
+                        class="makeStyles-metricAssignmentNameLine-146"
                       >
                         <span
                           class=""
@@ -4625,11 +4555,11 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-151"
+                      <span
+                        class=""
                       >
                         Not analyzed yet
-                      </div>
+                      </span>
                     </td>
                   </tr>
                 </tbody>
@@ -4640,7 +4570,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-143 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-140 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -4722,18 +4652,18 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-160 makeStyles-deemphasized-161 makeStyles-nowrap-162"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-171"
+                  class="makeStyles-tooltip-167"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-160 makeStyles-deemphasized-161 makeStyles-nowrap-162"
                 scope="row"
               >
                 1.0000
@@ -4745,7 +4675,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-167 makeStyles-indicationSeverityOk-168 makeStyles-monospace-164 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-163 makeStyles-indicationSeverityOk-164 makeStyles-monospace-160 makeStyles-nowrap-162"
                 scope="row"
               >
                 <span>
@@ -4753,13 +4683,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-160 makeStyles-deemphasized-161 makeStyles-nowrap-162"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-161"
                 scope="row"
               >
                 <p
@@ -4783,18 +4713,18 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-160 makeStyles-deemphasized-161 makeStyles-nowrap-162"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-171"
+                  class="makeStyles-tooltip-167"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-160 makeStyles-deemphasized-161 makeStyles-nowrap-162"
                 scope="row"
               >
                 1.0000
@@ -4806,7 +4736,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-167 makeStyles-indicationSeverityOk-168 makeStyles-monospace-164 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-163 makeStyles-indicationSeverityOk-164 makeStyles-monospace-160 makeStyles-nowrap-162"
                 scope="row"
               >
                 <span>
@@ -4814,13 +4744,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-160 makeStyles-deemphasized-161 makeStyles-nowrap-162"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-161"
                 scope="row"
               >
                 <p
@@ -4844,18 +4774,18 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-160 makeStyles-deemphasized-161 makeStyles-nowrap-162"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-171"
+                  class="makeStyles-tooltip-167"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-160 makeStyles-deemphasized-161 makeStyles-nowrap-162"
                 scope="row"
               >
                 1.0000
@@ -4867,7 +4797,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-167 makeStyles-indicationSeverityOk-168 makeStyles-monospace-164 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-163 makeStyles-indicationSeverityOk-164 makeStyles-monospace-160 makeStyles-nowrap-162"
                 scope="row"
               >
                 <span>
@@ -4875,13 +4805,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-160 makeStyles-deemphasized-161 makeStyles-nowrap-162"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-161"
                 scope="row"
               >
                 <p
@@ -4905,7 +4835,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-160 makeStyles-deemphasized-161 makeStyles-nowrap-162"
                 scope="row"
               >
                 <span>
@@ -4913,7 +4843,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-160 makeStyles-deemphasized-161 makeStyles-nowrap-162"
                 scope="row"
               >
                 0.0000
@@ -4925,7 +4855,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-167 makeStyles-indicationSeverityOk-168 makeStyles-monospace-164 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-163 makeStyles-indicationSeverityOk-164 makeStyles-monospace-160 makeStyles-nowrap-162"
                 scope="row"
               >
                 <span>
@@ -4933,13 +4863,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-160 makeStyles-deemphasized-161 makeStyles-nowrap-162"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.01
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-161"
                 scope="row"
               >
                 <p
@@ -4963,7 +4893,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-160 makeStyles-deemphasized-161 makeStyles-nowrap-162"
                 scope="row"
               >
                 <span>
@@ -4971,7 +4901,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-160 makeStyles-deemphasized-161 makeStyles-nowrap-162"
                 scope="row"
               >
                 0.0000
@@ -4983,7 +4913,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-167 makeStyles-indicationSeverityOk-168 makeStyles-monospace-164 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-163 makeStyles-indicationSeverityOk-164 makeStyles-monospace-160 makeStyles-nowrap-162"
                 scope="row"
               >
                 <span>
@@ -4991,13 +4921,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-160 makeStyles-deemphasized-161 makeStyles-nowrap-162"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-161"
                 scope="row"
               >
                 <p
@@ -5021,7 +4951,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-160 makeStyles-deemphasized-161 makeStyles-nowrap-162"
                 scope="row"
               >
                 <span>
@@ -5029,7 +4959,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-160 makeStyles-deemphasized-161 makeStyles-nowrap-162"
                 scope="row"
               >
                 2.5000
@@ -5043,7 +4973,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-167 makeStyles-indicationSeverityWarning-169 makeStyles-monospace-164 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-163 makeStyles-indicationSeverityWarning-165 makeStyles-monospace-160 makeStyles-nowrap-162"
                 scope="row"
               >
                 <span>
@@ -5051,13 +4981,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-160 makeStyles-deemphasized-161 makeStyles-nowrap-162"
                 scope="row"
               >
                 1.5 &lt; x ≤ ∞
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-161"
                 scope="row"
               >
                 <p
@@ -5083,7 +5013,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-160 makeStyles-deemphasized-161 makeStyles-nowrap-162"
                 scope="row"
               >
                 <span>
@@ -5091,7 +5021,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-160 makeStyles-deemphasized-161 makeStyles-nowrap-162"
                 scope="row"
               >
                 0.0000
@@ -5105,7 +5035,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-167 makeStyles-indicationSeverityWarning-169 makeStyles-monospace-164 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-163 makeStyles-indicationSeverityWarning-165 makeStyles-monospace-160 makeStyles-nowrap-162"
                 scope="row"
               >
                 <span>
@@ -5113,13 +5043,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-160 makeStyles-deemphasized-161 makeStyles-nowrap-162"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-165"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-161"
                 scope="row"
               >
                 <p
@@ -5134,7 +5064,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
       </div>
     </div>
     <div
-      class="makeStyles-accordions-144"
+      class="makeStyles-accordions-141"
     >
       <div
         class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -5193,7 +5123,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-145"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-142"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -5353,7 +5283,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-145"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-142"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -5366,7 +5296,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                     This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                   </p>
                   <pre
-                    class="makeStyles-pre-147"
+                    class="makeStyles-pre-144"
                   >
                     <code>
                       with tracks_counts as (
@@ -5400,10 +5330,10 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders correctly for 1 analysis datapoint, statistically significant 2`] = `
 <div
-  class="makeStyles-root-172 analysis-detail-panel"
+  class="makeStyles-root-168 analysis-detail-panel"
 >
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-186 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-182 MuiTypography-body1"
   >
     Summary
   </p>
@@ -5423,10 +5353,12 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
             class="MuiTableCell-root MuiTableCell-body"
           >
             <h5
-              class="MuiTypography-root makeStyles-recommendation-185 MuiTypography-h5 MuiTypography-gutterBottom"
+              class="MuiTypography-root makeStyles-recommendation-181 MuiTypography-h5 MuiTypography-gutterBottom"
             >
-              Deploy 
-              control
+              <span>
+                Deploy 
+                control
+              </span>
             </h5>
             <p
               class="MuiTypography-root MuiTypography-body1"
@@ -5465,7 +5397,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
               
               100
               <span
-                class="makeStyles-root-190"
+                class="makeStyles-root-186"
                 title="Percentage points."
               >
                 pp
@@ -5486,7 +5418,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
               
               10
               <span
-                class="makeStyles-root-190"
+                class="makeStyles-root-186"
                 title="Percentage points."
               >
                 pp
@@ -5498,7 +5430,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
             </strong>
              
             <span
-              class="makeStyles-root-191"
+              class="makeStyles-root-187"
               title="09/05/2020, 20:00:00"
             >
               2020-05-10
@@ -5523,7 +5455,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-186 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-182 MuiTypography-body1"
   >
     Analysis
   </p>
@@ -5531,7 +5463,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
     class="MuiPaper-root MuiTableContainer-root MuiPaper-elevation1 MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-coolTable-187"
+      class="MuiTable-root makeStyles-coolTable-183"
     >
       <thead
         class="MuiTableHead-root"
@@ -5572,22 +5504,22 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-180 makeStyles-headerCell-173 makeStyles-credibleIntervalHeader-184"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-176 makeStyles-headerCell-169 makeStyles-credibleIntervalHeader-180"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-174"
+              class="makeStyles-monospace-170"
             >
               test
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-174 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-170 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-162"
+              class="makeStyles-tooltipped-158"
             >
               50
                to 
@@ -5597,10 +5529,10 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-174 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-170 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-162"
+              class="makeStyles-tooltipped-158"
             >
               +
               50
@@ -5612,10 +5544,10 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-174 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-170 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-162"
+              class="makeStyles-tooltipped-158"
             >
               -50
                to 
@@ -5630,22 +5562,22 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-180 makeStyles-headerCell-173 makeStyles-credibleIntervalHeader-184"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-176 makeStyles-headerCell-169 makeStyles-credibleIntervalHeader-180"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-174"
+              class="makeStyles-monospace-170"
             >
               control
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-174 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-170 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-162"
+              class="makeStyles-tooltipped-158"
             >
               100
                to 
@@ -5655,12 +5587,12 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-174 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-170 MuiTableCell-alignRight"
           >
             Baseline
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-174 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-170 MuiTableCell-alignRight"
           >
             Baseline
           </td>
@@ -5669,7 +5601,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-analysisFinePrint-183 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-analysisFinePrint-179 MuiTypography-body1"
   >
     95% Credible Intervals (CIs). 
     <strong>
@@ -5679,7 +5611,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
     
     10
     <span
-      class="makeStyles-root-190"
+      class="makeStyles-root-186"
       title="Percentage points."
     >
       pp
@@ -5687,17 +5619,17 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
     .
   </p>
   <p
-    class="MuiTypography-root makeStyles-noPlotMessage-178 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-noPlotMessage-174 MuiTypography-body1"
   >
     Past values will be plotted once we have more than one day of results.
   </p>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-186 makeStyles-clickable-188 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-182 makeStyles-clickable-184 MuiTypography-body1"
     role="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-189"
+      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-185"
       focusable="false"
       viewBox="0 0 24 24"
     >
@@ -5715,7 +5647,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 3
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-142",
+        "className": "makeStyles-participantsPlot-139",
         "data": Array [
           Object {
             "line": Object {
@@ -5783,13 +5715,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-192"
+    class="makeStyles-root-188"
   >
     <div
-      class="makeStyles-summary-193"
+      class="makeStyles-summary-189"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-204 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-200 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -5798,16 +5730,16 @@ exports[`renders correctly for conflicting analysis data 1`] = `
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-195"
+        class="makeStyles-summaryColumn-191"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-196 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-192 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-197"
+            class="makeStyles-summaryStatsPart-193"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-199 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-195 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               1,000
             </h3>
@@ -5823,13 +5755,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-197"
+            class="makeStyles-summaryStatsPart-193"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-199 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-195 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               <span
-                class="makeStyles-tooltipped-216"
+                class="makeStyles-tooltipped-211"
                 title="Contact @experimentation-review on #a8c-experiments"
               >
                 Manual analysis required
@@ -5846,12 +5778,12 @@ exports[`renders correctly for conflicting analysis data 1`] = `
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-200 makeStyles-indicationSeverityWarning-202 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-196 makeStyles-indicationSeverityWarning-198 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-199 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-195 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Potential issues
             </h3>
@@ -5868,30 +5800,16 @@ exports[`renders correctly for conflicting analysis data 1`] = `
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-206 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-202 MuiTypography-h3"
     >
-      <span>
-        Metric Assignment Results
-      </span>
-       
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-infoIcon-215"
-        focusable="false"
-        title="Results that are both practically and statistically significant are indicated in bold.  Insignificant results are indicated by a lighter grey."
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
-        />
-      </svg>
+      Metric Assignment Results
     </h3>
     <div
       class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-221"
+        class="Component-horizontalScrollContainer-216"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -5910,33 +5828,33 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-222 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-217 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-222 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-217 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric (attribution window)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-222 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-217 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Absolute change
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-222 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-217 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Relative change (lift)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-222 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-217 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -5987,7 +5905,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-212"
+                        class="makeStyles-metricAssignmentNameLine-208"
                       >
                         <span
                           class=""
@@ -6001,7 +5919,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       </span>
                       <br />
                       <span
-                        class="makeStyles-root-223"
+                        class="makeStyles-root-218"
                       >
                         primary
                       </span>
@@ -6018,16 +5936,12 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusYes-213"
+                      <span
+                        class="makeStyles-isSignificant-209 makeStyles-tooltipped-211"
+                        title="Contact @experimentation-review on #a8c-experiments"
                       >
-                        <span
-                          class="makeStyles-tooltipped-216"
-                          title="Contact @experimentation-review on #a8c-experiments"
-                        >
-                          Manual analysis required
-                        </span>
-                      </div>
+                        Manual analysis required
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -6070,7 +5984,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-212"
+                        class="makeStyles-metricAssignmentNameLine-208"
                       >
                         <span
                           class=""
@@ -6095,11 +6009,11 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-214"
+                      <span
+                        class=""
                       >
                         Not analyzed yet
-                      </div>
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -6142,7 +6056,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-212"
+                        class="makeStyles-metricAssignmentNameLine-208"
                       >
                         <span
                           class=""
@@ -6167,11 +6081,11 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-214"
+                      <span
+                        class=""
                       >
                         Not analyzed yet
-                      </div>
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -6214,7 +6128,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-212"
+                        class="makeStyles-metricAssignmentNameLine-208"
                       >
                         <span
                           class=""
@@ -6239,11 +6153,11 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-214"
+                      <span
+                        class=""
                       >
                         Not analyzed yet
-                      </div>
+                      </span>
                     </td>
                   </tr>
                 </tbody>
@@ -6254,7 +6168,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-206 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-202 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -6336,18 +6250,18 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 makeStyles-deemphasized-221 makeStyles-nowrap-222"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-232"
+                  class="makeStyles-tooltip-227"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 makeStyles-deemphasized-221 makeStyles-nowrap-222"
                 scope="row"
               >
                 1.0000
@@ -6359,7 +6273,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-228 makeStyles-indicationSeverityOk-229 makeStyles-monospace-225 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-223 makeStyles-indicationSeverityOk-224 makeStyles-monospace-220 makeStyles-nowrap-222"
                 scope="row"
               >
                 <span>
@@ -6367,13 +6281,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 makeStyles-deemphasized-221 makeStyles-nowrap-222"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-226"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-221"
                 scope="row"
               >
                 <p
@@ -6397,18 +6311,18 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 makeStyles-deemphasized-221 makeStyles-nowrap-222"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-232"
+                  class="makeStyles-tooltip-227"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 makeStyles-deemphasized-221 makeStyles-nowrap-222"
                 scope="row"
               >
                 1.0000
@@ -6420,7 +6334,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-228 makeStyles-indicationSeverityOk-229 makeStyles-monospace-225 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-223 makeStyles-indicationSeverityOk-224 makeStyles-monospace-220 makeStyles-nowrap-222"
                 scope="row"
               >
                 <span>
@@ -6428,13 +6342,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 makeStyles-deemphasized-221 makeStyles-nowrap-222"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-226"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-221"
                 scope="row"
               >
                 <p
@@ -6458,18 +6372,18 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 makeStyles-deemphasized-221 makeStyles-nowrap-222"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-232"
+                  class="makeStyles-tooltip-227"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 makeStyles-deemphasized-221 makeStyles-nowrap-222"
                 scope="row"
               >
                 1.0000
@@ -6481,7 +6395,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-228 makeStyles-indicationSeverityOk-229 makeStyles-monospace-225 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-223 makeStyles-indicationSeverityOk-224 makeStyles-monospace-220 makeStyles-nowrap-222"
                 scope="row"
               >
                 <span>
@@ -6489,13 +6403,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 makeStyles-deemphasized-221 makeStyles-nowrap-222"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-226"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-221"
                 scope="row"
               >
                 <p
@@ -6519,7 +6433,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 makeStyles-deemphasized-221 makeStyles-nowrap-222"
                 scope="row"
               >
                 <span>
@@ -6527,7 +6441,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 makeStyles-deemphasized-221 makeStyles-nowrap-222"
                 scope="row"
               >
                 0.0000
@@ -6539,7 +6453,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-228 makeStyles-indicationSeverityOk-229 makeStyles-monospace-225 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-223 makeStyles-indicationSeverityOk-224 makeStyles-monospace-220 makeStyles-nowrap-222"
                 scope="row"
               >
                 <span>
@@ -6547,13 +6461,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 makeStyles-deemphasized-221 makeStyles-nowrap-222"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.01
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-226"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-221"
                 scope="row"
               >
                 <p
@@ -6577,7 +6491,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 makeStyles-deemphasized-221 makeStyles-nowrap-222"
                 scope="row"
               >
                 <span>
@@ -6585,7 +6499,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 makeStyles-deemphasized-221 makeStyles-nowrap-222"
                 scope="row"
               >
                 0.0000
@@ -6597,7 +6511,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-228 makeStyles-indicationSeverityOk-229 makeStyles-monospace-225 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-223 makeStyles-indicationSeverityOk-224 makeStyles-monospace-220 makeStyles-nowrap-222"
                 scope="row"
               >
                 <span>
@@ -6605,13 +6519,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 makeStyles-deemphasized-221 makeStyles-nowrap-222"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-226"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-221"
                 scope="row"
               >
                 <p
@@ -6635,7 +6549,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 makeStyles-deemphasized-221 makeStyles-nowrap-222"
                 scope="row"
               >
                 <span>
@@ -6643,7 +6557,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 makeStyles-deemphasized-221 makeStyles-nowrap-222"
                 scope="row"
               >
                 2.5000
@@ -6657,7 +6571,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-228 makeStyles-indicationSeverityWarning-230 makeStyles-monospace-225 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-223 makeStyles-indicationSeverityWarning-225 makeStyles-monospace-220 makeStyles-nowrap-222"
                 scope="row"
               >
                 <span>
@@ -6665,13 +6579,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 makeStyles-deemphasized-221 makeStyles-nowrap-222"
                 scope="row"
               >
                 1.5 &lt; x ≤ ∞
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-226"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-221"
                 scope="row"
               >
                 <p
@@ -6697,7 +6611,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 makeStyles-deemphasized-221 makeStyles-nowrap-222"
                 scope="row"
               >
                 <span>
@@ -6705,7 +6619,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 makeStyles-deemphasized-221 makeStyles-nowrap-222"
                 scope="row"
               >
                 0.0000
@@ -6719,7 +6633,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-228 makeStyles-indicationSeverityWarning-230 makeStyles-monospace-225 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-223 makeStyles-indicationSeverityWarning-225 makeStyles-monospace-220 makeStyles-nowrap-222"
                 scope="row"
               >
                 <span>
@@ -6727,13 +6641,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 makeStyles-deemphasized-221 makeStyles-nowrap-222"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-226"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-221"
                 scope="row"
               >
                 <p
@@ -6748,7 +6662,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
       </div>
     </div>
     <div
-      class="makeStyles-accordions-207"
+      class="makeStyles-accordions-203"
     >
       <div
         class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -6807,7 +6721,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-208"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-204"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -6967,7 +6881,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-208"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-204"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -6980,7 +6894,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                     This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                   </p>
                   <pre
-                    class="makeStyles-pre-210"
+                    class="makeStyles-pre-206"
                   >
                     <code>
                       with tracks_counts as (
@@ -7014,10 +6928,10 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders correctly for conflicting analysis data 2`] = `
 <div
-  class="makeStyles-root-233 analysis-detail-panel"
+  class="makeStyles-root-228 analysis-detail-panel"
 >
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-247 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-242 MuiTypography-body1"
   >
     Summary
   </p>
@@ -7037,10 +6951,10 @@ exports[`renders correctly for conflicting analysis data 2`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <h5
-              class="MuiTypography-root makeStyles-recommendation-246 MuiTypography-h5 MuiTypography-gutterBottom"
+              class="MuiTypography-root makeStyles-recommendation-241 MuiTypography-h5 MuiTypography-gutterBottom"
             >
               <span
-                class="makeStyles-tooltipped-216"
+                class="makeStyles-tooltipped-211"
                 title="Contact @experimentation-review on #a8c-experiments"
               >
                 Manual analysis required
@@ -7090,7 +7004,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
               
               100
               <span
-                class="makeStyles-root-251"
+                class="makeStyles-root-246"
                 title="Percentage points."
               >
                 pp
@@ -7111,7 +7025,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
               
               10
               <span
-                class="makeStyles-root-251"
+                class="makeStyles-root-246"
                 title="Percentage points."
               >
                 pp
@@ -7123,7 +7037,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
             </strong>
              
             <span
-              class="makeStyles-root-252"
+              class="makeStyles-root-247"
               title="09/05/2020, 20:00:00"
             >
               2020-05-10
@@ -7148,7 +7062,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-247 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-242 MuiTypography-body1"
   >
     Analysis
   </p>
@@ -7156,7 +7070,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
     class="MuiPaper-root MuiTableContainer-root MuiPaper-elevation1 MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-coolTable-248"
+      class="MuiTable-root makeStyles-coolTable-243"
     >
       <thead
         class="MuiTableHead-root"
@@ -7197,22 +7111,22 @@ exports[`renders correctly for conflicting analysis data 2`] = `
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-241 makeStyles-headerCell-234 makeStyles-credibleIntervalHeader-245"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-236 makeStyles-headerCell-229 makeStyles-credibleIntervalHeader-240"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-235"
+              class="makeStyles-monospace-230"
             >
               test
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-235 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-230 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-254"
+              class="makeStyles-tooltipped-249"
             >
               50
                to 
@@ -7222,10 +7136,10 @@ exports[`renders correctly for conflicting analysis data 2`] = `
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-235 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-230 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-254"
+              class="makeStyles-tooltipped-249"
             >
               +
               50
@@ -7237,10 +7151,10 @@ exports[`renders correctly for conflicting analysis data 2`] = `
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-235 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-230 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-254"
+              class="makeStyles-tooltipped-249"
             >
               -50
                to 
@@ -7255,22 +7169,22 @@ exports[`renders correctly for conflicting analysis data 2`] = `
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-241 makeStyles-headerCell-234 makeStyles-credibleIntervalHeader-245"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-236 makeStyles-headerCell-229 makeStyles-credibleIntervalHeader-240"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-235"
+              class="makeStyles-monospace-230"
             >
               control
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-235 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-230 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-254"
+              class="makeStyles-tooltipped-249"
             >
               100
                to 
@@ -7280,12 +7194,12 @@ exports[`renders correctly for conflicting analysis data 2`] = `
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-235 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-230 MuiTableCell-alignRight"
           >
             Baseline
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-235 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-230 MuiTableCell-alignRight"
           >
             Baseline
           </td>
@@ -7294,7 +7208,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-analysisFinePrint-244 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-analysisFinePrint-239 MuiTypography-body1"
   >
     95% Credible Intervals (CIs). 
     <strong>
@@ -7304,7 +7218,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
     
     10
     <span
-      class="makeStyles-root-251"
+      class="makeStyles-root-246"
       title="Percentage points."
     >
       pp
@@ -7312,17 +7226,17 @@ exports[`renders correctly for conflicting analysis data 2`] = `
     .
   </p>
   <p
-    class="MuiTypography-root makeStyles-noPlotMessage-239 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-noPlotMessage-234 MuiTypography-body1"
   >
     Past values will be plotted once we have more than one day of results.
   </p>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-247 makeStyles-clickable-249 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-242 makeStyles-clickable-244 MuiTypography-body1"
     role="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-250"
+      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-245"
       focusable="false"
       viewBox="0 0 24 24"
     >
@@ -7340,7 +7254,7 @@ exports[`renders correctly for conflicting analysis data 3`] = `
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-205",
+        "className": "makeStyles-participantsPlot-201",
         "data": Array [
           Object {
             "line": Object {
@@ -7408,13 +7322,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-255"
+    class="makeStyles-root-250"
   >
     <div
-      class="makeStyles-summary-256"
+      class="makeStyles-summary-251"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-267 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-262 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -7423,16 +7337,16 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-258"
+        class="makeStyles-summaryColumn-253"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-259 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-254 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-260"
+            class="makeStyles-summaryStatsPart-255"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-262 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-257 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               700
             </h3>
@@ -7448,12 +7362,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-260"
+            class="makeStyles-summaryStatsPart-255"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-262 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-257 MuiTypography-h3 MuiTypography-colorPrimary"
             >
-              Deploy either variation
+              <span>
+                Deploy either variation
+              </span>
             </h3>
             <h6
               class="MuiTypography-root MuiTypography-subtitle1"
@@ -7466,12 +7382,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-263 makeStyles-indicationSeverityError-266 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-258 makeStyles-indicationSeverityError-261 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-262 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-257 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Serious issues
             </h3>
@@ -7488,30 +7404,16 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-269 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-264 MuiTypography-h3"
     >
-      <span>
-        Metric Assignment Results
-      </span>
-       
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-infoIcon-278"
-        focusable="false"
-        title="Results that are both practically and statistically significant are indicated in bold.  Insignificant results are indicated by a lighter grey."
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
-        />
-      </svg>
+      Metric Assignment Results
     </h3>
     <div
       class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-284"
+        class="Component-horizontalScrollContainer-278"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -7530,33 +7432,33 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-285 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-279 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-285 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-279 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric (attribution window)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-285 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-279 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Absolute change
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-285 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-279 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Relative change (lift)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-285 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-279 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -7607,7 +7509,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-275"
+                        class="makeStyles-metricAssignmentNameLine-270"
                       >
                         <span
                           class=""
@@ -7621,7 +7523,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       </span>
                       <br />
                       <span
-                        class="makeStyles-root-286"
+                        class="makeStyles-root-280"
                       >
                         primary
                       </span>
@@ -7630,49 +7532,41 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-277"
+                      <span
+                        class=""
                       >
-                        <span
-                          class=""
-                        >
-                          -1
-                           to 
-                          +
-                          1
-                           
-                          pp
-                        </span>
-                      </div>
+                        -1
+                         to 
+                        +
+                        1
+                         
+                        pp
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-277"
+                      <span
+                        class=""
                       >
-                        <span
-                          class=""
-                        >
-                          -50
-                           to 
-                          +
-                          50
-                           
-                          %
-                        </span>
-                      </div>
+                        -50
+                         to 
+                        +
+                        50
+                         
+                        %
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-277"
+                      <span
+                        class=""
                       >
                         Deploy either variation
-                      </div>
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -7715,7 +7609,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-275"
+                        class="makeStyles-metricAssignmentNameLine-270"
                       >
                         <span
                           class=""
@@ -7740,11 +7634,11 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-277"
+                      <span
+                        class=""
                       >
                         Not analyzed yet
-                      </div>
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -7787,7 +7681,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-275"
+                        class="makeStyles-metricAssignmentNameLine-270"
                       >
                         <span
                           class=""
@@ -7812,11 +7706,11 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-277"
+                      <span
+                        class=""
                       >
                         Not analyzed yet
-                      </div>
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -7859,7 +7753,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-275"
+                        class="makeStyles-metricAssignmentNameLine-270"
                       >
                         <span
                           class=""
@@ -7876,49 +7770,41 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-277"
+                      <span
+                        class=""
                       >
-                        <span
-                          class=""
-                        >
-                          -1
-                           to 
-                          +
-                          1
-                           
-                          pp
-                        </span>
-                      </div>
+                        -1
+                         to 
+                        +
+                        1
+                         
+                        pp
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-277"
+                      <span
+                        class=""
                       >
-                        <span
-                          class=""
-                        >
-                          -50
-                           to 
-                          +
-                          50
-                           
-                          %
-                        </span>
-                      </div>
+                        -50
+                         to 
+                        +
+                        50
+                         
+                        %
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-277"
+                      <span
+                        class=""
                       >
                         Deploy either variation
-                      </div>
+                      </span>
                     </td>
                   </tr>
                 </tbody>
@@ -7929,7 +7815,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-269 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-264 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -8011,18 +7897,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-284 makeStyles-deemphasized-285 makeStyles-nowrap-286"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-297"
+                  class="makeStyles-tooltip-291"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-284 makeStyles-deemphasized-285 makeStyles-nowrap-286"
                 scope="row"
               >
                 1.0000
@@ -8034,7 +7920,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-293 makeStyles-indicationSeverityOk-294 makeStyles-monospace-290 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-287 makeStyles-indicationSeverityOk-288 makeStyles-monospace-284 makeStyles-nowrap-286"
                 scope="row"
               >
                 <span>
@@ -8042,13 +7928,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-284 makeStyles-deemphasized-285 makeStyles-nowrap-286"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-291"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-285"
                 scope="row"
               >
                 <p
@@ -8072,18 +7958,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-284 makeStyles-deemphasized-285 makeStyles-nowrap-286"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-297"
+                  class="makeStyles-tooltip-291"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-284 makeStyles-deemphasized-285 makeStyles-nowrap-286"
                 scope="row"
               >
                 1.0000
@@ -8095,7 +7981,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-293 makeStyles-indicationSeverityOk-294 makeStyles-monospace-290 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-287 makeStyles-indicationSeverityOk-288 makeStyles-monospace-284 makeStyles-nowrap-286"
                 scope="row"
               >
                 <span>
@@ -8103,13 +7989,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-284 makeStyles-deemphasized-285 makeStyles-nowrap-286"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-291"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-285"
                 scope="row"
               >
                 <p
@@ -8133,18 +8019,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-284 makeStyles-deemphasized-285 makeStyles-nowrap-286"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-297"
+                  class="makeStyles-tooltip-291"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-284 makeStyles-deemphasized-285 makeStyles-nowrap-286"
                 scope="row"
               >
                 1.0000
@@ -8156,7 +8042,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-293 makeStyles-indicationSeverityOk-294 makeStyles-monospace-290 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-287 makeStyles-indicationSeverityOk-288 makeStyles-monospace-284 makeStyles-nowrap-286"
                 scope="row"
               >
                 <span>
@@ -8164,13 +8050,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-284 makeStyles-deemphasized-285 makeStyles-nowrap-286"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-291"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-285"
                 scope="row"
               >
                 <p
@@ -8194,7 +8080,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-284 makeStyles-deemphasized-285 makeStyles-nowrap-286"
                 scope="row"
               >
                 <span>
@@ -8202,7 +8088,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-284 makeStyles-deemphasized-285 makeStyles-nowrap-286"
                 scope="row"
               >
                 0.1000
@@ -8216,7 +8102,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-293 makeStyles-indicationSeverityError-296 makeStyles-monospace-290 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-287 makeStyles-indicationSeverityError-290 makeStyles-monospace-284 makeStyles-nowrap-286"
                 scope="row"
               >
                 <span>
@@ -8224,13 +8110,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-284 makeStyles-deemphasized-285 makeStyles-nowrap-286"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-291"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-285"
                 scope="row"
               >
                 <p
@@ -8256,7 +8142,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-284 makeStyles-deemphasized-285 makeStyles-nowrap-286"
                 scope="row"
               >
                 <span>
@@ -8264,7 +8150,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-284 makeStyles-deemphasized-285 makeStyles-nowrap-286"
                 scope="row"
               >
                 0.1500
@@ -8278,7 +8164,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-293 makeStyles-indicationSeverityWarning-295 makeStyles-monospace-290 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-287 makeStyles-indicationSeverityWarning-289 makeStyles-monospace-284 makeStyles-nowrap-286"
                 scope="row"
               >
                 <span>
@@ -8286,13 +8172,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-284 makeStyles-deemphasized-285 makeStyles-nowrap-286"
                 scope="row"
               >
                 0.1 &lt; x ≤ 0.4
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-291"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-285"
                 scope="row"
               >
                 <p
@@ -8318,7 +8204,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-284 makeStyles-deemphasized-285 makeStyles-nowrap-286"
                 scope="row"
               >
                 <span>
@@ -8326,7 +8212,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-284 makeStyles-deemphasized-285 makeStyles-nowrap-286"
                 scope="row"
               >
                 0.1000
@@ -8338,7 +8224,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-293 makeStyles-indicationSeverityOk-294 makeStyles-monospace-290 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-287 makeStyles-indicationSeverityOk-288 makeStyles-monospace-284 makeStyles-nowrap-286"
                 scope="row"
               >
                 <span>
@@ -8346,13 +8232,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-284 makeStyles-deemphasized-285 makeStyles-nowrap-286"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.8
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-291"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-285"
                 scope="row"
               >
                 <p
@@ -8376,7 +8262,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-284 makeStyles-deemphasized-285 makeStyles-nowrap-286"
                 scope="row"
               >
                 <span>
@@ -8384,7 +8270,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-284 makeStyles-deemphasized-285 makeStyles-nowrap-286"
                 scope="row"
               >
                 0.0000
@@ -8398,7 +8284,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-293 makeStyles-indicationSeverityWarning-295 makeStyles-monospace-290 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-287 makeStyles-indicationSeverityWarning-289 makeStyles-monospace-284 makeStyles-nowrap-286"
                 scope="row"
               >
                 <span>
@@ -8406,13 +8292,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-284 makeStyles-deemphasized-285 makeStyles-nowrap-286"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-291"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-285"
                 scope="row"
               >
                 <p
@@ -8427,7 +8313,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <div
-      class="makeStyles-accordions-270"
+      class="makeStyles-accordions-265"
     >
       <div
         class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -8486,7 +8372,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-271"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-266"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -8646,7 +8532,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-271"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-266"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -8659,7 +8545,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                   </p>
                   <pre
-                    class="makeStyles-pre-273"
+                    class="makeStyles-pre-268"
                   >
                     <code>
                       with tracks_counts as (
@@ -8693,10 +8579,10 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders the condensed table with some analyses in non-debug mode for a Conversion Metric 2`] = `
 <div
-  class="makeStyles-root-298 analysis-detail-panel"
+  class="makeStyles-root-292 analysis-detail-panel"
 >
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-312 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-306 MuiTypography-body1"
   >
     Summary
   </p>
@@ -8716,9 +8602,11 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableCell-root MuiTableCell-body"
           >
             <h5
-              class="MuiTypography-root makeStyles-recommendation-311 MuiTypography-h5 MuiTypography-gutterBottom"
+              class="MuiTypography-root makeStyles-recommendation-305 MuiTypography-h5 MuiTypography-gutterBottom"
             >
-              Deploy either variation
+              <span>
+                Deploy either variation
+              </span>
             </h5>
             <p
               class="MuiTypography-root MuiTypography-body1"
@@ -8756,7 +8644,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               
               1
               <span
-                class="makeStyles-root-316"
+                class="makeStyles-root-310"
                 title="Percentage points."
               >
                 pp
@@ -8777,7 +8665,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               
               10
               <span
-                class="makeStyles-root-316"
+                class="makeStyles-root-310"
                 title="Percentage points."
               >
                 pp
@@ -8789,7 +8677,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </strong>
              
             <span
-              class="makeStyles-root-317"
+              class="makeStyles-root-311"
               title="09/05/2020, 20:00:00"
             >
               2020-05-10
@@ -8814,7 +8702,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-312 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-306 MuiTypography-body1"
   >
     Analysis
   </p>
@@ -8822,7 +8710,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     class="MuiPaper-root MuiTableContainer-root MuiPaper-elevation1 MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-coolTable-313"
+      class="MuiTable-root makeStyles-coolTable-307"
     >
       <thead
         class="MuiTableHead-root"
@@ -8863,22 +8751,22 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-306 makeStyles-headerCell-299 makeStyles-credibleIntervalHeader-310"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-300 makeStyles-headerCell-293 makeStyles-credibleIntervalHeader-304"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-300"
+              class="makeStyles-monospace-294"
             >
               test
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-300 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-294 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-288"
+              class="makeStyles-tooltipped-282"
             >
               -112.3
                to 
@@ -8888,10 +8776,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-300 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-294 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-288"
+              class="makeStyles-tooltipped-282"
             >
               -1
                to 
@@ -8902,10 +8790,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-300 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-294 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-288"
+              class="makeStyles-tooltipped-282"
             >
               -50
                to 
@@ -8920,22 +8808,22 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-306 makeStyles-headerCell-299 makeStyles-credibleIntervalHeader-310"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-300 makeStyles-headerCell-293 makeStyles-credibleIntervalHeader-304"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-300"
+              class="makeStyles-monospace-294"
             >
               control
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-300 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-294 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-288"
+              class="makeStyles-tooltipped-282"
             >
               0
                to 
@@ -8945,12 +8833,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-300 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-294 MuiTableCell-alignRight"
           >
             Baseline
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-300 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-294 MuiTableCell-alignRight"
           >
             Baseline
           </td>
@@ -8959,7 +8847,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-analysisFinePrint-309 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-analysisFinePrint-303 MuiTypography-body1"
   >
     95% Credible Intervals (CIs). 
     <strong>
@@ -8969,7 +8857,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     
     10
     <span
-      class="makeStyles-root-316"
+      class="makeStyles-root-310"
       title="Percentage points."
     >
       pp
@@ -8977,15 +8865,15 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     .
   </p>
   <div
-    class="makeStyles-metricEstimatePlots-301"
+    class="makeStyles-metricEstimatePlots-295"
   />
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-312 makeStyles-clickable-314 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-306 makeStyles-clickable-308 MuiTypography-body1"
     role="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-315"
+      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-309"
       focusable="false"
       viewBox="0 0 24 24"
     >
@@ -9003,7 +8891,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-268",
+        "className": "makeStyles-participantsPlot-263",
         "data": Array [
           Object {
             "line": Object {
@@ -9062,7 +8950,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-302",
+        "className": "makeStyles-metricEstimatePlot-296",
         "data": Array [
           Object {
             "line": Object {
@@ -9158,7 +9046,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-302",
+        "className": "makeStyles-metricEstimatePlot-296",
         "data": Array [
           Object {
             "line": Object {
@@ -9260,7 +9148,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-302",
+        "className": "makeStyles-metricEstimatePlot-296",
         "data": Array [
           Object {
             "line": Object {
@@ -9356,7 +9244,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-302",
+        "className": "makeStyles-metricEstimatePlot-296",
         "data": Array [
           Object {
             "line": Object {
@@ -9487,13 +9375,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-318"
+    class="makeStyles-root-312"
   >
     <div
-      class="makeStyles-summary-319"
+      class="makeStyles-summary-313"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-330 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-324 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -9502,16 +9390,16 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-321"
+        class="makeStyles-summaryColumn-315"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-322 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-316 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-323"
+            class="makeStyles-summaryStatsPart-317"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-325 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-319 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               700
             </h3>
@@ -9527,12 +9415,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-323"
+            class="makeStyles-summaryStatsPart-317"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-325 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-319 MuiTypography-h3 MuiTypography-colorPrimary"
             >
-              Deploy either variation
+              <span>
+                Deploy either variation
+              </span>
             </h3>
             <h6
               class="MuiTypography-root MuiTypography-subtitle1"
@@ -9545,12 +9435,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-326 makeStyles-indicationSeverityError-329 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-320 makeStyles-indicationSeverityError-323 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-325 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-319 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Serious issues
             </h3>
@@ -9567,30 +9457,16 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-332 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-326 MuiTypography-h3"
     >
-      <span>
-        Metric Assignment Results
-      </span>
-       
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-infoIcon-341"
-        focusable="false"
-        title="Results that are both practically and statistically significant are indicated in bold.  Insignificant results are indicated by a lighter grey."
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
-        />
-      </svg>
+      Metric Assignment Results
     </h3>
     <div
       class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-347"
+        class="Component-horizontalScrollContainer-340"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -9609,33 +9485,33 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-348 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-341 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-348 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-341 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric (attribution window)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-348 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-341 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Absolute change
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-348 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-341 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Relative change (lift)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-348 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-341 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -9686,7 +9562,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-338"
+                        class="makeStyles-metricAssignmentNameLine-332"
                       >
                         <span
                           class=""
@@ -9700,7 +9576,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       </span>
                       <br />
                       <span
-                        class="makeStyles-root-349"
+                        class="makeStyles-root-342"
                       >
                         primary
                       </span>
@@ -9709,49 +9585,41 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-340"
+                      <span
+                        class=""
                       >
-                        <span
-                          class=""
-                        >
-                          -0.01
-                           to 
-                          +
-                          0.01
-                           
-                          USD
-                        </span>
-                      </div>
+                        -0.01
+                         to 
+                        +
+                        0.01
+                         
+                        USD
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-340"
+                      <span
+                        class=""
                       >
-                        <span
-                          class=""
-                        >
-                          -50
-                           to 
-                          +
-                          50
-                           
-                          %
-                        </span>
-                      </div>
+                        -50
+                         to 
+                        +
+                        50
+                         
+                        %
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-340"
+                      <span
+                        class=""
                       >
                         Deploy either variation
-                      </div>
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -9794,7 +9662,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-338"
+                        class="makeStyles-metricAssignmentNameLine-332"
                       >
                         <span
                           class=""
@@ -9819,11 +9687,11 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-340"
+                      <span
+                        class=""
                       >
                         Not analyzed yet
-                      </div>
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -9866,7 +9734,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-338"
+                        class="makeStyles-metricAssignmentNameLine-332"
                       >
                         <span
                           class=""
@@ -9891,11 +9759,11 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-340"
+                      <span
+                        class=""
                       >
                         Not analyzed yet
-                      </div>
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -9938,7 +9806,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-338"
+                        class="makeStyles-metricAssignmentNameLine-332"
                       >
                         <span
                           class=""
@@ -9955,49 +9823,41 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-340"
+                      <span
+                        class=""
                       >
-                        <span
-                          class=""
-                        >
-                          -0.01
-                           to 
-                          +
-                          0.01
-                           
-                          USD
-                        </span>
-                      </div>
+                        -0.01
+                         to 
+                        +
+                        0.01
+                         
+                        USD
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-340"
+                      <span
+                        class=""
                       >
-                        <span
-                          class=""
-                        >
-                          -50
-                           to 
-                          +
-                          50
-                           
-                          %
-                        </span>
-                      </div>
+                        -50
+                         to 
+                        +
+                        50
+                         
+                        %
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <div
-                        class="makeStyles-significanceStatusNo-340"
+                      <span
+                        class=""
                       >
                         Deploy either variation
-                      </div>
+                      </span>
                     </td>
                   </tr>
                 </tbody>
@@ -10008,7 +9868,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-332 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-326 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -10090,18 +9950,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-346 makeStyles-deemphasized-347 makeStyles-nowrap-348"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-360"
+                  class="makeStyles-tooltip-353"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-346 makeStyles-deemphasized-347 makeStyles-nowrap-348"
                 scope="row"
               >
                 1.0000
@@ -10113,7 +9973,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-356 makeStyles-indicationSeverityOk-357 makeStyles-monospace-353 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-349 makeStyles-indicationSeverityOk-350 makeStyles-monospace-346 makeStyles-nowrap-348"
                 scope="row"
               >
                 <span>
@@ -10121,13 +9981,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-346 makeStyles-deemphasized-347 makeStyles-nowrap-348"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-354"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-347"
                 scope="row"
               >
                 <p
@@ -10151,18 +10011,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-346 makeStyles-deemphasized-347 makeStyles-nowrap-348"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-360"
+                  class="makeStyles-tooltip-353"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-346 makeStyles-deemphasized-347 makeStyles-nowrap-348"
                 scope="row"
               >
                 1.0000
@@ -10174,7 +10034,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-356 makeStyles-indicationSeverityOk-357 makeStyles-monospace-353 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-349 makeStyles-indicationSeverityOk-350 makeStyles-monospace-346 makeStyles-nowrap-348"
                 scope="row"
               >
                 <span>
@@ -10182,13 +10042,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-346 makeStyles-deemphasized-347 makeStyles-nowrap-348"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-354"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-347"
                 scope="row"
               >
                 <p
@@ -10212,18 +10072,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-346 makeStyles-deemphasized-347 makeStyles-nowrap-348"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-360"
+                  class="makeStyles-tooltip-353"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-346 makeStyles-deemphasized-347 makeStyles-nowrap-348"
                 scope="row"
               >
                 1.0000
@@ -10235,7 +10095,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-356 makeStyles-indicationSeverityOk-357 makeStyles-monospace-353 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-349 makeStyles-indicationSeverityOk-350 makeStyles-monospace-346 makeStyles-nowrap-348"
                 scope="row"
               >
                 <span>
@@ -10243,13 +10103,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-346 makeStyles-deemphasized-347 makeStyles-nowrap-348"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-354"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-347"
                 scope="row"
               >
                 <p
@@ -10273,7 +10133,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-346 makeStyles-deemphasized-347 makeStyles-nowrap-348"
                 scope="row"
               >
                 <span>
@@ -10281,7 +10141,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-346 makeStyles-deemphasized-347 makeStyles-nowrap-348"
                 scope="row"
               >
                 0.1000
@@ -10295,7 +10155,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-356 makeStyles-indicationSeverityError-359 makeStyles-monospace-353 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-349 makeStyles-indicationSeverityError-352 makeStyles-monospace-346 makeStyles-nowrap-348"
                 scope="row"
               >
                 <span>
@@ -10303,13 +10163,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-346 makeStyles-deemphasized-347 makeStyles-nowrap-348"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-354"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-347"
                 scope="row"
               >
                 <p
@@ -10335,7 +10195,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-346 makeStyles-deemphasized-347 makeStyles-nowrap-348"
                 scope="row"
               >
                 <span>
@@ -10343,7 +10203,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-346 makeStyles-deemphasized-347 makeStyles-nowrap-348"
                 scope="row"
               >
                 0.1500
@@ -10357,7 +10217,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-356 makeStyles-indicationSeverityWarning-358 makeStyles-monospace-353 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-349 makeStyles-indicationSeverityWarning-351 makeStyles-monospace-346 makeStyles-nowrap-348"
                 scope="row"
               >
                 <span>
@@ -10365,13 +10225,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-346 makeStyles-deemphasized-347 makeStyles-nowrap-348"
                 scope="row"
               >
                 0.1 &lt; x ≤ 0.4
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-354"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-347"
                 scope="row"
               >
                 <p
@@ -10397,7 +10257,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-346 makeStyles-deemphasized-347 makeStyles-nowrap-348"
                 scope="row"
               >
                 <span>
@@ -10405,7 +10265,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-346 makeStyles-deemphasized-347 makeStyles-nowrap-348"
                 scope="row"
               >
                 0.1000
@@ -10417,7 +10277,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-356 makeStyles-indicationSeverityOk-357 makeStyles-monospace-353 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-349 makeStyles-indicationSeverityOk-350 makeStyles-monospace-346 makeStyles-nowrap-348"
                 scope="row"
               >
                 <span>
@@ -10425,13 +10285,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-346 makeStyles-deemphasized-347 makeStyles-nowrap-348"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.8
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-354"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-347"
                 scope="row"
               >
                 <p
@@ -10455,7 +10315,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-346 makeStyles-deemphasized-347 makeStyles-nowrap-348"
                 scope="row"
               >
                 <span>
@@ -10463,7 +10323,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-346 makeStyles-deemphasized-347 makeStyles-nowrap-348"
                 scope="row"
               >
                 0.0000
@@ -10477,7 +10337,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-356 makeStyles-indicationSeverityWarning-358 makeStyles-monospace-353 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-349 makeStyles-indicationSeverityWarning-351 makeStyles-monospace-346 makeStyles-nowrap-348"
                 scope="row"
               >
                 <span>
@@ -10485,13 +10345,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-346 makeStyles-deemphasized-347 makeStyles-nowrap-348"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-354"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-347"
                 scope="row"
               >
                 <p
@@ -10506,7 +10366,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <div
-      class="makeStyles-accordions-333"
+      class="makeStyles-accordions-327"
     >
       <div
         class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -10565,7 +10425,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-334"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-328"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -10725,7 +10585,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-334"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-328"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -10738,7 +10598,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                   </p>
                   <pre
-                    class="makeStyles-pre-336"
+                    class="makeStyles-pre-330"
                   >
                     <code>
                       with tracks_counts as (
@@ -10772,10 +10632,10 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders the condensed table with some analyses in non-debug mode for a Revenue Metric 2`] = `
 <div
-  class="makeStyles-root-361 analysis-detail-panel"
+  class="makeStyles-root-354 analysis-detail-panel"
 >
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-375 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-368 MuiTypography-body1"
   >
     Summary
   </p>
@@ -10795,9 +10655,11 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableCell-root MuiTableCell-body"
           >
             <h5
-              class="MuiTypography-root makeStyles-recommendation-374 MuiTypography-h5 MuiTypography-gutterBottom"
+              class="MuiTypography-root makeStyles-recommendation-367 MuiTypography-h5 MuiTypography-gutterBottom"
             >
-              Deploy either variation
+              <span>
+                Deploy either variation
+              </span>
             </h5>
             <p
               class="MuiTypography-root MuiTypography-body1"
@@ -10858,7 +10720,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </strong>
              
             <span
-              class="makeStyles-root-379"
+              class="makeStyles-root-372"
               title="09/05/2020, 20:00:00"
             >
               2020-05-10
@@ -10883,7 +10745,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-375 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-368 MuiTypography-body1"
   >
     Analysis
   </p>
@@ -10891,7 +10753,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     class="MuiPaper-root MuiTableContainer-root MuiPaper-elevation1 MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-coolTable-376"
+      class="MuiTable-root makeStyles-coolTable-369"
     >
       <thead
         class="MuiTableHead-root"
@@ -10932,22 +10794,22 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-369 makeStyles-headerCell-362 makeStyles-credibleIntervalHeader-373"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-362 makeStyles-headerCell-355 makeStyles-credibleIntervalHeader-366"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-363"
+              class="makeStyles-monospace-356"
             >
               test
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-363 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-356 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-351"
+              class="makeStyles-tooltipped-344"
             >
               -1.12
                to 
@@ -10957,10 +10819,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-363 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-356 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-351"
+              class="makeStyles-tooltipped-344"
             >
               -0.01
                to 
@@ -10971,10 +10833,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-363 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-356 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-351"
+              class="makeStyles-tooltipped-344"
             >
               -50
                to 
@@ -10989,22 +10851,22 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-369 makeStyles-headerCell-362 makeStyles-credibleIntervalHeader-373"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-362 makeStyles-headerCell-355 makeStyles-credibleIntervalHeader-366"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-363"
+              class="makeStyles-monospace-356"
             >
               control
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-363 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-356 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-351"
+              class="makeStyles-tooltipped-344"
             >
               0.00
                to 
@@ -11014,12 +10876,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-363 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-356 MuiTableCell-alignRight"
           >
             Baseline
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-363 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-356 MuiTableCell-alignRight"
           >
             Baseline
           </td>
@@ -11028,7 +10890,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-analysisFinePrint-372 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-analysisFinePrint-365 MuiTypography-body1"
   >
     95% Credible Intervals (CIs). 
     <strong>
@@ -11041,15 +10903,15 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     .
   </p>
   <div
-    class="makeStyles-metricEstimatePlots-364"
+    class="makeStyles-metricEstimatePlots-357"
   />
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-375 makeStyles-clickable-377 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-368 makeStyles-clickable-370 MuiTypography-body1"
     role="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-378"
+      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-371"
       focusable="false"
       viewBox="0 0 24 24"
     >
@@ -11067,7 +10929,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-331",
+        "className": "makeStyles-participantsPlot-325",
         "data": Array [
           Object {
             "line": Object {
@@ -11126,7 +10988,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-365",
+        "className": "makeStyles-metricEstimatePlot-358",
         "data": Array [
           Object {
             "line": Object {
@@ -11222,7 +11084,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-365",
+        "className": "makeStyles-metricEstimatePlot-358",
         "data": Array [
           Object {
             "line": Object {
@@ -11324,7 +11186,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-365",
+        "className": "makeStyles-metricEstimatePlot-358",
         "data": Array [
           Object {
             "line": Object {
@@ -11420,7 +11282,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-365",
+        "className": "makeStyles-metricEstimatePlot-358",
         "data": Array [
           Object {
             "line": Object {

--- a/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`allows you to change analysis strategy 1`] = `
     class="analysis-latest-results"
   >
     <div
-      class="makeStyles-root-359"
+      class="makeStyles-root-380"
     >
       <div
-        class="makeStyles-summary-360"
+        class="makeStyles-summary-381"
       >
         <div
-          class="MuiPaper-root makeStyles-participantsPlotPaper-371 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-participantsPlotPaper-392 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <h3
             class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -21,16 +21,16 @@ exports[`allows you to change analysis strategy 1`] = `
           </h3>
         </div>
         <div
-          class="makeStyles-summaryColumn-362"
+          class="makeStyles-summaryColumn-383"
         >
           <div
-            class="MuiPaper-root makeStyles-summaryStatsPaper-363 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-summaryStatsPaper-384 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-summaryStatsPart-364"
+              class="makeStyles-summaryStatsPart-385"
             >
               <h3
-                class="MuiTypography-root makeStyles-summaryStatsStat-366 MuiTypography-h3 MuiTypography-colorPrimary"
+                class="MuiTypography-root makeStyles-summaryStatsStat-387 MuiTypography-h3 MuiTypography-colorPrimary"
               >
                 1,000
               </h3>
@@ -46,10 +46,10 @@ exports[`allows you to change analysis strategy 1`] = `
               </h6>
             </div>
             <div
-              class="makeStyles-summaryStatsPart-364"
+              class="makeStyles-summaryStatsPart-385"
             >
               <h3
-                class="MuiTypography-root makeStyles-summaryStatsStat-366 MuiTypography-h3 MuiTypography-colorPrimary"
+                class="MuiTypography-root makeStyles-summaryStatsStat-387 MuiTypography-h3 MuiTypography-colorPrimary"
               >
                 Deploy either variation
               </h3>
@@ -64,12 +64,12 @@ exports[`allows you to change analysis strategy 1`] = `
             </div>
           </div>
           <a
-            class="MuiPaper-root makeStyles-summaryHealthPaper-367 makeStyles-indicationSeverityWarning-369 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-summaryHealthPaper-388 makeStyles-indicationSeverityWarning-390 MuiPaper-elevation1 MuiPaper-rounded"
             href="#health-report"
           >
             <div>
               <h3
-                class="MuiTypography-root makeStyles-summaryStatsStat-366 MuiTypography-h3 MuiTypography-colorPrimary"
+                class="MuiTypography-root makeStyles-summaryStatsStat-387 MuiTypography-h3 MuiTypography-colorPrimary"
               >
                 Potential issues
               </h3>
@@ -86,16 +86,30 @@ exports[`allows you to change analysis strategy 1`] = `
         </div>
       </div>
       <h3
-        class="MuiTypography-root makeStyles-tableTitle-373 MuiTypography-h3"
+        class="MuiTypography-root makeStyles-tableTitle-394 MuiTypography-h3"
       >
-        Metric Assignment Results
+        <span>
+          Metric Assignment Results
+        </span>
+         
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root makeStyles-infoIcon-403"
+          focusable="false"
+          title="Results that are both practically and statistically significant are indicated in bold.  Insignificant results are indicated by a lighter grey."
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+          />
+        </svg>
       </h3>
       <div
         class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
         style="position: relative;"
       >
         <div
-          class="Component-horizontalScrollContainer-385"
+          class="Component-horizontalScrollContainer-409"
           style="overflow-x: auto; position: relative;"
         >
           <div>
@@ -114,33 +128,33 @@ exports[`allows you to change analysis strategy 1`] = `
                       class="MuiTableRow-root MuiTableRow-head"
                     >
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-386 MuiTableCell-paddingNone"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-410 MuiTableCell-paddingNone"
                         scope="col"
                         style="font-weight: 700;"
                       />
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-386 MuiTableCell-alignLeft"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-410 MuiTableCell-alignLeft"
                         scope="col"
                         style="font-weight: 700; box-sizing: border-box;"
                       >
                         Metric (attribution window)
                       </th>
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-386 MuiTableCell-alignLeft"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-410 MuiTableCell-alignLeft"
                         scope="col"
                         style="font-weight: 700; box-sizing: border-box;"
                       >
                         Absolute change
                       </th>
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-386 MuiTableCell-alignLeft"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-410 MuiTableCell-alignLeft"
                         scope="col"
                         style="font-weight: 700; box-sizing: border-box;"
                       >
                         Relative change (lift)
                       </th>
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-386 MuiTableCell-alignLeft"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-410 MuiTableCell-alignLeft"
                         scope="col"
                         style="font-weight: 700; box-sizing: border-box;"
                       >
@@ -191,7 +205,7 @@ exports[`allows you to change analysis strategy 1`] = `
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                       >
                         <span
-                          class="makeStyles-metricAssignmentNameLine-379"
+                          class="makeStyles-metricAssignmentNameLine-400"
                         >
                           <span
                             class=""
@@ -205,7 +219,7 @@ exports[`allows you to change analysis strategy 1`] = `
                         </span>
                         <br />
                         <span
-                          class="makeStyles-root-387"
+                          class="makeStyles-root-411"
                         >
                           primary
                         </span>
@@ -214,37 +228,49 @@ exports[`allows you to change analysis strategy 1`] = `
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                       >
-                        <span
-                          class=""
+                        <div
+                          class="makeStyles-significanceStatusNo-402"
                         >
-                          -1
-                           to 
-                          +
-                          1
-                           
-                          pp
-                        </span>
+                          <span
+                            class=""
+                          >
+                            -1
+                             to 
+                            +
+                            1
+                             
+                            pp
+                          </span>
+                        </div>
                       </td>
                       <td
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                       >
-                        <span
-                          class=""
+                        <div
+                          class="makeStyles-significanceStatusNo-402"
                         >
-                          -50
-                           to 
-                          +
-                          50
-                           
-                          %
-                        </span>
+                          <span
+                            class=""
+                          >
+                            -50
+                             to 
+                            +
+                            50
+                             
+                            %
+                          </span>
+                        </div>
                       </td>
                       <td
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                       >
-                        Deploy either variation
+                        <div
+                          class="makeStyles-significanceStatusNo-402"
+                        >
+                          Deploy either variation
+                        </div>
                       </td>
                     </tr>
                     <tr
@@ -287,7 +313,7 @@ exports[`allows you to change analysis strategy 1`] = `
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                       >
                         <span
-                          class="makeStyles-metricAssignmentNameLine-379"
+                          class="makeStyles-metricAssignmentNameLine-400"
                         >
                           <span
                             class=""
@@ -312,7 +338,11 @@ exports[`allows you to change analysis strategy 1`] = `
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                       >
-                        Not analyzed yet
+                        <div
+                          class="makeStyles-significanceStatusNo-402"
+                        >
+                          Not analyzed yet
+                        </div>
                       </td>
                     </tr>
                     <tr
@@ -355,7 +385,7 @@ exports[`allows you to change analysis strategy 1`] = `
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                       >
                         <span
-                          class="makeStyles-metricAssignmentNameLine-379"
+                          class="makeStyles-metricAssignmentNameLine-400"
                         >
                           <span
                             class=""
@@ -380,7 +410,11 @@ exports[`allows you to change analysis strategy 1`] = `
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                       >
-                        Not analyzed yet
+                        <div
+                          class="makeStyles-significanceStatusNo-402"
+                        >
+                          Not analyzed yet
+                        </div>
                       </td>
                     </tr>
                     <tr
@@ -423,7 +457,7 @@ exports[`allows you to change analysis strategy 1`] = `
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                       >
                         <span
-                          class="makeStyles-metricAssignmentNameLine-379"
+                          class="makeStyles-metricAssignmentNameLine-400"
                         >
                           <span
                             class=""
@@ -448,7 +482,11 @@ exports[`allows you to change analysis strategy 1`] = `
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                       >
-                        Not analyzed yet
+                        <div
+                          class="makeStyles-significanceStatusNo-402"
+                        >
+                          Not analyzed yet
+                        </div>
                       </td>
                     </tr>
                   </tbody>
@@ -459,7 +497,7 @@ exports[`allows you to change analysis strategy 1`] = `
         </div>
       </div>
       <h3
-        class="MuiTypography-root makeStyles-tableTitle-373 MuiTypography-h3"
+        class="MuiTypography-root makeStyles-tableTitle-394 MuiTypography-h3"
       >
         Health Report
       </h3>
@@ -541,18 +579,18 @@ exports[`allows you to change analysis strategy 1`] = `
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-391 makeStyles-deemphasized-392 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
                   scope="row"
                 >
                   <span
-                    class="makeStyles-tooltip-398"
+                    class="makeStyles-tooltip-422"
                     title="The smaller the p-value the more likely there is an issue."
                   >
                     p-value
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-391 makeStyles-deemphasized-392 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
                   scope="row"
                 >
                   1.0000
@@ -564,7 +602,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   <span />
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-394 makeStyles-indicationSeverityOk-395 makeStyles-monospace-391 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-418 makeStyles-indicationSeverityOk-419 makeStyles-monospace-415 makeStyles-nowrap-417"
                   scope="row"
                 >
                   <span>
@@ -572,13 +610,13 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-391 makeStyles-deemphasized-392 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
                   scope="row"
                 >
                   0.05 &lt; x ≤ 1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-392"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-416"
                   scope="row"
                 >
                   <p
@@ -602,18 +640,18 @@ exports[`allows you to change analysis strategy 1`] = `
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-391 makeStyles-deemphasized-392 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
                   scope="row"
                 >
                   <span
-                    class="makeStyles-tooltip-398"
+                    class="makeStyles-tooltip-422"
                     title="The smaller the p-value the more likely there is an issue."
                   >
                     p-value
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-391 makeStyles-deemphasized-392 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
                   scope="row"
                 >
                   1.0000
@@ -625,7 +663,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   <span />
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-394 makeStyles-indicationSeverityOk-395 makeStyles-monospace-391 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-418 makeStyles-indicationSeverityOk-419 makeStyles-monospace-415 makeStyles-nowrap-417"
                   scope="row"
                 >
                   <span>
@@ -633,13 +671,13 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-391 makeStyles-deemphasized-392 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
                   scope="row"
                 >
                   0.05 &lt; x ≤ 1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-392"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-416"
                   scope="row"
                 >
                   <p
@@ -663,7 +701,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-391 makeStyles-deemphasized-392 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
                   scope="row"
                 >
                   <span>
@@ -671,7 +709,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-391 makeStyles-deemphasized-392 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
                   scope="row"
                 >
                   0.0000
@@ -683,7 +721,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   <span />
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-394 makeStyles-indicationSeverityOk-395 makeStyles-monospace-391 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-418 makeStyles-indicationSeverityOk-419 makeStyles-monospace-415 makeStyles-nowrap-417"
                   scope="row"
                 >
                   <span>
@@ -691,13 +729,13 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-391 makeStyles-deemphasized-392 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
                   scope="row"
                 >
                   −∞ &lt; x ≤ 0.01
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-392"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-416"
                   scope="row"
                 >
                   <p
@@ -721,7 +759,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-391 makeStyles-deemphasized-392 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
                   scope="row"
                 >
                   <span>
@@ -729,7 +767,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-391 makeStyles-deemphasized-392 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
                   scope="row"
                 >
                   0.0000
@@ -741,7 +779,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   <span />
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-394 makeStyles-indicationSeverityOk-395 makeStyles-monospace-391 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-418 makeStyles-indicationSeverityOk-419 makeStyles-monospace-415 makeStyles-nowrap-417"
                   scope="row"
                 >
                   <span>
@@ -749,13 +787,13 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-391 makeStyles-deemphasized-392 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
                   scope="row"
                 >
                   −∞ &lt; x ≤ 0.1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-392"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-416"
                   scope="row"
                 >
                   <p
@@ -779,7 +817,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-391 makeStyles-deemphasized-392 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
                   scope="row"
                 >
                   <span>
@@ -787,7 +825,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-391 makeStyles-deemphasized-392 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
                   scope="row"
                 >
                   0.1000
@@ -799,7 +837,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   <span />
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-394 makeStyles-indicationSeverityOk-395 makeStyles-monospace-391 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-418 makeStyles-indicationSeverityOk-419 makeStyles-monospace-415 makeStyles-nowrap-417"
                   scope="row"
                 >
                   <span>
@@ -807,13 +845,13 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-391 makeStyles-deemphasized-392 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
                   scope="row"
                 >
                   −∞ &lt; x ≤ 0.8
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-392"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-416"
                   scope="row"
                 >
                   <p
@@ -837,7 +875,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-391 makeStyles-deemphasized-392 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
                   scope="row"
                 >
                   <span>
@@ -845,7 +883,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-391 makeStyles-deemphasized-392 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
                   scope="row"
                 >
                   0.0000
@@ -859,7 +897,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-394 makeStyles-indicationSeverityWarning-396 makeStyles-monospace-391 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-418 makeStyles-indicationSeverityWarning-420 makeStyles-monospace-415 makeStyles-nowrap-417"
                   scope="row"
                 >
                   <span>
@@ -867,13 +905,13 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-391 makeStyles-deemphasized-392 makeStyles-nowrap-393"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-415 makeStyles-deemphasized-416 makeStyles-nowrap-417"
                   scope="row"
                 >
                   −∞ &lt; x ≤ 3
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-392"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-416"
                   scope="row"
                 >
                   <p
@@ -888,7 +926,7 @@ exports[`allows you to change analysis strategy 1`] = `
         </div>
       </div>
       <div
-        class="makeStyles-accordions-374"
+        class="makeStyles-accordions-395"
       >
         <div
           class="MuiPaper-root MuiAccordion-root Mui-expanded MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -947,7 +985,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   role="region"
                 >
                   <div
-                    class="MuiAccordionDetails-root makeStyles-accordionDetails-375"
+                    class="MuiAccordionDetails-root makeStyles-accordionDetails-396"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -1106,7 +1144,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   role="region"
                 >
                   <div
-                    class="MuiAccordionDetails-root makeStyles-accordionDetails-375"
+                    class="MuiAccordionDetails-root makeStyles-accordionDetails-396"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -1119,7 +1157,7 @@ exports[`allows you to change analysis strategy 1`] = `
                       This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                     </p>
                     <pre
-                      class="makeStyles-pre-377"
+                      class="makeStyles-pre-398"
                     >
                       <code>
                         with tracks_counts as (
@@ -1158,13 +1196,13 @@ exports[`renders an appropriate message for analyses missing analysis data due t
     class="analysis-latest-results"
   >
     <div
-      class="makeStyles-root-22"
+      class="makeStyles-root-25"
     >
       <div
-        class="makeStyles-summary-23"
+        class="makeStyles-summary-26"
       >
         <div
-          class="MuiPaper-root makeStyles-participantsPlotPaper-34 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-participantsPlotPaper-37 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <h3
             class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -1173,16 +1211,16 @@ exports[`renders an appropriate message for analyses missing analysis data due t
           </h3>
         </div>
         <div
-          class="makeStyles-summaryColumn-25"
+          class="makeStyles-summaryColumn-28"
         >
           <div
-            class="MuiPaper-root makeStyles-summaryStatsPaper-26 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-summaryStatsPaper-29 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-summaryStatsPart-27"
+              class="makeStyles-summaryStatsPart-30"
             >
               <h3
-                class="MuiTypography-root makeStyles-summaryStatsStat-29 MuiTypography-h3 MuiTypography-colorPrimary"
+                class="MuiTypography-root makeStyles-summaryStatsStat-32 MuiTypography-h3 MuiTypography-colorPrimary"
               >
                 1,000
               </h3>
@@ -1198,10 +1236,10 @@ exports[`renders an appropriate message for analyses missing analysis data due t
               </h6>
             </div>
             <div
-              class="makeStyles-summaryStatsPart-27"
+              class="makeStyles-summaryStatsPart-30"
             >
               <h3
-                class="MuiTypography-root makeStyles-summaryStatsStat-29 MuiTypography-h3 MuiTypography-colorPrimary"
+                class="MuiTypography-root makeStyles-summaryStatsStat-32 MuiTypography-h3 MuiTypography-colorPrimary"
               >
                 Not analyzed yet
               </h3>
@@ -1216,12 +1254,12 @@ exports[`renders an appropriate message for analyses missing analysis data due t
             </div>
           </div>
           <a
-            class="MuiPaper-root makeStyles-summaryHealthPaper-30 makeStyles-indicationSeverityError-33 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-summaryHealthPaper-33 makeStyles-indicationSeverityError-36 MuiPaper-elevation1 MuiPaper-rounded"
             href="#health-report"
           >
             <div>
               <h3
-                class="MuiTypography-root makeStyles-summaryStatsStat-29 MuiTypography-h3 MuiTypography-colorPrimary"
+                class="MuiTypography-root makeStyles-summaryStatsStat-32 MuiTypography-h3 MuiTypography-colorPrimary"
               >
                 Serious issues
               </h3>
@@ -1238,16 +1276,30 @@ exports[`renders an appropriate message for analyses missing analysis data due t
         </div>
       </div>
       <h3
-        class="MuiTypography-root makeStyles-tableTitle-36 MuiTypography-h3"
+        class="MuiTypography-root makeStyles-tableTitle-39 MuiTypography-h3"
       >
-        Metric Assignment Results
+        <span>
+          Metric Assignment Results
+        </span>
+         
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root makeStyles-infoIcon-48"
+          focusable="false"
+          title="Results that are both practically and statistically significant are indicated in bold.  Insignificant results are indicated by a lighter grey."
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+          />
+        </svg>
       </h3>
       <div
         class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
         style="position: relative;"
       >
         <div
-          class="Component-horizontalScrollContainer-48"
+          class="Component-horizontalScrollContainer-54"
           style="overflow-x: auto; position: relative;"
         >
           <div>
@@ -1266,33 +1318,33 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                       class="MuiTableRow-root MuiTableRow-head"
                     >
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-49 MuiTableCell-paddingNone"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-55 MuiTableCell-paddingNone"
                         scope="col"
                         style="font-weight: 700;"
                       />
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-49 MuiTableCell-alignLeft"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-55 MuiTableCell-alignLeft"
                         scope="col"
                         style="font-weight: 700; box-sizing: border-box;"
                       >
                         Metric (attribution window)
                       </th>
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-49 MuiTableCell-alignLeft"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-55 MuiTableCell-alignLeft"
                         scope="col"
                         style="font-weight: 700; box-sizing: border-box;"
                       >
                         Absolute change
                       </th>
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-49 MuiTableCell-alignLeft"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-55 MuiTableCell-alignLeft"
                         scope="col"
                         style="font-weight: 700; box-sizing: border-box;"
                       >
                         Relative change (lift)
                       </th>
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-49 MuiTableCell-alignLeft"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-55 MuiTableCell-alignLeft"
                         scope="col"
                         style="font-weight: 700; box-sizing: border-box;"
                       >
@@ -1343,7 +1395,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                       >
                         <span
-                          class="makeStyles-metricAssignmentNameLine-42"
+                          class="makeStyles-metricAssignmentNameLine-45"
                         >
                           <span
                             class=""
@@ -1357,7 +1409,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                         </span>
                         <br />
                         <span
-                          class="makeStyles-root-50"
+                          class="makeStyles-root-56"
                         >
                           primary
                         </span>
@@ -1374,7 +1426,11 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                       >
-                        Not analyzed yet
+                        <div
+                          class="makeStyles-significanceStatusNo-47"
+                        >
+                          Not analyzed yet
+                        </div>
                       </td>
                     </tr>
                     <tr
@@ -1417,7 +1473,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                       >
                         <span
-                          class="makeStyles-metricAssignmentNameLine-42"
+                          class="makeStyles-metricAssignmentNameLine-45"
                         >
                           <span
                             class=""
@@ -1442,7 +1498,11 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                       >
-                        Not analyzed yet
+                        <div
+                          class="makeStyles-significanceStatusNo-47"
+                        >
+                          Not analyzed yet
+                        </div>
                       </td>
                     </tr>
                     <tr
@@ -1485,7 +1545,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                       >
                         <span
-                          class="makeStyles-metricAssignmentNameLine-42"
+                          class="makeStyles-metricAssignmentNameLine-45"
                         >
                           <span
                             class=""
@@ -1510,7 +1570,11 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                       >
-                        Not analyzed yet
+                        <div
+                          class="makeStyles-significanceStatusNo-47"
+                        >
+                          Not analyzed yet
+                        </div>
                       </td>
                     </tr>
                     <tr
@@ -1553,7 +1617,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                       >
                         <span
-                          class="makeStyles-metricAssignmentNameLine-42"
+                          class="makeStyles-metricAssignmentNameLine-45"
                         >
                           <span
                             class=""
@@ -1578,7 +1642,11 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                       >
-                        Not analyzed yet
+                        <div
+                          class="makeStyles-significanceStatusNo-47"
+                        >
+                          Not analyzed yet
+                        </div>
                       </td>
                     </tr>
                   </tbody>
@@ -1589,7 +1657,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
         </div>
       </div>
       <h3
-        class="MuiTypography-root makeStyles-tableTitle-36 MuiTypography-h3"
+        class="MuiTypography-root makeStyles-tableTitle-39 MuiTypography-h3"
       >
         Health Report
       </h3>
@@ -1671,18 +1739,18 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
                   scope="row"
                 >
                   <span
-                    class="makeStyles-tooltip-59"
+                    class="makeStyles-tooltip-65"
                     title="The smaller the p-value the more likely there is an issue."
                   >
                     p-value
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
                   scope="row"
                 >
                   1.0000
@@ -1694,7 +1762,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   <span />
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-55 makeStyles-indicationSeverityOk-56 makeStyles-monospace-52 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-61 makeStyles-indicationSeverityOk-62 makeStyles-monospace-58 makeStyles-nowrap-60"
                   scope="row"
                 >
                   <span>
@@ -1702,13 +1770,13 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
                   scope="row"
                 >
                   0.05 &lt; x ≤ 1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-53"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-59"
                   scope="row"
                 >
                   <p
@@ -1732,18 +1800,18 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
                   scope="row"
                 >
                   <span
-                    class="makeStyles-tooltip-59"
+                    class="makeStyles-tooltip-65"
                     title="The smaller the p-value the more likely there is an issue."
                   >
                     p-value
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
                   scope="row"
                 >
                   1.0000
@@ -1755,7 +1823,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   <span />
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-55 makeStyles-indicationSeverityOk-56 makeStyles-monospace-52 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-61 makeStyles-indicationSeverityOk-62 makeStyles-monospace-58 makeStyles-nowrap-60"
                   scope="row"
                 >
                   <span>
@@ -1763,13 +1831,13 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
                   scope="row"
                 >
                   0.05 &lt; x ≤ 1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-53"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-59"
                   scope="row"
                 >
                   <p
@@ -1793,18 +1861,18 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
                   scope="row"
                 >
                   <span
-                    class="makeStyles-tooltip-59"
+                    class="makeStyles-tooltip-65"
                     title="The smaller the p-value the more likely there is an issue."
                   >
                     p-value
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
                   scope="row"
                 >
                   1.0000
@@ -1816,7 +1884,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   <span />
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-55 makeStyles-indicationSeverityOk-56 makeStyles-monospace-52 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-61 makeStyles-indicationSeverityOk-62 makeStyles-monospace-58 makeStyles-nowrap-60"
                   scope="row"
                 >
                   <span>
@@ -1824,13 +1892,13 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
                   scope="row"
                 >
                   0.05 &lt; x ≤ 1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-53"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-59"
                   scope="row"
                 >
                   <p
@@ -1854,7 +1922,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
                   scope="row"
                 >
                   <span>
@@ -1862,7 +1930,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
                   scope="row"
                 >
                   NaN
@@ -1876,7 +1944,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-55 makeStyles-indicationSeverityError-58 makeStyles-monospace-52 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-61 makeStyles-indicationSeverityError-64 makeStyles-monospace-58 makeStyles-nowrap-60"
                   scope="row"
                 >
                   <span>
@@ -1884,13 +1952,13 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
                   scope="row"
                 >
                   Unexpected value
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-53"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-59"
                   scope="row"
                 >
                   <p
@@ -1916,7 +1984,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
                   scope="row"
                 >
                   <span>
@@ -1924,7 +1992,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
                   scope="row"
                 >
                   NaN
@@ -1938,7 +2006,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-55 makeStyles-indicationSeverityError-58 makeStyles-monospace-52 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-61 makeStyles-indicationSeverityError-64 makeStyles-monospace-58 makeStyles-nowrap-60"
                   scope="row"
                 >
                   <span>
@@ -1946,13 +2014,13 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
                   scope="row"
                 >
                   Unexpected value
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-53"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-59"
                   scope="row"
                 >
                   <p
@@ -1978,7 +2046,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
                   scope="row"
                 >
                   <span>
@@ -1986,7 +2054,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
                   scope="row"
                 >
                   0.0000
@@ -2000,7 +2068,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-55 makeStyles-indicationSeverityWarning-57 makeStyles-monospace-52 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-61 makeStyles-indicationSeverityWarning-63 makeStyles-monospace-58 makeStyles-nowrap-60"
                   scope="row"
                 >
                   <span>
@@ -2008,13 +2076,13 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-52 makeStyles-deemphasized-53 makeStyles-nowrap-54"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-58 makeStyles-deemphasized-59 makeStyles-nowrap-60"
                   scope="row"
                 >
                   −∞ &lt; x ≤ 3
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-53"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-59"
                   scope="row"
                 >
                   <p
@@ -2029,7 +2097,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
         </div>
       </div>
       <div
-        class="makeStyles-accordions-37"
+        class="makeStyles-accordions-40"
       >
         <div
           class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -2088,7 +2156,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   role="region"
                 >
                   <div
-                    class="MuiAccordionDetails-root makeStyles-accordionDetails-38"
+                    class="MuiAccordionDetails-root makeStyles-accordionDetails-41"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -2248,7 +2316,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                   role="region"
                 >
                   <div
-                    class="MuiAccordionDetails-root makeStyles-accordionDetails-38"
+                    class="MuiAccordionDetails-root makeStyles-accordionDetails-41"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -2261,7 +2329,7 @@ exports[`renders an appropriate message for analyses missing analysis data due t
                       This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                     </p>
                     <pre
-                      class="makeStyles-pre-40"
+                      class="makeStyles-pre-43"
                     >
                       <code>
                         with tracks_counts as (
@@ -2447,13 +2515,13 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-60"
+    class="makeStyles-root-66"
   >
     <div
-      class="makeStyles-summary-61"
+      class="makeStyles-summary-67"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-72 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-78 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -2462,16 +2530,16 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-63"
+        class="makeStyles-summaryColumn-69"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-64 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-70 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-65"
+            class="makeStyles-summaryStatsPart-71"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-67 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-73 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               1,000
             </h3>
@@ -2487,10 +2555,10 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-65"
+            class="makeStyles-summaryStatsPart-71"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-67 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-73 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Inconclusive
             </h3>
@@ -2505,12 +2573,12 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-68 makeStyles-indicationSeverityWarning-70 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-74 makeStyles-indicationSeverityWarning-76 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-67 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-73 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Potential issues
             </h3>
@@ -2527,16 +2595,30 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-74 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-80 MuiTypography-h3"
     >
-      Metric Assignment Results
+      <span>
+        Metric Assignment Results
+      </span>
+       
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root makeStyles-infoIcon-89"
+        focusable="false"
+        title="Results that are both practically and statistically significant are indicated in bold.  Insignificant results are indicated by a lighter grey."
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+        />
+      </svg>
     </h3>
     <div
       class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-86"
+        class="Component-horizontalScrollContainer-95"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -2555,33 +2637,33 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-87 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-96 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-87 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-96 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric (attribution window)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-87 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-96 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Absolute change
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-87 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-96 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Relative change (lift)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-87 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-96 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -2632,7 +2714,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-80"
+                        class="makeStyles-metricAssignmentNameLine-86"
                       >
                         <span
                           class=""
@@ -2646,7 +2728,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                       </span>
                       <br />
                       <span
-                        class="makeStyles-root-88"
+                        class="makeStyles-root-97"
                       >
                         primary
                       </span>
@@ -2655,37 +2737,49 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <span
-                        class=""
+                      <div
+                        class="makeStyles-significanceStatusNo-88"
                       >
-                        -100
-                         to 
-                        +
-                        100
-                         
-                        pp
-                      </span>
+                        <span
+                          class=""
+                        >
+                          -100
+                           to 
+                          +
+                          100
+                           
+                          pp
+                        </span>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <span
-                        class=""
+                      <div
+                        class="makeStyles-significanceStatusNo-88"
                       >
-                        -50
-                         to 
-                        +
-                        0
-                         
-                        %
-                      </span>
+                        <span
+                          class=""
+                        >
+                          -50
+                           to 
+                          +
+                          0
+                           
+                          %
+                        </span>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Inconclusive
+                      <div
+                        class="makeStyles-significanceStatusNo-88"
+                      >
+                        Inconclusive
+                      </div>
                     </td>
                   </tr>
                   <tr
@@ -2728,7 +2822,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-80"
+                        class="makeStyles-metricAssignmentNameLine-86"
                       >
                         <span
                           class=""
@@ -2753,7 +2847,11 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Not analyzed yet
+                      <div
+                        class="makeStyles-significanceStatusNo-88"
+                      >
+                        Not analyzed yet
+                      </div>
                     </td>
                   </tr>
                   <tr
@@ -2796,7 +2894,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-80"
+                        class="makeStyles-metricAssignmentNameLine-86"
                       >
                         <span
                           class=""
@@ -2821,7 +2919,11 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Not analyzed yet
+                      <div
+                        class="makeStyles-significanceStatusNo-88"
+                      >
+                        Not analyzed yet
+                      </div>
                     </td>
                   </tr>
                   <tr
@@ -2864,7 +2966,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-80"
+                        class="makeStyles-metricAssignmentNameLine-86"
                       >
                         <span
                           class=""
@@ -2889,7 +2991,11 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Not analyzed yet
+                      <div
+                        class="makeStyles-significanceStatusNo-88"
+                      >
+                        Not analyzed yet
+                      </div>
                     </td>
                   </tr>
                 </tbody>
@@ -2900,7 +3006,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-74 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-80 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -2982,18 +3088,18 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-92 makeStyles-deemphasized-93 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-99"
+                  class="makeStyles-tooltip-108"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-92 makeStyles-deemphasized-93 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
                 scope="row"
               >
                 1.0000
@@ -3005,7 +3111,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-95 makeStyles-indicationSeverityOk-96 makeStyles-monospace-92 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-104 makeStyles-indicationSeverityOk-105 makeStyles-monospace-101 makeStyles-nowrap-103"
                 scope="row"
               >
                 <span>
@@ -3013,13 +3119,13 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-92 makeStyles-deemphasized-93 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-93"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-102"
                 scope="row"
               >
                 <p
@@ -3043,18 +3149,18 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-92 makeStyles-deemphasized-93 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-99"
+                  class="makeStyles-tooltip-108"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-92 makeStyles-deemphasized-93 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
                 scope="row"
               >
                 1.0000
@@ -3066,7 +3172,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-95 makeStyles-indicationSeverityOk-96 makeStyles-monospace-92 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-104 makeStyles-indicationSeverityOk-105 makeStyles-monospace-101 makeStyles-nowrap-103"
                 scope="row"
               >
                 <span>
@@ -3074,13 +3180,13 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-92 makeStyles-deemphasized-93 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-93"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-102"
                 scope="row"
               >
                 <p
@@ -3104,18 +3210,18 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-92 makeStyles-deemphasized-93 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-99"
+                  class="makeStyles-tooltip-108"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-92 makeStyles-deemphasized-93 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
                 scope="row"
               >
                 1.0000
@@ -3127,7 +3233,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-95 makeStyles-indicationSeverityOk-96 makeStyles-monospace-92 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-104 makeStyles-indicationSeverityOk-105 makeStyles-monospace-101 makeStyles-nowrap-103"
                 scope="row"
               >
                 <span>
@@ -3135,13 +3241,13 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-92 makeStyles-deemphasized-93 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-93"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-102"
                 scope="row"
               >
                 <p
@@ -3165,7 +3271,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-92 makeStyles-deemphasized-93 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
                 scope="row"
               >
                 <span>
@@ -3173,7 +3279,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-92 makeStyles-deemphasized-93 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
                 scope="row"
               >
                 0.0000
@@ -3185,7 +3291,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-95 makeStyles-indicationSeverityOk-96 makeStyles-monospace-92 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-104 makeStyles-indicationSeverityOk-105 makeStyles-monospace-101 makeStyles-nowrap-103"
                 scope="row"
               >
                 <span>
@@ -3193,13 +3299,13 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-92 makeStyles-deemphasized-93 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.01
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-93"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-102"
                 scope="row"
               >
                 <p
@@ -3223,7 +3329,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-92 makeStyles-deemphasized-93 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
                 scope="row"
               >
                 <span>
@@ -3231,7 +3337,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-92 makeStyles-deemphasized-93 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
                 scope="row"
               >
                 0.0000
@@ -3243,7 +3349,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-95 makeStyles-indicationSeverityOk-96 makeStyles-monospace-92 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-104 makeStyles-indicationSeverityOk-105 makeStyles-monospace-101 makeStyles-nowrap-103"
                 scope="row"
               >
                 <span>
@@ -3251,13 +3357,13 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-92 makeStyles-deemphasized-93 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-93"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-102"
                 scope="row"
               >
                 <p
@@ -3281,7 +3387,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-92 makeStyles-deemphasized-93 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
                 scope="row"
               >
                 <span>
@@ -3289,7 +3395,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-92 makeStyles-deemphasized-93 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
                 scope="row"
               >
                 10.0000
@@ -3303,7 +3409,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-95 makeStyles-indicationSeverityWarning-97 makeStyles-monospace-92 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-104 makeStyles-indicationSeverityWarning-106 makeStyles-monospace-101 makeStyles-nowrap-103"
                 scope="row"
               >
                 <span>
@@ -3311,13 +3417,13 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-92 makeStyles-deemphasized-93 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
                 scope="row"
               >
                 1.5 &lt; x ≤ ∞
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-93"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-102"
                 scope="row"
               >
                 <p
@@ -3343,7 +3449,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-92 makeStyles-deemphasized-93 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
                 scope="row"
               >
                 <span>
@@ -3351,7 +3457,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-92 makeStyles-deemphasized-93 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
                 scope="row"
               >
                 0.0000
@@ -3365,7 +3471,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-95 makeStyles-indicationSeverityWarning-97 makeStyles-monospace-92 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-104 makeStyles-indicationSeverityWarning-106 makeStyles-monospace-101 makeStyles-nowrap-103"
                 scope="row"
               >
                 <span>
@@ -3373,13 +3479,13 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-92 makeStyles-deemphasized-93 makeStyles-nowrap-94"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-101 makeStyles-deemphasized-102 makeStyles-nowrap-103"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-93"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-102"
                 scope="row"
               >
                 <p
@@ -3394,7 +3500,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
       </div>
     </div>
     <div
-      class="makeStyles-accordions-75"
+      class="makeStyles-accordions-81"
     >
       <div
         class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -3453,7 +3559,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-76"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-82"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -3613,7 +3719,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-76"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-82"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -3626,7 +3732,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
                     This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                   </p>
                   <pre
-                    class="makeStyles-pre-78"
+                    class="makeStyles-pre-84"
                   >
                     <code>
                       with tracks_counts as (
@@ -3660,10 +3766,10 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders correctly for 1 analysis datapoint, not statistically significant 2`] = `
 <div
-  class="makeStyles-root-100 analysis-detail-panel"
+  class="makeStyles-root-109 analysis-detail-panel"
 >
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-114 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-123 MuiTypography-body1"
   >
     Summary
   </p>
@@ -3683,7 +3789,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
             class="MuiTableCell-root MuiTableCell-body"
           >
             <h5
-              class="MuiTypography-root makeStyles-recommendation-113 MuiTypography-h5 MuiTypography-gutterBottom"
+              class="MuiTypography-root makeStyles-recommendation-122 MuiTypography-h5 MuiTypography-gutterBottom"
             >
               Inconclusive
             </h5>
@@ -3723,7 +3829,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
               
               100
               <span
-                class="makeStyles-root-118"
+                class="makeStyles-root-127"
                 title="Percentage points."
               >
                 pp
@@ -3744,7 +3850,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
               
               10
               <span
-                class="makeStyles-root-118"
+                class="makeStyles-root-127"
                 title="Percentage points."
               >
                 pp
@@ -3756,7 +3862,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
             </strong>
              
             <span
-              class="makeStyles-root-119"
+              class="makeStyles-root-128"
               title="09/05/2020, 20:00:00"
             >
               2020-05-10
@@ -3781,7 +3887,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-114 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-123 MuiTypography-body1"
   >
     Analysis
   </p>
@@ -3789,7 +3895,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
     class="MuiPaper-root MuiTableContainer-root MuiPaper-elevation1 MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-coolTable-115"
+      class="MuiTable-root makeStyles-coolTable-124"
     >
       <thead
         class="MuiTableHead-root"
@@ -3830,22 +3936,22 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-108 makeStyles-headerCell-101 makeStyles-credibleIntervalHeader-112"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-117 makeStyles-headerCell-110 makeStyles-credibleIntervalHeader-121"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-102"
+              class="makeStyles-monospace-111"
             >
               test
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-90"
+              class="makeStyles-tooltipped-99"
             >
               50
                to 
@@ -3855,10 +3961,10 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-90"
+              class="makeStyles-tooltipped-99"
             >
               -100
                to 
@@ -3869,10 +3975,10 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-90"
+              class="makeStyles-tooltipped-99"
             >
               -50
                to 
@@ -3887,22 +3993,22 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-108 makeStyles-headerCell-101 makeStyles-credibleIntervalHeader-112"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-117 makeStyles-headerCell-110 makeStyles-credibleIntervalHeader-121"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-102"
+              class="makeStyles-monospace-111"
             >
               control
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-90"
+              class="makeStyles-tooltipped-99"
             >
               50
                to 
@@ -3912,12 +4018,12 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 MuiTableCell-alignRight"
           >
             Baseline
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-102 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-111 MuiTableCell-alignRight"
           >
             Baseline
           </td>
@@ -3926,7 +4032,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-analysisFinePrint-111 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-analysisFinePrint-120 MuiTypography-body1"
   >
     95% Credible Intervals (CIs). 
     <strong>
@@ -3936,7 +4042,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
     
     10
     <span
-      class="makeStyles-root-118"
+      class="makeStyles-root-127"
       title="Percentage points."
     >
       pp
@@ -3944,17 +4050,17 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
     .
   </p>
   <p
-    class="MuiTypography-root makeStyles-noPlotMessage-106 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-noPlotMessage-115 MuiTypography-body1"
   >
     Past values will be plotted once we have more than one day of results.
   </p>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-114 makeStyles-clickable-116 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-123 makeStyles-clickable-125 MuiTypography-body1"
     role="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-117"
+      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-126"
       focusable="false"
       viewBox="0 0 24 24"
     >
@@ -3972,7 +4078,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-73",
+        "className": "makeStyles-participantsPlot-79",
         "data": Array [
           Object {
             "line": Object {
@@ -4040,13 +4146,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-120"
+    class="makeStyles-root-129"
   >
     <div
-      class="makeStyles-summary-121"
+      class="makeStyles-summary-130"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-132 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-141 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -4055,16 +4161,16 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-123"
+        class="makeStyles-summaryColumn-132"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-124 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-133 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-125"
+            class="makeStyles-summaryStatsPart-134"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-127 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-136 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               1,000
             </h3>
@@ -4080,10 +4186,10 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-125"
+            class="makeStyles-summaryStatsPart-134"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-127 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-136 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Deploy 
               control
@@ -4099,12 +4205,12 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-128 makeStyles-indicationSeverityWarning-130 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-137 makeStyles-indicationSeverityWarning-139 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-127 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-136 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Potential issues
             </h3>
@@ -4121,16 +4227,30 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-134 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-143 MuiTypography-h3"
     >
-      Metric Assignment Results
+      <span>
+        Metric Assignment Results
+      </span>
+       
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root makeStyles-infoIcon-152"
+        focusable="false"
+        title="Results that are both practically and statistically significant are indicated in bold.  Insignificant results are indicated by a lighter grey."
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+        />
+      </svg>
     </h3>
     <div
       class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-146"
+        class="Component-horizontalScrollContainer-158"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -4149,33 +4269,33 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-147 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-147 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric (attribution window)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-147 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Absolute change
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-147 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Relative change (lift)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-147 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-159 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -4226,7 +4346,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-140"
+                        class="makeStyles-metricAssignmentNameLine-149"
                       >
                         <span
                           class=""
@@ -4240,7 +4360,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       </span>
                       <br />
                       <span
-                        class="makeStyles-root-148"
+                        class="makeStyles-root-160"
                       >
                         primary
                       </span>
@@ -4249,39 +4369,51 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <span
-                        class=""
+                      <div
+                        class="makeStyles-significanceStatusYes-150"
                       >
-                        +
-                        50
-                         to 
-                        +
-                        100
-                         
-                        pp
-                      </span>
+                        <span
+                          class=""
+                        >
+                          +
+                          50
+                           to 
+                          +
+                          100
+                           
+                          pp
+                        </span>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <span
-                        class=""
+                      <div
+                        class="makeStyles-significanceStatusYes-150"
                       >
-                        -50
-                         to 
-                        +
-                        0
-                         
-                        %
-                      </span>
+                        <span
+                          class=""
+                        >
+                          -50
+                           to 
+                          +
+                          0
+                           
+                          %
+                        </span>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Deploy 
-                      control
+                      <div
+                        class="makeStyles-significanceStatusYes-150"
+                      >
+                        Deploy 
+                        control
+                      </div>
                     </td>
                   </tr>
                   <tr
@@ -4324,7 +4456,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-140"
+                        class="makeStyles-metricAssignmentNameLine-149"
                       >
                         <span
                           class=""
@@ -4349,7 +4481,11 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Not analyzed yet
+                      <div
+                        class="makeStyles-significanceStatusNo-151"
+                      >
+                        Not analyzed yet
+                      </div>
                     </td>
                   </tr>
                   <tr
@@ -4392,7 +4528,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-140"
+                        class="makeStyles-metricAssignmentNameLine-149"
                       >
                         <span
                           class=""
@@ -4417,7 +4553,11 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Not analyzed yet
+                      <div
+                        class="makeStyles-significanceStatusNo-151"
+                      >
+                        Not analyzed yet
+                      </div>
                     </td>
                   </tr>
                   <tr
@@ -4460,7 +4600,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-140"
+                        class="makeStyles-metricAssignmentNameLine-149"
                       >
                         <span
                           class=""
@@ -4485,7 +4625,11 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Not analyzed yet
+                      <div
+                        class="makeStyles-significanceStatusNo-151"
+                      >
+                        Not analyzed yet
+                      </div>
                     </td>
                   </tr>
                 </tbody>
@@ -4496,7 +4640,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-134 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-143 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -4578,18 +4722,18 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-152 makeStyles-deemphasized-153 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-159"
+                  class="makeStyles-tooltip-171"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-152 makeStyles-deemphasized-153 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
                 scope="row"
               >
                 1.0000
@@ -4601,7 +4745,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-155 makeStyles-indicationSeverityOk-156 makeStyles-monospace-152 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-167 makeStyles-indicationSeverityOk-168 makeStyles-monospace-164 makeStyles-nowrap-166"
                 scope="row"
               >
                 <span>
@@ -4609,13 +4753,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-152 makeStyles-deemphasized-153 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-153"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-165"
                 scope="row"
               >
                 <p
@@ -4639,18 +4783,18 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-152 makeStyles-deemphasized-153 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-159"
+                  class="makeStyles-tooltip-171"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-152 makeStyles-deemphasized-153 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
                 scope="row"
               >
                 1.0000
@@ -4662,7 +4806,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-155 makeStyles-indicationSeverityOk-156 makeStyles-monospace-152 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-167 makeStyles-indicationSeverityOk-168 makeStyles-monospace-164 makeStyles-nowrap-166"
                 scope="row"
               >
                 <span>
@@ -4670,13 +4814,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-152 makeStyles-deemphasized-153 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-153"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-165"
                 scope="row"
               >
                 <p
@@ -4700,18 +4844,18 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-152 makeStyles-deemphasized-153 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-159"
+                  class="makeStyles-tooltip-171"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-152 makeStyles-deemphasized-153 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
                 scope="row"
               >
                 1.0000
@@ -4723,7 +4867,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-155 makeStyles-indicationSeverityOk-156 makeStyles-monospace-152 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-167 makeStyles-indicationSeverityOk-168 makeStyles-monospace-164 makeStyles-nowrap-166"
                 scope="row"
               >
                 <span>
@@ -4731,13 +4875,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-152 makeStyles-deemphasized-153 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-153"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-165"
                 scope="row"
               >
                 <p
@@ -4761,7 +4905,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-152 makeStyles-deemphasized-153 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
                 scope="row"
               >
                 <span>
@@ -4769,7 +4913,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-152 makeStyles-deemphasized-153 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
                 scope="row"
               >
                 0.0000
@@ -4781,7 +4925,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-155 makeStyles-indicationSeverityOk-156 makeStyles-monospace-152 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-167 makeStyles-indicationSeverityOk-168 makeStyles-monospace-164 makeStyles-nowrap-166"
                 scope="row"
               >
                 <span>
@@ -4789,13 +4933,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-152 makeStyles-deemphasized-153 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.01
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-153"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-165"
                 scope="row"
               >
                 <p
@@ -4819,7 +4963,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-152 makeStyles-deemphasized-153 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
                 scope="row"
               >
                 <span>
@@ -4827,7 +4971,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-152 makeStyles-deemphasized-153 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
                 scope="row"
               >
                 0.0000
@@ -4839,7 +4983,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-155 makeStyles-indicationSeverityOk-156 makeStyles-monospace-152 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-167 makeStyles-indicationSeverityOk-168 makeStyles-monospace-164 makeStyles-nowrap-166"
                 scope="row"
               >
                 <span>
@@ -4847,13 +4991,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-152 makeStyles-deemphasized-153 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-153"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-165"
                 scope="row"
               >
                 <p
@@ -4877,7 +5021,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-152 makeStyles-deemphasized-153 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
                 scope="row"
               >
                 <span>
@@ -4885,7 +5029,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-152 makeStyles-deemphasized-153 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
                 scope="row"
               >
                 2.5000
@@ -4899,7 +5043,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-155 makeStyles-indicationSeverityWarning-157 makeStyles-monospace-152 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-167 makeStyles-indicationSeverityWarning-169 makeStyles-monospace-164 makeStyles-nowrap-166"
                 scope="row"
               >
                 <span>
@@ -4907,13 +5051,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-152 makeStyles-deemphasized-153 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
                 scope="row"
               >
                 1.5 &lt; x ≤ ∞
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-153"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-165"
                 scope="row"
               >
                 <p
@@ -4939,7 +5083,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-152 makeStyles-deemphasized-153 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
                 scope="row"
               >
                 <span>
@@ -4947,7 +5091,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-152 makeStyles-deemphasized-153 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
                 scope="row"
               >
                 0.0000
@@ -4961,7 +5105,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-155 makeStyles-indicationSeverityWarning-157 makeStyles-monospace-152 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-167 makeStyles-indicationSeverityWarning-169 makeStyles-monospace-164 makeStyles-nowrap-166"
                 scope="row"
               >
                 <span>
@@ -4969,13 +5113,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-152 makeStyles-deemphasized-153 makeStyles-nowrap-154"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-164 makeStyles-deemphasized-165 makeStyles-nowrap-166"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-153"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-165"
                 scope="row"
               >
                 <p
@@ -4990,7 +5134,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
       </div>
     </div>
     <div
-      class="makeStyles-accordions-135"
+      class="makeStyles-accordions-144"
     >
       <div
         class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -5049,7 +5193,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-136"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-145"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -5209,7 +5353,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-136"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-145"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -5222,7 +5366,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                     This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                   </p>
                   <pre
-                    class="makeStyles-pre-138"
+                    class="makeStyles-pre-147"
                   >
                     <code>
                       with tracks_counts as (
@@ -5256,10 +5400,10 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders correctly for 1 analysis datapoint, statistically significant 2`] = `
 <div
-  class="makeStyles-root-160 analysis-detail-panel"
+  class="makeStyles-root-172 analysis-detail-panel"
 >
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-174 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-186 MuiTypography-body1"
   >
     Summary
   </p>
@@ -5279,7 +5423,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
             class="MuiTableCell-root MuiTableCell-body"
           >
             <h5
-              class="MuiTypography-root makeStyles-recommendation-173 MuiTypography-h5 MuiTypography-gutterBottom"
+              class="MuiTypography-root makeStyles-recommendation-185 MuiTypography-h5 MuiTypography-gutterBottom"
             >
               Deploy 
               control
@@ -5321,7 +5465,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
               
               100
               <span
-                class="makeStyles-root-178"
+                class="makeStyles-root-190"
                 title="Percentage points."
               >
                 pp
@@ -5342,7 +5486,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
               
               10
               <span
-                class="makeStyles-root-178"
+                class="makeStyles-root-190"
                 title="Percentage points."
               >
                 pp
@@ -5354,7 +5498,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
             </strong>
              
             <span
-              class="makeStyles-root-179"
+              class="makeStyles-root-191"
               title="09/05/2020, 20:00:00"
             >
               2020-05-10
@@ -5379,7 +5523,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-174 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-186 MuiTypography-body1"
   >
     Analysis
   </p>
@@ -5387,7 +5531,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
     class="MuiPaper-root MuiTableContainer-root MuiPaper-elevation1 MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-coolTable-175"
+      class="MuiTable-root makeStyles-coolTable-187"
     >
       <thead
         class="MuiTableHead-root"
@@ -5428,22 +5572,22 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-168 makeStyles-headerCell-161 makeStyles-credibleIntervalHeader-172"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-180 makeStyles-headerCell-173 makeStyles-credibleIntervalHeader-184"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-162"
+              class="makeStyles-monospace-174"
             >
               test
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-174 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-150"
+              class="makeStyles-tooltipped-162"
             >
               50
                to 
@@ -5453,10 +5597,10 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-174 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-150"
+              class="makeStyles-tooltipped-162"
             >
               +
               50
@@ -5468,10 +5612,10 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-174 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-150"
+              class="makeStyles-tooltipped-162"
             >
               -50
                to 
@@ -5486,22 +5630,22 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-168 makeStyles-headerCell-161 makeStyles-credibleIntervalHeader-172"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-180 makeStyles-headerCell-173 makeStyles-credibleIntervalHeader-184"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-162"
+              class="makeStyles-monospace-174"
             >
               control
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-174 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-150"
+              class="makeStyles-tooltipped-162"
             >
               100
                to 
@@ -5511,12 +5655,12 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-174 MuiTableCell-alignRight"
           >
             Baseline
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-162 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-174 MuiTableCell-alignRight"
           >
             Baseline
           </td>
@@ -5525,7 +5669,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-analysisFinePrint-171 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-analysisFinePrint-183 MuiTypography-body1"
   >
     95% Credible Intervals (CIs). 
     <strong>
@@ -5535,7 +5679,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
     
     10
     <span
-      class="makeStyles-root-178"
+      class="makeStyles-root-190"
       title="Percentage points."
     >
       pp
@@ -5543,17 +5687,17 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
     .
   </p>
   <p
-    class="MuiTypography-root makeStyles-noPlotMessage-166 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-noPlotMessage-178 MuiTypography-body1"
   >
     Past values will be plotted once we have more than one day of results.
   </p>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-174 makeStyles-clickable-176 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-186 makeStyles-clickable-188 MuiTypography-body1"
     role="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-177"
+      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-189"
       focusable="false"
       viewBox="0 0 24 24"
     >
@@ -5571,7 +5715,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 3
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-133",
+        "className": "makeStyles-participantsPlot-142",
         "data": Array [
           Object {
             "line": Object {
@@ -5639,13 +5783,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-180"
+    class="makeStyles-root-192"
   >
     <div
-      class="makeStyles-summary-181"
+      class="makeStyles-summary-193"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-192 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-204 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -5654,16 +5798,16 @@ exports[`renders correctly for conflicting analysis data 1`] = `
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-183"
+        class="makeStyles-summaryColumn-195"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-184 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-196 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-185"
+            class="makeStyles-summaryStatsPart-197"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-187 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-199 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               1,000
             </h3>
@@ -5679,13 +5823,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-185"
+            class="makeStyles-summaryStatsPart-197"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-187 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-199 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               <span
-                class="makeStyles-tooltipped-201"
+                class="makeStyles-tooltipped-216"
                 title="Contact @experimentation-review on #a8c-experiments"
               >
                 Manual analysis required
@@ -5702,12 +5846,12 @@ exports[`renders correctly for conflicting analysis data 1`] = `
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-188 makeStyles-indicationSeverityWarning-190 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-200 makeStyles-indicationSeverityWarning-202 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-187 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-199 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Potential issues
             </h3>
@@ -5724,16 +5868,30 @@ exports[`renders correctly for conflicting analysis data 1`] = `
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-194 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-206 MuiTypography-h3"
     >
-      Metric Assignment Results
+      <span>
+        Metric Assignment Results
+      </span>
+       
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root makeStyles-infoIcon-215"
+        focusable="false"
+        title="Results that are both practically and statistically significant are indicated in bold.  Insignificant results are indicated by a lighter grey."
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+        />
+      </svg>
     </h3>
     <div
       class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-206"
+        class="Component-horizontalScrollContainer-221"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -5752,33 +5910,33 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-207 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-222 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-207 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-222 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric (attribution window)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-207 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-222 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Absolute change
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-207 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-222 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Relative change (lift)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-207 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-222 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -5829,7 +5987,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-200"
+                        class="makeStyles-metricAssignmentNameLine-212"
                       >
                         <span
                           class=""
@@ -5843,7 +6001,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       </span>
                       <br />
                       <span
-                        class="makeStyles-root-208"
+                        class="makeStyles-root-223"
                       >
                         primary
                       </span>
@@ -5860,12 +6018,16 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <span
-                        class="makeStyles-tooltipped-201"
-                        title="Contact @experimentation-review on #a8c-experiments"
+                      <div
+                        class="makeStyles-significanceStatusYes-213"
                       >
-                        Manual analysis required
-                      </span>
+                        <span
+                          class="makeStyles-tooltipped-216"
+                          title="Contact @experimentation-review on #a8c-experiments"
+                        >
+                          Manual analysis required
+                        </span>
+                      </div>
                     </td>
                   </tr>
                   <tr
@@ -5908,7 +6070,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-200"
+                        class="makeStyles-metricAssignmentNameLine-212"
                       >
                         <span
                           class=""
@@ -5933,7 +6095,11 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Not analyzed yet
+                      <div
+                        class="makeStyles-significanceStatusNo-214"
+                      >
+                        Not analyzed yet
+                      </div>
                     </td>
                   </tr>
                   <tr
@@ -5976,7 +6142,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-200"
+                        class="makeStyles-metricAssignmentNameLine-212"
                       >
                         <span
                           class=""
@@ -6001,7 +6167,11 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Not analyzed yet
+                      <div
+                        class="makeStyles-significanceStatusNo-214"
+                      >
+                        Not analyzed yet
+                      </div>
                     </td>
                   </tr>
                   <tr
@@ -6044,7 +6214,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-200"
+                        class="makeStyles-metricAssignmentNameLine-212"
                       >
                         <span
                           class=""
@@ -6069,7 +6239,11 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Not analyzed yet
+                      <div
+                        class="makeStyles-significanceStatusNo-214"
+                      >
+                        Not analyzed yet
+                      </div>
                     </td>
                   </tr>
                 </tbody>
@@ -6080,7 +6254,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-194 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-206 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -6162,18 +6336,18 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-210 makeStyles-deemphasized-211 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-217"
+                  class="makeStyles-tooltip-232"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-210 makeStyles-deemphasized-211 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
                 scope="row"
               >
                 1.0000
@@ -6185,7 +6359,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-213 makeStyles-indicationSeverityOk-214 makeStyles-monospace-210 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-228 makeStyles-indicationSeverityOk-229 makeStyles-monospace-225 makeStyles-nowrap-227"
                 scope="row"
               >
                 <span>
@@ -6193,13 +6367,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-210 makeStyles-deemphasized-211 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-211"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-226"
                 scope="row"
               >
                 <p
@@ -6223,18 +6397,18 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-210 makeStyles-deemphasized-211 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-217"
+                  class="makeStyles-tooltip-232"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-210 makeStyles-deemphasized-211 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
                 scope="row"
               >
                 1.0000
@@ -6246,7 +6420,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-213 makeStyles-indicationSeverityOk-214 makeStyles-monospace-210 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-228 makeStyles-indicationSeverityOk-229 makeStyles-monospace-225 makeStyles-nowrap-227"
                 scope="row"
               >
                 <span>
@@ -6254,13 +6428,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-210 makeStyles-deemphasized-211 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-211"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-226"
                 scope="row"
               >
                 <p
@@ -6284,18 +6458,18 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-210 makeStyles-deemphasized-211 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-217"
+                  class="makeStyles-tooltip-232"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-210 makeStyles-deemphasized-211 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
                 scope="row"
               >
                 1.0000
@@ -6307,7 +6481,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-213 makeStyles-indicationSeverityOk-214 makeStyles-monospace-210 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-228 makeStyles-indicationSeverityOk-229 makeStyles-monospace-225 makeStyles-nowrap-227"
                 scope="row"
               >
                 <span>
@@ -6315,13 +6489,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-210 makeStyles-deemphasized-211 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-211"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-226"
                 scope="row"
               >
                 <p
@@ -6345,7 +6519,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-210 makeStyles-deemphasized-211 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
                 scope="row"
               >
                 <span>
@@ -6353,7 +6527,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-210 makeStyles-deemphasized-211 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
                 scope="row"
               >
                 0.0000
@@ -6365,7 +6539,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-213 makeStyles-indicationSeverityOk-214 makeStyles-monospace-210 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-228 makeStyles-indicationSeverityOk-229 makeStyles-monospace-225 makeStyles-nowrap-227"
                 scope="row"
               >
                 <span>
@@ -6373,13 +6547,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-210 makeStyles-deemphasized-211 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.01
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-211"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-226"
                 scope="row"
               >
                 <p
@@ -6403,7 +6577,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-210 makeStyles-deemphasized-211 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
                 scope="row"
               >
                 <span>
@@ -6411,7 +6585,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-210 makeStyles-deemphasized-211 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
                 scope="row"
               >
                 0.0000
@@ -6423,7 +6597,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-213 makeStyles-indicationSeverityOk-214 makeStyles-monospace-210 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-228 makeStyles-indicationSeverityOk-229 makeStyles-monospace-225 makeStyles-nowrap-227"
                 scope="row"
               >
                 <span>
@@ -6431,13 +6605,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-210 makeStyles-deemphasized-211 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-211"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-226"
                 scope="row"
               >
                 <p
@@ -6461,7 +6635,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-210 makeStyles-deemphasized-211 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
                 scope="row"
               >
                 <span>
@@ -6469,7 +6643,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-210 makeStyles-deemphasized-211 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
                 scope="row"
               >
                 2.5000
@@ -6483,7 +6657,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-213 makeStyles-indicationSeverityWarning-215 makeStyles-monospace-210 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-228 makeStyles-indicationSeverityWarning-230 makeStyles-monospace-225 makeStyles-nowrap-227"
                 scope="row"
               >
                 <span>
@@ -6491,13 +6665,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-210 makeStyles-deemphasized-211 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
                 scope="row"
               >
                 1.5 &lt; x ≤ ∞
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-211"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-226"
                 scope="row"
               >
                 <p
@@ -6523,7 +6697,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-210 makeStyles-deemphasized-211 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
                 scope="row"
               >
                 <span>
@@ -6531,7 +6705,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-210 makeStyles-deemphasized-211 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
                 scope="row"
               >
                 0.0000
@@ -6545,7 +6719,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-213 makeStyles-indicationSeverityWarning-215 makeStyles-monospace-210 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-228 makeStyles-indicationSeverityWarning-230 makeStyles-monospace-225 makeStyles-nowrap-227"
                 scope="row"
               >
                 <span>
@@ -6553,13 +6727,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-210 makeStyles-deemphasized-211 makeStyles-nowrap-212"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-225 makeStyles-deemphasized-226 makeStyles-nowrap-227"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-211"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-226"
                 scope="row"
               >
                 <p
@@ -6574,7 +6748,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
       </div>
     </div>
     <div
-      class="makeStyles-accordions-195"
+      class="makeStyles-accordions-207"
     >
       <div
         class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -6633,7 +6807,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-196"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-208"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -6793,7 +6967,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-196"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-208"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -6806,7 +6980,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                     This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                   </p>
                   <pre
-                    class="makeStyles-pre-198"
+                    class="makeStyles-pre-210"
                   >
                     <code>
                       with tracks_counts as (
@@ -6840,10 +7014,10 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders correctly for conflicting analysis data 2`] = `
 <div
-  class="makeStyles-root-218 analysis-detail-panel"
+  class="makeStyles-root-233 analysis-detail-panel"
 >
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-232 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-247 MuiTypography-body1"
   >
     Summary
   </p>
@@ -6863,10 +7037,10 @@ exports[`renders correctly for conflicting analysis data 2`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <h5
-              class="MuiTypography-root makeStyles-recommendation-231 MuiTypography-h5 MuiTypography-gutterBottom"
+              class="MuiTypography-root makeStyles-recommendation-246 MuiTypography-h5 MuiTypography-gutterBottom"
             >
               <span
-                class="makeStyles-tooltipped-201"
+                class="makeStyles-tooltipped-216"
                 title="Contact @experimentation-review on #a8c-experiments"
               >
                 Manual analysis required
@@ -6916,7 +7090,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
               
               100
               <span
-                class="makeStyles-root-236"
+                class="makeStyles-root-251"
                 title="Percentage points."
               >
                 pp
@@ -6937,7 +7111,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
               
               10
               <span
-                class="makeStyles-root-236"
+                class="makeStyles-root-251"
                 title="Percentage points."
               >
                 pp
@@ -6949,7 +7123,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
             </strong>
              
             <span
-              class="makeStyles-root-237"
+              class="makeStyles-root-252"
               title="09/05/2020, 20:00:00"
             >
               2020-05-10
@@ -6974,7 +7148,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-232 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-247 MuiTypography-body1"
   >
     Analysis
   </p>
@@ -6982,7 +7156,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
     class="MuiPaper-root MuiTableContainer-root MuiPaper-elevation1 MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-coolTable-233"
+      class="MuiTable-root makeStyles-coolTable-248"
     >
       <thead
         class="MuiTableHead-root"
@@ -7023,22 +7197,22 @@ exports[`renders correctly for conflicting analysis data 2`] = `
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-226 makeStyles-headerCell-219 makeStyles-credibleIntervalHeader-230"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-241 makeStyles-headerCell-234 makeStyles-credibleIntervalHeader-245"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-220"
+              class="makeStyles-monospace-235"
             >
               test
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-235 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-239"
+              class="makeStyles-tooltipped-254"
             >
               50
                to 
@@ -7048,10 +7222,10 @@ exports[`renders correctly for conflicting analysis data 2`] = `
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-235 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-239"
+              class="makeStyles-tooltipped-254"
             >
               +
               50
@@ -7063,10 +7237,10 @@ exports[`renders correctly for conflicting analysis data 2`] = `
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-235 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-239"
+              class="makeStyles-tooltipped-254"
             >
               -50
                to 
@@ -7081,22 +7255,22 @@ exports[`renders correctly for conflicting analysis data 2`] = `
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-226 makeStyles-headerCell-219 makeStyles-credibleIntervalHeader-230"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-241 makeStyles-headerCell-234 makeStyles-credibleIntervalHeader-245"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-220"
+              class="makeStyles-monospace-235"
             >
               control
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-235 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-239"
+              class="makeStyles-tooltipped-254"
             >
               100
                to 
@@ -7106,12 +7280,12 @@ exports[`renders correctly for conflicting analysis data 2`] = `
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-235 MuiTableCell-alignRight"
           >
             Baseline
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-220 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-235 MuiTableCell-alignRight"
           >
             Baseline
           </td>
@@ -7120,7 +7294,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-analysisFinePrint-229 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-analysisFinePrint-244 MuiTypography-body1"
   >
     95% Credible Intervals (CIs). 
     <strong>
@@ -7130,7 +7304,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
     
     10
     <span
-      class="makeStyles-root-236"
+      class="makeStyles-root-251"
       title="Percentage points."
     >
       pp
@@ -7138,17 +7312,17 @@ exports[`renders correctly for conflicting analysis data 2`] = `
     .
   </p>
   <p
-    class="MuiTypography-root makeStyles-noPlotMessage-224 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-noPlotMessage-239 MuiTypography-body1"
   >
     Past values will be plotted once we have more than one day of results.
   </p>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-232 makeStyles-clickable-234 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-247 makeStyles-clickable-249 MuiTypography-body1"
     role="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-235"
+      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-250"
       focusable="false"
       viewBox="0 0 24 24"
     >
@@ -7166,7 +7340,7 @@ exports[`renders correctly for conflicting analysis data 3`] = `
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-193",
+        "className": "makeStyles-participantsPlot-205",
         "data": Array [
           Object {
             "line": Object {
@@ -7234,13 +7408,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-240"
+    class="makeStyles-root-255"
   >
     <div
-      class="makeStyles-summary-241"
+      class="makeStyles-summary-256"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-252 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-267 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -7249,16 +7423,16 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-243"
+        class="makeStyles-summaryColumn-258"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-244 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-259 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-245"
+            class="makeStyles-summaryStatsPart-260"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-247 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-262 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               700
             </h3>
@@ -7274,10 +7448,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-245"
+            class="makeStyles-summaryStatsPart-260"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-247 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-262 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Deploy either variation
             </h3>
@@ -7292,12 +7466,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-248 makeStyles-indicationSeverityError-251 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-263 makeStyles-indicationSeverityError-266 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-247 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-262 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Serious issues
             </h3>
@@ -7314,16 +7488,30 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-254 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-269 MuiTypography-h3"
     >
-      Metric Assignment Results
+      <span>
+        Metric Assignment Results
+      </span>
+       
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root makeStyles-infoIcon-278"
+        focusable="false"
+        title="Results that are both practically and statistically significant are indicated in bold.  Insignificant results are indicated by a lighter grey."
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+        />
+      </svg>
     </h3>
     <div
       class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-266"
+        class="Component-horizontalScrollContainer-284"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -7342,33 +7530,33 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-267 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-285 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-267 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-285 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric (attribution window)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-267 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-285 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Absolute change
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-267 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-285 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Relative change (lift)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-267 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-285 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -7419,7 +7607,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-260"
+                        class="makeStyles-metricAssignmentNameLine-275"
                       >
                         <span
                           class=""
@@ -7433,7 +7621,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       </span>
                       <br />
                       <span
-                        class="makeStyles-root-268"
+                        class="makeStyles-root-286"
                       >
                         primary
                       </span>
@@ -7442,37 +7630,49 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <span
-                        class=""
+                      <div
+                        class="makeStyles-significanceStatusNo-277"
                       >
-                        -1
-                         to 
-                        +
-                        1
-                         
-                        pp
-                      </span>
+                        <span
+                          class=""
+                        >
+                          -1
+                           to 
+                          +
+                          1
+                           
+                          pp
+                        </span>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <span
-                        class=""
+                      <div
+                        class="makeStyles-significanceStatusNo-277"
                       >
-                        -50
-                         to 
-                        +
-                        50
-                         
-                        %
-                      </span>
+                        <span
+                          class=""
+                        >
+                          -50
+                           to 
+                          +
+                          50
+                           
+                          %
+                        </span>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Deploy either variation
+                      <div
+                        class="makeStyles-significanceStatusNo-277"
+                      >
+                        Deploy either variation
+                      </div>
                     </td>
                   </tr>
                   <tr
@@ -7515,7 +7715,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-260"
+                        class="makeStyles-metricAssignmentNameLine-275"
                       >
                         <span
                           class=""
@@ -7540,7 +7740,11 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Not analyzed yet
+                      <div
+                        class="makeStyles-significanceStatusNo-277"
+                      >
+                        Not analyzed yet
+                      </div>
                     </td>
                   </tr>
                   <tr
@@ -7583,7 +7787,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-260"
+                        class="makeStyles-metricAssignmentNameLine-275"
                       >
                         <span
                           class=""
@@ -7608,7 +7812,11 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Not analyzed yet
+                      <div
+                        class="makeStyles-significanceStatusNo-277"
+                      >
+                        Not analyzed yet
+                      </div>
                     </td>
                   </tr>
                   <tr
@@ -7651,7 +7859,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-260"
+                        class="makeStyles-metricAssignmentNameLine-275"
                       >
                         <span
                           class=""
@@ -7668,37 +7876,49 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <span
-                        class=""
+                      <div
+                        class="makeStyles-significanceStatusNo-277"
                       >
-                        -1
-                         to 
-                        +
-                        1
-                         
-                        pp
-                      </span>
+                        <span
+                          class=""
+                        >
+                          -1
+                           to 
+                          +
+                          1
+                           
+                          pp
+                        </span>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <span
-                        class=""
+                      <div
+                        class="makeStyles-significanceStatusNo-277"
                       >
-                        -50
-                         to 
-                        +
-                        50
-                         
-                        %
-                      </span>
+                        <span
+                          class=""
+                        >
+                          -50
+                           to 
+                          +
+                          50
+                           
+                          %
+                        </span>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Deploy either variation
+                      <div
+                        class="makeStyles-significanceStatusNo-277"
+                      >
+                        Deploy either variation
+                      </div>
                     </td>
                   </tr>
                 </tbody>
@@ -7709,7 +7929,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-254 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-269 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -7791,18 +8011,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-272 makeStyles-deemphasized-273 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-279"
+                  class="makeStyles-tooltip-297"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-272 makeStyles-deemphasized-273 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
                 scope="row"
               >
                 1.0000
@@ -7814,7 +8034,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-275 makeStyles-indicationSeverityOk-276 makeStyles-monospace-272 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-293 makeStyles-indicationSeverityOk-294 makeStyles-monospace-290 makeStyles-nowrap-292"
                 scope="row"
               >
                 <span>
@@ -7822,13 +8042,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-272 makeStyles-deemphasized-273 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-273"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-291"
                 scope="row"
               >
                 <p
@@ -7852,18 +8072,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-272 makeStyles-deemphasized-273 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-279"
+                  class="makeStyles-tooltip-297"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-272 makeStyles-deemphasized-273 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
                 scope="row"
               >
                 1.0000
@@ -7875,7 +8095,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-275 makeStyles-indicationSeverityOk-276 makeStyles-monospace-272 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-293 makeStyles-indicationSeverityOk-294 makeStyles-monospace-290 makeStyles-nowrap-292"
                 scope="row"
               >
                 <span>
@@ -7883,13 +8103,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-272 makeStyles-deemphasized-273 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-273"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-291"
                 scope="row"
               >
                 <p
@@ -7913,18 +8133,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-272 makeStyles-deemphasized-273 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-279"
+                  class="makeStyles-tooltip-297"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-272 makeStyles-deemphasized-273 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
                 scope="row"
               >
                 1.0000
@@ -7936,7 +8156,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-275 makeStyles-indicationSeverityOk-276 makeStyles-monospace-272 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-293 makeStyles-indicationSeverityOk-294 makeStyles-monospace-290 makeStyles-nowrap-292"
                 scope="row"
               >
                 <span>
@@ -7944,13 +8164,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-272 makeStyles-deemphasized-273 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-273"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-291"
                 scope="row"
               >
                 <p
@@ -7974,7 +8194,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-272 makeStyles-deemphasized-273 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
                 scope="row"
               >
                 <span>
@@ -7982,7 +8202,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-272 makeStyles-deemphasized-273 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
                 scope="row"
               >
                 0.1000
@@ -7996,7 +8216,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-275 makeStyles-indicationSeverityError-278 makeStyles-monospace-272 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-293 makeStyles-indicationSeverityError-296 makeStyles-monospace-290 makeStyles-nowrap-292"
                 scope="row"
               >
                 <span>
@@ -8004,13 +8224,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-272 makeStyles-deemphasized-273 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-273"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-291"
                 scope="row"
               >
                 <p
@@ -8036,7 +8256,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-272 makeStyles-deemphasized-273 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
                 scope="row"
               >
                 <span>
@@ -8044,7 +8264,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-272 makeStyles-deemphasized-273 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
                 scope="row"
               >
                 0.1500
@@ -8058,7 +8278,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-275 makeStyles-indicationSeverityWarning-277 makeStyles-monospace-272 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-293 makeStyles-indicationSeverityWarning-295 makeStyles-monospace-290 makeStyles-nowrap-292"
                 scope="row"
               >
                 <span>
@@ -8066,13 +8286,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-272 makeStyles-deemphasized-273 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
                 scope="row"
               >
                 0.1 &lt; x ≤ 0.4
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-273"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-291"
                 scope="row"
               >
                 <p
@@ -8098,7 +8318,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-272 makeStyles-deemphasized-273 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
                 scope="row"
               >
                 <span>
@@ -8106,7 +8326,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-272 makeStyles-deemphasized-273 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
                 scope="row"
               >
                 0.1000
@@ -8118,7 +8338,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-275 makeStyles-indicationSeverityOk-276 makeStyles-monospace-272 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-293 makeStyles-indicationSeverityOk-294 makeStyles-monospace-290 makeStyles-nowrap-292"
                 scope="row"
               >
                 <span>
@@ -8126,13 +8346,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-272 makeStyles-deemphasized-273 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.8
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-273"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-291"
                 scope="row"
               >
                 <p
@@ -8156,7 +8376,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-272 makeStyles-deemphasized-273 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
                 scope="row"
               >
                 <span>
@@ -8164,7 +8384,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-272 makeStyles-deemphasized-273 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
                 scope="row"
               >
                 0.0000
@@ -8178,7 +8398,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-275 makeStyles-indicationSeverityWarning-277 makeStyles-monospace-272 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-293 makeStyles-indicationSeverityWarning-295 makeStyles-monospace-290 makeStyles-nowrap-292"
                 scope="row"
               >
                 <span>
@@ -8186,13 +8406,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-272 makeStyles-deemphasized-273 makeStyles-nowrap-274"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-290 makeStyles-deemphasized-291 makeStyles-nowrap-292"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-273"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-291"
                 scope="row"
               >
                 <p
@@ -8207,7 +8427,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <div
-      class="makeStyles-accordions-255"
+      class="makeStyles-accordions-270"
     >
       <div
         class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -8266,7 +8486,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-256"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-271"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -8426,7 +8646,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-256"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-271"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -8439,7 +8659,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                   </p>
                   <pre
-                    class="makeStyles-pre-258"
+                    class="makeStyles-pre-273"
                   >
                     <code>
                       with tracks_counts as (
@@ -8473,10 +8693,10 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders the condensed table with some analyses in non-debug mode for a Conversion Metric 2`] = `
 <div
-  class="makeStyles-root-280 analysis-detail-panel"
+  class="makeStyles-root-298 analysis-detail-panel"
 >
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-294 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-312 MuiTypography-body1"
   >
     Summary
   </p>
@@ -8496,7 +8716,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableCell-root MuiTableCell-body"
           >
             <h5
-              class="MuiTypography-root makeStyles-recommendation-293 MuiTypography-h5 MuiTypography-gutterBottom"
+              class="MuiTypography-root makeStyles-recommendation-311 MuiTypography-h5 MuiTypography-gutterBottom"
             >
               Deploy either variation
             </h5>
@@ -8536,7 +8756,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               
               1
               <span
-                class="makeStyles-root-298"
+                class="makeStyles-root-316"
                 title="Percentage points."
               >
                 pp
@@ -8557,7 +8777,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               
               10
               <span
-                class="makeStyles-root-298"
+                class="makeStyles-root-316"
                 title="Percentage points."
               >
                 pp
@@ -8569,7 +8789,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </strong>
              
             <span
-              class="makeStyles-root-299"
+              class="makeStyles-root-317"
               title="09/05/2020, 20:00:00"
             >
               2020-05-10
@@ -8594,7 +8814,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-294 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-312 MuiTypography-body1"
   >
     Analysis
   </p>
@@ -8602,7 +8822,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     class="MuiPaper-root MuiTableContainer-root MuiPaper-elevation1 MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-coolTable-295"
+      class="MuiTable-root makeStyles-coolTable-313"
     >
       <thead
         class="MuiTableHead-root"
@@ -8643,22 +8863,22 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-288 makeStyles-headerCell-281 makeStyles-credibleIntervalHeader-292"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-306 makeStyles-headerCell-299 makeStyles-credibleIntervalHeader-310"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-282"
+              class="makeStyles-monospace-300"
             >
               test
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-282 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-300 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-270"
+              class="makeStyles-tooltipped-288"
             >
               -112.3
                to 
@@ -8668,10 +8888,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-282 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-300 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-270"
+              class="makeStyles-tooltipped-288"
             >
               -1
                to 
@@ -8682,10 +8902,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-282 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-300 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-270"
+              class="makeStyles-tooltipped-288"
             >
               -50
                to 
@@ -8700,22 +8920,22 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-288 makeStyles-headerCell-281 makeStyles-credibleIntervalHeader-292"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-306 makeStyles-headerCell-299 makeStyles-credibleIntervalHeader-310"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-282"
+              class="makeStyles-monospace-300"
             >
               control
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-282 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-300 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-270"
+              class="makeStyles-tooltipped-288"
             >
               0
                to 
@@ -8725,12 +8945,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-282 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-300 MuiTableCell-alignRight"
           >
             Baseline
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-282 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-300 MuiTableCell-alignRight"
           >
             Baseline
           </td>
@@ -8739,7 +8959,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-analysisFinePrint-291 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-analysisFinePrint-309 MuiTypography-body1"
   >
     95% Credible Intervals (CIs). 
     <strong>
@@ -8749,7 +8969,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     
     10
     <span
-      class="makeStyles-root-298"
+      class="makeStyles-root-316"
       title="Percentage points."
     >
       pp
@@ -8757,15 +8977,15 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     .
   </p>
   <div
-    class="makeStyles-metricEstimatePlots-283"
+    class="makeStyles-metricEstimatePlots-301"
   />
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-294 makeStyles-clickable-296 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-312 makeStyles-clickable-314 MuiTypography-body1"
     role="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-297"
+      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-315"
       focusable="false"
       viewBox="0 0 24 24"
     >
@@ -8783,7 +9003,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-253",
+        "className": "makeStyles-participantsPlot-268",
         "data": Array [
           Object {
             "line": Object {
@@ -8842,7 +9062,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-284",
+        "className": "makeStyles-metricEstimatePlot-302",
         "data": Array [
           Object {
             "line": Object {
@@ -8938,7 +9158,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-284",
+        "className": "makeStyles-metricEstimatePlot-302",
         "data": Array [
           Object {
             "line": Object {
@@ -9040,7 +9260,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-284",
+        "className": "makeStyles-metricEstimatePlot-302",
         "data": Array [
           Object {
             "line": Object {
@@ -9136,7 +9356,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-284",
+        "className": "makeStyles-metricEstimatePlot-302",
         "data": Array [
           Object {
             "line": Object {
@@ -9267,13 +9487,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-300"
+    class="makeStyles-root-318"
   >
     <div
-      class="makeStyles-summary-301"
+      class="makeStyles-summary-319"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-312 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-330 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -9282,16 +9502,16 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-303"
+        class="makeStyles-summaryColumn-321"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-304 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-322 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-305"
+            class="makeStyles-summaryStatsPart-323"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-307 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-325 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               700
             </h3>
@@ -9307,10 +9527,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-305"
+            class="makeStyles-summaryStatsPart-323"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-307 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-325 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Deploy either variation
             </h3>
@@ -9325,12 +9545,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-308 makeStyles-indicationSeverityError-311 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-326 makeStyles-indicationSeverityError-329 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-307 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-325 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Serious issues
             </h3>
@@ -9347,16 +9567,30 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-314 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-332 MuiTypography-h3"
     >
-      Metric Assignment Results
+      <span>
+        Metric Assignment Results
+      </span>
+       
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root makeStyles-infoIcon-341"
+        focusable="false"
+        title="Results that are both practically and statistically significant are indicated in bold.  Insignificant results are indicated by a lighter grey."
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+        />
+      </svg>
     </h3>
     <div
       class="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-326"
+        class="Component-horizontalScrollContainer-347"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -9375,33 +9609,33 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-327 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-348 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-327 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-348 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric (attribution window)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-327 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-348 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Absolute change
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-327 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-348 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Relative change (lift)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-327 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-348 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -9452,7 +9686,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-320"
+                        class="makeStyles-metricAssignmentNameLine-338"
                       >
                         <span
                           class=""
@@ -9466,7 +9700,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       </span>
                       <br />
                       <span
-                        class="makeStyles-root-328"
+                        class="makeStyles-root-349"
                       >
                         primary
                       </span>
@@ -9475,37 +9709,49 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <span
-                        class=""
+                      <div
+                        class="makeStyles-significanceStatusNo-340"
                       >
-                        -0.01
-                         to 
-                        +
-                        0.01
-                         
-                        USD
-                      </span>
+                        <span
+                          class=""
+                        >
+                          -0.01
+                           to 
+                          +
+                          0.01
+                           
+                          USD
+                        </span>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <span
-                        class=""
+                      <div
+                        class="makeStyles-significanceStatusNo-340"
                       >
-                        -50
-                         to 
-                        +
-                        50
-                         
-                        %
-                      </span>
+                        <span
+                          class=""
+                        >
+                          -50
+                           to 
+                          +
+                          50
+                           
+                          %
+                        </span>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Deploy either variation
+                      <div
+                        class="makeStyles-significanceStatusNo-340"
+                      >
+                        Deploy either variation
+                      </div>
                     </td>
                   </tr>
                   <tr
@@ -9548,7 +9794,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-320"
+                        class="makeStyles-metricAssignmentNameLine-338"
                       >
                         <span
                           class=""
@@ -9573,7 +9819,11 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Not analyzed yet
+                      <div
+                        class="makeStyles-significanceStatusNo-340"
+                      >
+                        Not analyzed yet
+                      </div>
                     </td>
                   </tr>
                   <tr
@@ -9616,7 +9866,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-320"
+                        class="makeStyles-metricAssignmentNameLine-338"
                       >
                         <span
                           class=""
@@ -9641,7 +9891,11 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Not analyzed yet
+                      <div
+                        class="makeStyles-significanceStatusNo-340"
+                      >
+                        Not analyzed yet
+                      </div>
                     </td>
                   </tr>
                   <tr
@@ -9684,7 +9938,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 600;"
                     >
                       <span
-                        class="makeStyles-metricAssignmentNameLine-320"
+                        class="makeStyles-metricAssignmentNameLine-338"
                       >
                         <span
                           class=""
@@ -9701,37 +9955,49 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <span
-                        class=""
+                      <div
+                        class="makeStyles-significanceStatusNo-340"
                       >
-                        -0.01
-                         to 
-                        +
-                        0.01
-                         
-                        USD
-                      </span>
+                        <span
+                          class=""
+                        >
+                          -0.01
+                           to 
+                          +
+                          0.01
+                           
+                          USD
+                        </span>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      <span
-                        class=""
+                      <div
+                        class="makeStyles-significanceStatusNo-340"
                       >
-                        -50
-                         to 
-                        +
-                        50
-                         
-                        %
-                      </span>
+                        <span
+                          class=""
+                        >
+                          -50
+                           to 
+                          +
+                          50
+                           
+                          %
+                        </span>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace;"
                     >
-                      Deploy either variation
+                      <div
+                        class="makeStyles-significanceStatusNo-340"
+                      >
+                        Deploy either variation
+                      </div>
                     </td>
                   </tr>
                 </tbody>
@@ -9742,7 +10008,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-314 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-332 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -9824,18 +10090,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-332 makeStyles-deemphasized-333 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-339"
+                  class="makeStyles-tooltip-360"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-332 makeStyles-deemphasized-333 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
                 scope="row"
               >
                 1.0000
@@ -9847,7 +10113,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-335 makeStyles-indicationSeverityOk-336 makeStyles-monospace-332 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-356 makeStyles-indicationSeverityOk-357 makeStyles-monospace-353 makeStyles-nowrap-355"
                 scope="row"
               >
                 <span>
@@ -9855,13 +10121,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-332 makeStyles-deemphasized-333 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-333"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-354"
                 scope="row"
               >
                 <p
@@ -9885,18 +10151,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-332 makeStyles-deemphasized-333 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-339"
+                  class="makeStyles-tooltip-360"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-332 makeStyles-deemphasized-333 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
                 scope="row"
               >
                 1.0000
@@ -9908,7 +10174,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-335 makeStyles-indicationSeverityOk-336 makeStyles-monospace-332 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-356 makeStyles-indicationSeverityOk-357 makeStyles-monospace-353 makeStyles-nowrap-355"
                 scope="row"
               >
                 <span>
@@ -9916,13 +10182,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-332 makeStyles-deemphasized-333 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-333"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-354"
                 scope="row"
               >
                 <p
@@ -9946,18 +10212,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-332 makeStyles-deemphasized-333 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltip-339"
+                  class="makeStyles-tooltip-360"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-332 makeStyles-deemphasized-333 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
                 scope="row"
               >
                 1.0000
@@ -9969,7 +10235,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-335 makeStyles-indicationSeverityOk-336 makeStyles-monospace-332 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-356 makeStyles-indicationSeverityOk-357 makeStyles-monospace-353 makeStyles-nowrap-355"
                 scope="row"
               >
                 <span>
@@ -9977,13 +10243,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-332 makeStyles-deemphasized-333 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-333"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-354"
                 scope="row"
               >
                 <p
@@ -10007,7 +10273,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-332 makeStyles-deemphasized-333 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
                 scope="row"
               >
                 <span>
@@ -10015,7 +10281,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-332 makeStyles-deemphasized-333 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
                 scope="row"
               >
                 0.1000
@@ -10029,7 +10295,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-335 makeStyles-indicationSeverityError-338 makeStyles-monospace-332 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-356 makeStyles-indicationSeverityError-359 makeStyles-monospace-353 makeStyles-nowrap-355"
                 scope="row"
               >
                 <span>
@@ -10037,13 +10303,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-332 makeStyles-deemphasized-333 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-333"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-354"
                 scope="row"
               >
                 <p
@@ -10069,7 +10335,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-332 makeStyles-deemphasized-333 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
                 scope="row"
               >
                 <span>
@@ -10077,7 +10343,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-332 makeStyles-deemphasized-333 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
                 scope="row"
               >
                 0.1500
@@ -10091,7 +10357,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-335 makeStyles-indicationSeverityWarning-337 makeStyles-monospace-332 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-356 makeStyles-indicationSeverityWarning-358 makeStyles-monospace-353 makeStyles-nowrap-355"
                 scope="row"
               >
                 <span>
@@ -10099,13 +10365,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-332 makeStyles-deemphasized-333 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
                 scope="row"
               >
                 0.1 &lt; x ≤ 0.4
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-333"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-354"
                 scope="row"
               >
                 <p
@@ -10131,7 +10397,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-332 makeStyles-deemphasized-333 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
                 scope="row"
               >
                 <span>
@@ -10139,7 +10405,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-332 makeStyles-deemphasized-333 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
                 scope="row"
               >
                 0.1000
@@ -10151,7 +10417,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-335 makeStyles-indicationSeverityOk-336 makeStyles-monospace-332 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-356 makeStyles-indicationSeverityOk-357 makeStyles-monospace-353 makeStyles-nowrap-355"
                 scope="row"
               >
                 <span>
@@ -10159,13 +10425,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-332 makeStyles-deemphasized-333 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.8
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-333"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-354"
                 scope="row"
               >
                 <p
@@ -10189,7 +10455,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-332 makeStyles-deemphasized-333 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
                 scope="row"
               >
                 <span>
@@ -10197,7 +10463,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-332 makeStyles-deemphasized-333 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
                 scope="row"
               >
                 0.0000
@@ -10211,7 +10477,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-335 makeStyles-indicationSeverityWarning-337 makeStyles-monospace-332 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-356 makeStyles-indicationSeverityWarning-358 makeStyles-monospace-353 makeStyles-nowrap-355"
                 scope="row"
               >
                 <span>
@@ -10219,13 +10485,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-332 makeStyles-deemphasized-333 makeStyles-nowrap-334"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 makeStyles-deemphasized-354 makeStyles-nowrap-355"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-333"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-354"
                 scope="row"
               >
                 <p
@@ -10240,7 +10506,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <div
-      class="makeStyles-accordions-315"
+      class="makeStyles-accordions-333"
     >
       <div
         class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -10299,7 +10565,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-316"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-334"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -10459,7 +10725,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-316"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-334"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -10472,7 +10738,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                   </p>
                   <pre
-                    class="makeStyles-pre-318"
+                    class="makeStyles-pre-336"
                   >
                     <code>
                       with tracks_counts as (
@@ -10506,10 +10772,10 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders the condensed table with some analyses in non-debug mode for a Revenue Metric 2`] = `
 <div
-  class="makeStyles-root-340 analysis-detail-panel"
+  class="makeStyles-root-361 analysis-detail-panel"
 >
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-354 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-375 MuiTypography-body1"
   >
     Summary
   </p>
@@ -10529,7 +10795,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableCell-root MuiTableCell-body"
           >
             <h5
-              class="MuiTypography-root makeStyles-recommendation-353 MuiTypography-h5 MuiTypography-gutterBottom"
+              class="MuiTypography-root makeStyles-recommendation-374 MuiTypography-h5 MuiTypography-gutterBottom"
             >
               Deploy either variation
             </h5>
@@ -10592,7 +10858,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </strong>
              
             <span
-              class="makeStyles-root-358"
+              class="makeStyles-root-379"
               title="09/05/2020, 20:00:00"
             >
               2020-05-10
@@ -10617,7 +10883,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-354 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-375 MuiTypography-body1"
   >
     Analysis
   </p>
@@ -10625,7 +10891,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     class="MuiPaper-root MuiTableContainer-root MuiPaper-elevation1 MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-coolTable-355"
+      class="MuiTable-root makeStyles-coolTable-376"
     >
       <thead
         class="MuiTableHead-root"
@@ -10666,22 +10932,22 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-348 makeStyles-headerCell-341 makeStyles-credibleIntervalHeader-352"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-369 makeStyles-headerCell-362 makeStyles-credibleIntervalHeader-373"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-342"
+              class="makeStyles-monospace-363"
             >
               test
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-342 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-363 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-330"
+              class="makeStyles-tooltipped-351"
             >
               -1.12
                to 
@@ -10691,10 +10957,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-342 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-363 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-330"
+              class="makeStyles-tooltipped-351"
             >
               -0.01
                to 
@@ -10705,10 +10971,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-342 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-363 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-330"
+              class="makeStyles-tooltipped-351"
             >
               -50
                to 
@@ -10723,22 +10989,22 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-348 makeStyles-headerCell-341 makeStyles-credibleIntervalHeader-352"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-369 makeStyles-headerCell-362 makeStyles-credibleIntervalHeader-373"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-342"
+              class="makeStyles-monospace-363"
             >
               control
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-342 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-363 MuiTableCell-alignRight"
           >
             <span
-              class="makeStyles-tooltipped-330"
+              class="makeStyles-tooltipped-351"
             >
               0.00
                to 
@@ -10748,12 +11014,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-342 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-363 MuiTableCell-alignRight"
           >
             Baseline
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-342 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-363 MuiTableCell-alignRight"
           >
             Baseline
           </td>
@@ -10762,7 +11028,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-analysisFinePrint-351 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-analysisFinePrint-372 MuiTypography-body1"
   >
     95% Credible Intervals (CIs). 
     <strong>
@@ -10775,15 +11041,15 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     .
   </p>
   <div
-    class="makeStyles-metricEstimatePlots-343"
+    class="makeStyles-metricEstimatePlots-364"
   />
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-354 makeStyles-clickable-356 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-375 makeStyles-clickable-377 MuiTypography-body1"
     role="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-357"
+      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-378"
       focusable="false"
       viewBox="0 0 24 24"
     >
@@ -10801,7 +11067,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-313",
+        "className": "makeStyles-participantsPlot-331",
         "data": Array [
           Object {
             "line": Object {
@@ -10860,7 +11126,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-344",
+        "className": "makeStyles-metricEstimatePlot-365",
         "data": Array [
           Object {
             "line": Object {
@@ -10956,7 +11222,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-344",
+        "className": "makeStyles-metricEstimatePlot-365",
         "data": Array [
           Object {
             "line": Object {
@@ -11058,7 +11324,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-344",
+        "className": "makeStyles-metricEstimatePlot-365",
         "data": Array [
           Object {
             "line": Object {
@@ -11154,7 +11420,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-344",
+        "className": "makeStyles-metricEstimatePlot-365",
         "data": Array [
           Object {
             "line": Object {

--- a/src/components/general/MetricValueInterval.tsx
+++ b/src/components/general/MetricValueInterval.tsx
@@ -20,6 +20,7 @@ const useStyles = makeStyles((theme: Theme) =>
  * Displays a metric value interval.
  */
 export default function MetricValueInterval({
+  className,
   intervalName,
   metricParameterType,
   isDifference = false,
@@ -28,6 +29,7 @@ export default function MetricValueInterval({
   displayTooltipHint = true,
   displayPositiveSign = true,
 }: {
+  className?: string
   intervalName: string
   metricParameterType: MetricParameterType
   isDifference?: boolean
@@ -62,7 +64,7 @@ export default function MetricValueInterval({
         </>
       }
     >
-      <span className={clsx(displayTooltipHint && classes.tooltipped)}>
+      <span className={clsx(displayTooltipHint && classes.tooltipped, className)}>
         <MetricValue
           value={bottomValue}
           metricParameterType={metricParameterType}


### PR DESCRIPTION
This PR emphasizes significant results and de-emphasizes insignificant ones in the Metric Assignment Results table.

<!-- Describe your changes in detail. -->

- Bold font == practically and statistically significant
- Light grey font == practically insignificant and/or statistically insignificant
- The light grey is the same as the Health Report table grey
- Also added an info icon with a tooltip explaining the meaning of the style differences

ActualExperimentResults.tsx was edited to add the varying font styles based on if the results were practically significant and statistically significant.

In issue #555, it was mentioned that:

> We could then add an info icon somewhere in the header educating experimenters about these three styles.

Is the info icon with tooltip a good implementation of this, or is there a better way to design this?

Before
<img width="1320" alt="Screen Shot 2021-10-03 at 4 58 37 PM" src="https://user-images.githubusercontent.com/1518252/135772832-c9fde474-523b-4231-9c68-f9bc844692db.png">

After
<img width="1316" alt="Screen Shot 2021-10-03 at 4 38 50 PM" src="https://user-images.githubusercontent.com/1518252/135772706-033aa94b-037e-4595-87f4-4ad5018be6d5.png">

<!-- If it fixes an open issue, please link to the issue here. -->
Closes #555 

## How has this been tested?

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
- Updated snapshot for testing this change