### PR TITLE
Metrics Assignment Table: Resize row height on column resize for AgGridWithDetails

### DIFF
--- a/src/components/general/AgGridWithDetails.tsx
+++ b/src/components/general/AgGridWithDetails.tsx
@@ -1,6 +1,7 @@
 import {
   CellClickedEvent,
   ColumnApi,
+  ColumnResizedEvent,
   GetRowNodeIdFunc,
   GridApi,
   GridReadyEvent,
@@ -214,6 +215,16 @@ const AgGridWithDetails: ForwardRefRenderFunction<AgGridWithDetailsHandle, AgGri
     gridApiRef.current.sizeColumnsToFit()
   }
 
+  // istanbul ignore next; difficult to test through unit testing, better to test visually
+  const onColumnResized = (event: ColumnResizedEvent) => {
+    if (!gridApiRef.current || !event.finished) {
+      return
+    }
+
+    gridApiRef.current.resetRowHeights()
+    gridApiRef.current.redrawRows()
+  }
+
   const onCellClicked = (event: CellClickedEvent) => {
     // Ignore clicks on cells with 'actions'
     if (actionColumnIdSuffix && event.column.getColId().endsWith(actionColumnIdSuffix)) {
@@ -255,6 +266,7 @@ const AgGridWithDetails: ForwardRefRenderFunction<AgGridWithDetailsHandle, AgGri
       onCellClicked={onCellClicked}
       onGridReady={onGridReady}
       onGridSizeChanged={onGridSizeChanged}
+      onColumnResized={onColumnResized}
       immutableData={true}
       {...gridOptions}
     />


### PR DESCRIPTION
## Changes in this PR

**Metrics Assignment Table Stacked PR: 2/3**: based on #625. Next #630 

- Fixes a bug where when an AG Grid (with details) column is resized, the row height did not properly adjust.
- The e2e test for the Metrics page was also adjusted to hopefully decrease the flakiness.

Relevant to #604 

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
- Manual testing with mock data (locally or on Vercel)
