### PR TITLE
Metrics Assignment Table: Add 'Assign Metric' button option to Metrics table

### DIFF
--- a/src/components/metrics/MetricsTableAgGrid.test.tsx
+++ b/src/components/metrics/MetricsTableAgGrid.test.tsx
@@ -108,3 +108,20 @@ test('with some metrics can search parameters', async () => {
     expect(metric).not.toBeInTheDocument()
   })
 })
+
+test('with some metrics and onAssignMetric can click on the assign metric button', async () => {
+  const user = userEvent.setup()
+  const onAssignMetric = jest.fn()
+  const { container } = render(
+    <MetricsTableAgGrid metrics={Fixtures.createMetrics(2)} onAssignMetric={onAssignMetric} />,
+  )
+
+  const containerElmt = container.querySelector('.ag-center-cols-container') as HTMLDivElement
+  await waitFor(() => getByText(containerElmt, /metric_1/), { container })
+
+  const buttons = screen.getAllByRole('button', { name: /Assign metric/i })
+
+  await user.click(buttons[0])
+
+  expect(onAssignMetric.mock.calls.length).toBe(1)
+})

--- a/src/components/metrics/MetricsTableAgGrid.tsx
+++ b/src/components/metrics/MetricsTableAgGrid.tsx
@@ -8,7 +8,13 @@ import React from 'react'
 import { Metric } from 'src/lib/schemas'
 
 import GridContainer from '../general/GridContainer'
-import { Data, MetricDetailRenderer, MetricEditButtonRenderer, MetricNameRenderer } from './MetricsTableAgGrid.utils'
+import {
+  AssignMetricButtonRenderer,
+  Data,
+  MetricDetailRenderer,
+  MetricEditButtonRenderer,
+  MetricNameRenderer,
+} from './MetricsTableAgGrid.utils'
 
 const ACTION_COLUMN_SUFFIX = '--actions'
 
@@ -19,10 +25,12 @@ const MetricsTableAgGrid = ({
   title,
   metrics,
   onEditMetric,
+  onAssignMetric,
 }: {
   title?: string
   metrics: Metric[]
   onEditMetric?: (metricId: number) => void
+  onAssignMetric?: (data: Metric) => void
 }): JSX.Element => {
   const theme = useTheme()
 
@@ -70,6 +78,7 @@ const MetricsTableAgGrid = ({
     {
       headerName: 'Parameter Type',
       field: 'parameterType',
+      hide: !!onAssignMetric,
       width: 200,
     },
     {
@@ -91,7 +100,7 @@ const MetricsTableAgGrid = ({
       ? [
           {
             headerName: 'Actions',
-            field: `metrics${ACTION_COLUMN_SUFFIX}`,
+            field: `metrics-edit${ACTION_COLUMN_SUFFIX}`,
             sortable: false,
             filter: false,
             resizable: false,
@@ -107,6 +116,26 @@ const MetricsTableAgGrid = ({
             ),
             width: 100,
             minWidth: 54,
+          },
+        ]
+      : []),
+    ...(onAssignMetric
+      ? [
+          {
+            headerName: 'Actions',
+            field: `metrics-assign${ACTION_COLUMN_SUFFIX}`,
+            sortable: false,
+            filter: false,
+            resizable: false,
+            cellStyle: {
+              justifyContent: 'center',
+              padding: '10px 4px',
+            },
+            cellRendererFramework: ({ data }: { data: Metric }) => (
+              <AssignMetricButtonRenderer data={data} onAssignMetric={onAssignMetric} />
+            ),
+            width: 150,
+            minWidth: 150,
           },
         ]
       : []),

--- a/src/components/metrics/MetricsTableAgGrid.utils.tsx
+++ b/src/components/metrics/MetricsTableAgGrid.utils.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   createStyles,
   IconButton,
   makeStyles,
@@ -9,9 +10,9 @@ import {
   TableRow,
   Theme,
   Tooltip,
+  withStyles,
 } from '@material-ui/core'
-import { Edit as EditIcon } from '@material-ui/icons'
-import debugFactory from 'debug'
+import { Add as AddIcon, Edit as EditIcon } from '@material-ui/icons'
 import React from 'react'
 
 import { Metric } from 'src/lib/schemas'
@@ -19,9 +20,7 @@ import { formatBoolean } from 'src/utils/formatters'
 
 export type Data = Partial<Metric & Record<string, unknown>>
 
-const debug = debugFactory('abacus:components/MetricTableRenderers.tsx')
-
-const useStyles = makeStyles((theme: Theme) =>
+const useMetricDetailStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       padding: theme.spacing(2, 8),
@@ -46,20 +45,45 @@ const useStyles = makeStyles((theme: Theme) =>
       borderStyle: 'solid',
       background: '#fff',
     },
-    metricName: {
-      minWidth: 0,
-      flex: 1,
-      justifyContent: 'flex-start',
-      whiteSpace: 'nowrap',
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-    },
   }),
 )
 
+const useMetricNameStyles = makeStyles({
+  metricName: {
+    minWidth: 0,
+    flex: 1,
+    justifyContent: 'flex-start',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+})
+
+const useAssignMetricButtonStyles = makeStyles({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    '& .MuiButton-containedSizeSmall': {
+      padding: '5px 15px',
+      fontSize: '14px',
+      lineHeight: 1.75,
+    },
+    '& .MuiButton-label': {
+      fontSize: '0.875rem',
+      marginRight: 4,
+    },
+    '& .MuiButton-startIcon': {
+      marginLeft: 0,
+      marginRight: 2,
+    },
+  },
+  noWrap: {
+    whiteSpace: 'nowrap',
+  },
+})
+
 export const MetricDetailRenderer = ({ data }: { data: Data }): JSX.Element => {
-  debug('MetricDetailRenderer#render')
-  const classes = useStyles()
+  const classes = useMetricDetailStyles()
 
   return (
     <TableContainer className={classes.root}>
@@ -84,8 +108,7 @@ export const MetricDetailRenderer = ({ data }: { data: Data }): JSX.Element => {
 }
 
 export const MetricNameRenderer = ({ name }: { name: string }): JSX.Element => {
-  debug('MetricNameRenderer#render')
-  const classes = useStyles()
+  const classes = useMetricNameStyles()
 
   return (
     <Tooltip title={name}>
@@ -101,8 +124,6 @@ export const MetricEditButtonRenderer = ({
   data: Metric
   onEditMetric: (metricId: number) => void
 }): JSX.Element => {
-  debug('MetricEditButtonRenderer#render')
-
   return (
     <IconButton
       onClick={() => {
@@ -112,5 +133,42 @@ export const MetricEditButtonRenderer = ({
     >
       <EditIcon />
     </IconButton>
+  )
+}
+
+export const AssignMetricButtonRenderer = ({
+  data,
+  onAssignMetric,
+}: {
+  data: Metric
+  onAssignMetric: (data: Metric) => void
+}): JSX.Element => {
+  const classes = useAssignMetricButtonStyles()
+
+  const ColorButton = withStyles((theme: Theme) => ({
+    root: {
+      color: theme.palette.primary.contrastText,
+      backgroundColor: theme.palette.primary.light,
+      '&:hover': {
+        backgroundColor: theme.palette.primary.main,
+      },
+    },
+  }))(Button)
+
+  return (
+    <div className={classes.root}>
+      <ColorButton
+        variant='contained'
+        color='primary'
+        disableElevation
+        size='small'
+        onClick={() => onAssignMetric(data)}
+        startIcon={<AddIcon />}
+        className={classes.noWrap}
+        aria-label='Assign metric'
+      >
+        Assign Metric
+      </ColorButton>
+    </div>
   )
 }


### PR DESCRIPTION
## Changes in this PR

**Metrics Assignment Table Stacked PR: 4/6**: based on #627. Next #630 

- Adds an option to add an "Assign Metric" button to the Metrics Table so that it can be used for the Experiment Wizard
- This PR only adds the component code for review, but it is not added to Abacus at this stage. The next PR adds the component to the Wizard.

Relevant to #604

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
