### PR TITLE
Metrics Assignment Table: Add metrics table AG Grid to experiment wizard

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -35,5 +35,5 @@ module.exports = {
   // Adds special extended assertions to Jest, thus simplifying the tests.
   setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect', '<rootDir>/src/test-helpers/unit-test-setup.ts'],
   testPathIgnorePatterns: ['/src/__tests__/', '/e2e/', '/node_modules/'],
-  testTimeout: 180000,
+  testTimeout: 360000,
 }

--- a/src/components/experiments/wizard/ExperimentForm.test.tsx
+++ b/src/components/experiments/wizard/ExperimentForm.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, getByRole, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { StatusCodes } from 'http-status-codes'
 import _ from 'lodash'
 import noop from 'lodash/noop'
@@ -134,7 +134,7 @@ test('sections should be browsable by the next and prev buttons', async () => {
   })
   screen.getByText(/Assign Metrics/)
   await act(async () => {
-    fireEvent.click(screen.getByRole('button', { name: /Next/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
   })
   screen.getByText(/Confirm and Submit Your Experiment/)
 })
@@ -178,17 +178,9 @@ test('sections should be browsable by the section buttons and show validation er
   // We add a metricAssignment first so it can show validation errors
   screen.getByText(/Assign Metrics/)
   expect(container).toMatchSnapshot()
-  const metricSearchField = screen.getByRole('combobox', { name: /Select a metric/ })
-  const metricSearchFieldMoreButton = getByRole(metricSearchField, 'button', { name: 'Open' })
-  const metricAddButton = screen.getByRole('button', { name: 'Add metric' })
-
-  fireEvent.click(metricSearchFieldMoreButton)
-  const metricOption = await screen.findByRole('option', { name: /metric_10/ })
+  const metricAssignButtons = await screen.findAllByRole('button', { name: 'Assign metric' })
   await act(async () => {
-    fireEvent.click(metricOption)
-  })
-  await act(async () => {
-    fireEvent.click(metricAddButton)
+    fireEvent.click(metricAssignButtons[0])
   })
 
   await act(async () => {
@@ -434,17 +426,14 @@ test('form submits with valid fields', async () => {
 
   // ### Metrics
   screen.getByText(/Assign Metrics/)
-  const metricSearchField = screen.getByRole('combobox', { name: /Select a metric/ })
-  const metricSearchFieldMoreButton = getByRole(metricSearchField, 'button', { name: 'Open' })
-  const metricAddButton = screen.getByRole('button', { name: 'Add metric' })
-
-  fireEvent.click(metricSearchFieldMoreButton)
-  const metricOption = await screen.findByRole('option', { name: /metric_10/ })
-  await act(async () => {
-    fireEvent.click(metricOption)
+  let metricAssignButtons: HTMLElement[] = []
+  await screen.findByText(/metric_1/)
+  await waitFor(() => {
+    metricAssignButtons = screen.getAllByRole('button', { name: /Assign metric/i })
+    expect(metricAssignButtons.length).toBeGreaterThanOrEqual(2)
   })
   await act(async () => {
-    fireEvent.click(metricAddButton)
+    fireEvent.click(metricAssignButtons[1])
   })
 
   const attributionWindowField = await screen.findByLabelText('Attribution Window')
@@ -495,7 +484,7 @@ test('form submits with valid fields', async () => {
   await changeFieldByRole('textbox', /Property Value/, 'value')
 
   await act(async () => {
-    fireEvent.click(screen.getByRole('button', { name: /Next/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
   })
 
   // ### Submit
@@ -610,7 +599,7 @@ test('form submits an edited experiment without any changes', async () => {
     fireEvent.click(screen.getByRole('button', { name: /Next/ }))
   })
   await act(async () => {
-    fireEvent.click(screen.getByRole('button', { name: /Next/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
   })
 
   // ### Submit

--- a/src/components/experiments/wizard/Metrics.test.tsx
+++ b/src/components/experiments/wizard/Metrics.test.tsx
@@ -1,4 +1,12 @@
-import { act, fireEvent, getByRole, screen } from '@testing-library/react'
+import {
+  act,
+  fireEvent,
+  getByText,
+  getDefaultNormalizer,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from '@testing-library/react'
 import { Formik } from 'formik'
 import React from 'react'
 
@@ -14,13 +22,28 @@ const indexedMetrics: Record<number, Metric> = {
     metricId: 1,
     name: 'asdf_7d_refund',
     description: 'string',
+    higherIsBetter: true,
     parameterType: MetricParameterType.Revenue,
+    revenueParams: {
+      refundDays: 7,
+      productSlugs: ['wp-bundles'],
+      transactionTypes: ['new purchase'],
+    },
   },
   2: {
     metricId: 2,
     name: 'registration_start',
     description: 'string',
+    higherIsBetter: true,
     parameterType: MetricParameterType.Conversion,
+    eventParams: [
+      {
+        event: 'wpcom_registration_start',
+        props: {
+          has_blocks: true,
+        },
+      },
+    ],
   },
 }
 const completionBag: ExperimentFormCompletionBag = {
@@ -76,19 +99,22 @@ test('allows adding, editing and removing a Metric Assignment', async () => {
       {(formikProps) => <Metrics {...{ indexedMetrics, completionBag, formikProps }} />}
     </Formik>,
   )
-  expect(container).toMatchSnapshot()
 
-  const metricSearchField = screen.getByRole('combobox', { name: /Select a metric/ })
-  const metricSearchFieldMoreButton = getByRole(metricSearchField, 'button', { name: 'Open' })
-  const metricAddButton = screen.getByRole('button', { name: 'Add metric' })
-
-  fireEvent.click(metricAddButton)
+  const containerElmt = container.querySelector('.ag-center-cols-container') as HTMLDivElement
+  await waitFor(() => expect(containerElmt).not.toBeNull())
 
   expect(container).toMatchSnapshot()
 
-  fireEvent.click(metricSearchFieldMoreButton)
-  fireEvent.click(await screen.findByRole('option', { name: /asdf_7d_refund/ }))
-  fireEvent.click(metricAddButton)
+  let metricAssignButtons: HTMLElement[] = []
+  await waitFor(() => {
+    metricAssignButtons = screen.getAllByRole('button', { name: /Assign metric/i })
+    expect(metricAssignButtons.length).toBe(2)
+  })
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  await act(async () => {
+    fireEvent.click(metricAssignButtons[0])
+  })
 
   expect(container).toMatchSnapshot()
 
@@ -102,7 +128,9 @@ test('allows adding, editing and removing a Metric Assignment', async () => {
   await changeFieldByRole('spinbutton', /Minimum Difference/, '0.01')
 
   const moreMenu = screen.getByRole('button', { name: /more/ })
+
   fireEvent.click(moreMenu)
+  await screen.findByRole('menuitem', { name: /Set as Primary/ })
 
   expect(container).toMatchSnapshot()
 
@@ -123,12 +151,58 @@ test('allows adding, editing and removing a Metric Assignment', async () => {
 
   expect(container).toMatchSnapshot()
 
-  fireEvent.click(metricSearchFieldMoreButton)
-  fireEvent.click(await screen.findByRole('option', { name: /registration_start/ }))
   // eslint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
-    fireEvent.click(metricAddButton)
+    fireEvent.click(metricAssignButtons[1])
   })
 
   expect(container).toMatchSnapshot()
+})
+
+test('renders metric details in the metrics table', async () => {
+  const { container } = render(
+    <Formik
+      initialValues={{ experiment: experimentToFormData({}) }}
+      onSubmit={
+        /* istanbul ignore next; This is unused */
+        () => undefined
+      }
+    >
+      {(formikProps) => <Metrics {...{ indexedMetrics, completionBag, formikProps }} />}
+    </Formik>,
+  )
+
+  const containerElmt = container.querySelector('.ag-center-cols-container') as HTMLDivElement
+  expect(containerElmt).not.toBeNull()
+  await waitFor(() => getByText(containerElmt, /registration_start/), { container })
+
+  // Open metric details
+  for (let i = 1; i <= Object.keys(indexedMetrics).length; i++) {
+    const metric = indexedMetrics[i]
+    const metricElmt = containerElmt.querySelector(`div.ag-row[row-id='${metric.name}'] .ag-cell`) as HTMLElement
+    fireEvent.click(metricElmt)
+    const detailContainerElmt = container.querySelector('div.ag-full-width-container') as HTMLDivElement
+
+    await waitFor(() => getByText(detailContainerElmt, /Higher is Better:/))
+    getByText(detailContainerElmt, metric.name)
+    metric.parameterType === 'conversion'
+      ? getByText(detailContainerElmt, /conversion/)
+      : getByText(detailContainerElmt, /revenue/)
+    metric.higherIsBetter ? getByText(detailContainerElmt, /Yes/) : getByText(detailContainerElmt, /No/)
+    getByText(detailContainerElmt, /Parameters/)
+
+    getByText(
+      detailContainerElmt,
+      JSON.stringify(metric.parameterType === 'conversion' ? metric.eventParams : metric.revenueParams, null, 4),
+      {
+        normalizer: getDefaultNormalizer({ trim: true, collapseWhitespace: false }),
+      },
+    )
+
+    // Close metric details
+    fireEvent.click(metricElmt)
+    await waitForElementToBeRemoved(
+      detailContainerElmt.querySelector(`div.ag-full-width-row[row-id='${metric.name}-detail']`),
+    )
+  }
 })

--- a/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
@@ -421,10 +421,10 @@ exports[`renders as expected 1`] = `
 exports[`sections should be browsable by the section buttons and show validation errors without crashing 1`] = `
 <div>
   <div
-    class="makeStyles-root-112"
+    class="makeStyles-root-113"
   >
     <div
-      class="MuiPaper-root makeStyles-navigation-113 MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root makeStyles-navigation-114 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-horizontal MuiPaper-elevation0"
@@ -711,7 +711,7 @@ exports[`sections should be browsable by the section buttons and show validation
     </div>
     <div>
       <form
-        class="makeStyles-form-114"
+        class="makeStyles-form-115"
         novalidate=""
       >
         <button
@@ -721,13 +721,13 @@ exports[`sections should be browsable by the section buttons and show validation
           type="submit"
         />
         <div
-          class="makeStyles-formPart-115"
+          class="makeStyles-formPart-116"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-117 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-118 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-118"
+              class="makeStyles-root-119"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -773,7 +773,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-p2EntryField-119"
+                class="MuiFormControl-root MuiTextField-root makeStyles-p2EntryField-120"
               >
                 <label
                   class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
@@ -797,10 +797,10 @@ exports[`sections should be browsable by the section buttons and show validation
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-121 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-122 MuiOutlinedInput-notchedOutline"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legendLabelled-123 PrivateNotchedOutline-legendNotched-124"
+                      class="PrivateNotchedOutline-legendLabelled-124 PrivateNotchedOutline-legendNotched-125"
                     >
                       <span>
                         Your Post's URL
@@ -812,7 +812,7 @@ exports[`sections should be browsable by the section buttons and show validation
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-116"
+            class="makeStyles-formPartActions-117"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -839,10 +839,10 @@ exports[`sections should be browsable by the section buttons and show validation
 exports[`sections should be browsable by the section buttons and show validation errors without crashing 2`] = `
 <div>
   <div
-    class="makeStyles-root-112"
+    class="makeStyles-root-113"
   >
     <div
-      class="MuiPaper-root makeStyles-navigation-113 MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root makeStyles-navigation-114 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-horizontal MuiPaper-elevation0"
@@ -1089,7 +1089,7 @@ exports[`sections should be browsable by the section buttons and show validation
     </div>
     <div>
       <form
-        class="makeStyles-form-114"
+        class="makeStyles-form-115"
         novalidate=""
       >
         <button
@@ -1099,10 +1099,10 @@ exports[`sections should be browsable by the section buttons and show validation
           type="submit"
         />
         <div
-          class="makeStyles-formPart-115"
+          class="makeStyles-formPart-116"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-117 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-118 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <h4
               class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1138,7 +1138,7 @@ exports[`sections should be browsable by the section buttons and show validation
             </p>
           </div>
           <div
-            class="makeStyles-formPartActions-116"
+            class="makeStyles-formPartActions-117"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -1155,7 +1155,7 @@ exports[`sections should be browsable by the section buttons and show validation
               />
             </button>
             <div
-              class="makeStyles-root-126"
+              class="makeStyles-root-127"
             >
               <button
                 class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary Mui-disabled Mui-disabled"
@@ -1181,10 +1181,10 @@ exports[`sections should be browsable by the section buttons and show validation
 exports[`sections should be browsable by the section buttons and show validation errors without crashing 3`] = `
 <div>
   <div
-    class="makeStyles-root-112"
+    class="makeStyles-root-113"
   >
     <div
-      class="MuiPaper-root makeStyles-navigation-113 MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root makeStyles-navigation-114 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-horizontal MuiPaper-elevation0"
@@ -1441,7 +1441,7 @@ exports[`sections should be browsable by the section buttons and show validation
     </div>
     <div>
       <form
-        class="makeStyles-form-114"
+        class="makeStyles-form-115"
         novalidate=""
       >
         <button
@@ -1451,13 +1451,13 @@ exports[`sections should be browsable by the section buttons and show validation
           type="submit"
         />
         <div
-          class="makeStyles-formPart-115"
+          class="makeStyles-formPart-116"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-117 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-118 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-128"
+              class="makeStyles-root-129"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1527,22 +1527,22 @@ exports[`sections should be browsable by the section buttons and show validation
                 </table>
               </div>
               <div
-                class="makeStyles-tableContainer-148"
+                class="makeStyles-tableContainer-149"
               >
                 <div
-                  class="ag-theme-alpine makeStyles-root-152"
+                  class="ag-theme-alpine makeStyles-root-153"
                 >
                   <div
-                    class="makeStyles-toolbar-153"
+                    class="makeStyles-toolbar-154"
                   >
                     <div
-                      class="makeStyles-rootFullWidth-156"
+                      class="makeStyles-rootFullWidth-157"
                     >
                       <div
-                        class="makeStyles-search-157"
+                        class="makeStyles-search-158 makeStyles-searchBorder-159"
                       >
                         <div
-                          class="makeStyles-searchIcon-158"
+                          class="makeStyles-searchIcon-160"
                         >
                           <svg
                             aria-hidden="true"
@@ -1556,11 +1556,11 @@ exports[`sections should be browsable by the section buttons and show validation
                           </svg>
                         </div>
                         <div
-                          class="MuiInputBase-root makeStyles-inputRootFullWidth-159"
+                          class="MuiInputBase-root makeStyles-inputRootFullWidth-161"
                         >
                           <input
                             aria-label="Search"
-                            class="MuiInputBase-input makeStyles-inputInputFullWidth-160"
+                            class="MuiInputBase-input makeStyles-inputInputFullWidth-162"
                             placeholder="Search…"
                             type="text"
                             value=""
@@ -1584,7 +1584,7 @@ exports[`sections should be browsable by the section buttons and show validation
                     </div>
                   </div>
                   <div
-                    class="ag-theme-alpine makeStyles-gridContainer-154"
+                    class="ag-theme-alpine makeStyles-gridContainer-155"
                   >
                     <div
                       style="height: auto; flex: 1;"
@@ -1770,7 +1770,7 @@ exports[`sections should be browsable by the section buttons and show validation
                                     <div
                                       aria-colindex="2"
                                       aria-sort="none"
-                                      class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-151"
+                                      class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-152"
                                       col-id="name"
                                       role="columnheader"
                                       style="width: 465px; left: 34px;"
@@ -3449,7 +3449,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-138 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-139 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -3487,7 +3487,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-139 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-140 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -3508,13 +3508,13 @@ exports[`sections should be browsable by the section buttons and show validation
                   class="MuiAlert-message"
                 >
                   <div
-                    class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-163 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+                    class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-165 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
                   >
                     <div
                       aria-controls="attr-window-panel-content"
                       aria-disabled="false"
                       aria-expanded="false"
-                      class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-164"
+                      class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-166"
                       id="attr-window-panel"
                       role="button"
                       tabindex="0"
@@ -3578,7 +3578,7 @@ exports[`sections should be browsable by the section buttons and show validation
                                 is the window of time after exposure to an experiment that we capture metric events for a participant (exposure can be from either assignment or specified exposure events). The refund window is the window of time after a purchase event. Revenue metrics will automatically deduct transactions that have been refunded within the metric’s refund window.
                                 <br />
                                 <div
-                                  class="makeStyles-attributionWindowDiagram-140"
+                                  class="makeStyles-attributionWindowDiagram-141"
                                 >
                                   <svg>
                                     attribution_window.svg
@@ -3597,7 +3597,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-141 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-142 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -3618,13 +3618,13 @@ exports[`sections should be browsable by the section buttons and show validation
                   class="MuiAlert-message"
                 >
                   <div
-                    class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-163 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+                    class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-165 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
                   >
                     <div
                       aria-controls="min-diff-panel-content"
                       aria-disabled="false"
                       aria-expanded="false"
-                      class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-164"
+                      class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-166"
                       id="min-diff-panel"
                       role="button"
                       tabindex="0"
@@ -3688,7 +3688,7 @@ exports[`sections should be browsable by the section buttons and show validation
                                 are absolute differences from the baseline (not relative). For example, if the baseline conversion rate is 5%, a minimum difference of 0.5 pp is equivalent to a 10% relative change.
                                 <br />
                                 <div
-                                  class="makeStyles-minDiffDiagram-142"
+                                  class="makeStyles-minDiffDiagram-143"
                                 >
                                   <svg>
                                     min_diffs.svg
@@ -3704,7 +3704,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-143 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-144 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -3734,7 +3734,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <h4
-                class="MuiTypography-root makeStyles-exposureEventsTitle-144 MuiTypography-h4"
+                class="MuiTypography-root makeStyles-exposureEventsTitle-145 MuiTypography-h4"
               >
                 Exposure Events
               </h4>
@@ -3767,11 +3767,11 @@ exports[`sections should be browsable by the section buttons and show validation
                 </table>
               </div>
               <div
-                class="makeStyles-addMetric-149"
+                class="makeStyles-addMetric-150"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-150"
+                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-151"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -3796,7 +3796,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </button>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-145 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-146 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -3830,7 +3830,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-146 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-147 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -3861,7 +3861,7 @@ exports[`sections should be browsable by the section buttons and show validation
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-116"
+            class="makeStyles-formPartActions-117"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -3902,10 +3902,10 @@ exports[`sections should be browsable by the section buttons and show validation
 exports[`sections should be browsable by the section buttons and show validation errors without crashing 4`] = `
 <div>
   <div
-    class="makeStyles-root-112"
+    class="makeStyles-root-113"
   >
     <div
-      class="MuiPaper-root makeStyles-navigation-113 MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root makeStyles-navigation-114 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-horizontal MuiPaper-elevation0"
@@ -4162,7 +4162,7 @@ exports[`sections should be browsable by the section buttons and show validation
     </div>
     <div>
       <form
-        class="makeStyles-form-114"
+        class="makeStyles-form-115"
         novalidate=""
       >
         <button
@@ -4172,13 +4172,13 @@ exports[`sections should be browsable by the section buttons and show validation
           type="submit"
         />
         <div
-          class="makeStyles-formPart-115"
+          class="makeStyles-formPart-116"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-117 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-118 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-213"
+              class="makeStyles-root-215"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -4186,7 +4186,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 Basic Info
               </h4>
               <div
-                class="makeStyles-row-214"
+                class="makeStyles-row-216"
               >
                 <div
                   class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -4222,10 +4222,10 @@ exports[`sections should be browsable by the section buttons and show validation
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-196 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-196 PrivateNotchedOutline-legendNotched-197"
+                        class="PrivateNotchedOutline-legendLabelled-198 PrivateNotchedOutline-legendNotched-199"
                       >
                         <span>
                           Experiment name
@@ -4243,7 +4243,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="makeStyles-row-214"
+                class="makeStyles-row-216"
               >
                 <div
                   class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -4278,10 +4278,10 @@ exports[`sections should be browsable by the section buttons and show validation
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-196 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-196 PrivateNotchedOutline-legendNotched-197"
+                        class="PrivateNotchedOutline-legendLabelled-198 PrivateNotchedOutline-legendNotched-199"
                       >
                         <span>
                           Experiment description
@@ -4299,10 +4299,10 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="makeStyles-row-214"
+                class="makeStyles-row-216"
               >
                 <div
-                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-216"
+                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-218"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-error Mui-error Mui-required Mui-required"
@@ -4336,10 +4336,10 @@ exports[`sections should be browsable by the section buttons and show validation
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-196 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-196 PrivateNotchedOutline-legendNotched-197"
+                        class="PrivateNotchedOutline-legendLabelled-198 PrivateNotchedOutline-legendNotched-199"
                       >
                         <span>
                           Start date (UTC)
@@ -4356,12 +4356,12 @@ exports[`sections should be browsable by the section buttons and show validation
                   </p>
                 </div>
                 <span
-                  class="makeStyles-through-215"
+                  class="makeStyles-through-217"
                 >
                    through 
                 </span>
                 <div
-                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-216"
+                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-218"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-error Mui-error Mui-required Mui-required"
@@ -4393,10 +4393,10 @@ exports[`sections should be browsable by the section buttons and show validation
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-196 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-196 PrivateNotchedOutline-legendNotched-197"
+                        class="PrivateNotchedOutline-legendLabelled-198 PrivateNotchedOutline-legendNotched-199"
                       >
                         <span>
                           End date (UTC)
@@ -4442,7 +4442,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="makeStyles-row-214"
+                class="makeStyles-row-216"
               >
                 <div
                   aria-expanded="false"
@@ -4550,10 +4550,10 @@ exports[`sections should be browsable by the section buttons and show validation
                       </div>
                       <fieldset
                         aria-hidden="true"
-                        class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
+                        class="PrivateNotchedOutline-root-196 MuiOutlinedInput-notchedOutline"
                       >
                         <legend
-                          class="PrivateNotchedOutline-legendLabelled-196 PrivateNotchedOutline-legendNotched-197"
+                          class="PrivateNotchedOutline-legendLabelled-198 PrivateNotchedOutline-legendNotched-199"
                         >
                           <span>
                             Owner
@@ -4574,7 +4574,7 @@ exports[`sections should be browsable by the section buttons and show validation
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-116"
+            class="makeStyles-formPartActions-117"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -4615,10 +4615,10 @@ exports[`sections should be browsable by the section buttons and show validation
 exports[`sections should be browsable by the section buttons and show validation errors without crashing 5`] = `
 <div>
   <div
-    class="makeStyles-root-112"
+    class="makeStyles-root-113"
   >
     <div
-      class="MuiPaper-root makeStyles-navigation-113 MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root makeStyles-navigation-114 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-horizontal MuiPaper-elevation0"
@@ -4875,7 +4875,7 @@ exports[`sections should be browsable by the section buttons and show validation
     </div>
     <div>
       <form
-        class="makeStyles-form-114"
+        class="makeStyles-form-115"
         novalidate=""
       >
         <button
@@ -4885,13 +4885,13 @@ exports[`sections should be browsable by the section buttons and show validation
           type="submit"
         />
         <div
-          class="makeStyles-formPart-115"
+          class="makeStyles-formPart-116"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-117 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-118 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-217"
+              class="makeStyles-root-219"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -4947,17 +4947,17 @@ exports[`sections should be browsable by the section buttons and show validation
                       class="MuiTableRow-root"
                     >
                       <td
-                        class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-222"
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-224"
                       >
                         <span
-                          class="makeStyles-metricName-223 makeStyles-tooltipped-224"
+                          class="makeStyles-metricName-225 makeStyles-tooltipped-226"
                           title="This is metric 1"
                         >
                           metric_1
                         </span>
                         <br />
                         <span
-                          class="makeStyles-root-240 makeStyles-monospaced-221"
+                          class="makeStyles-root-242 makeStyles-monospaced-223"
                         >
                           primary
                         </span>
@@ -4966,7 +4966,7 @@ exports[`sections should be browsable by the section buttons and show validation
                         class="MuiTableCell-root MuiTableCell-body"
                       >
                         <div
-                          class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-220 Mui-error Mui-error"
+                          class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-222 Mui-error Mui-error"
                         >
                           <div
                             aria-haspopup="listbox"
@@ -4998,11 +4998,11 @@ exports[`sections should be browsable by the section buttons and show validation
                           </svg>
                           <fieldset
                             aria-hidden="true"
-                            class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
+                            class="PrivateNotchedOutline-root-196 MuiOutlinedInput-notchedOutline"
                             style="padding-left: 8px;"
                           >
                             <legend
-                              class="PrivateNotchedOutline-legend-195"
+                              class="PrivateNotchedOutline-legend-197"
                               style="width: 0.01px;"
                             >
                               <span>
@@ -5018,7 +5018,7 @@ exports[`sections should be browsable by the section buttons and show validation
                         </p>
                       </td>
                       <td
-                        class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-226"
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-228"
                       >
                         <span
                           class="MuiSwitch-root"
@@ -5026,7 +5026,7 @@ exports[`sections should be browsable by the section buttons and show validation
                           <span
                             aria-disabled="false"
                             aria-label="Change Expected"
-                            class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-241 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-242 Mui-checked"
+                            class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-243 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-244 Mui-checked"
                             variant="outlined"
                           >
                             <span
@@ -5034,7 +5034,7 @@ exports[`sections should be browsable by the section buttons and show validation
                             >
                               <input
                                 checked=""
-                                class="PrivateSwitchBase-input-244 MuiSwitch-input"
+                                class="PrivateSwitchBase-input-246 MuiSwitch-input"
                                 id="experiment.metricAssignments[0].changeExpected"
                                 name="experiment.metricAssignments[0].changeExpected"
                                 type="checkbox"
@@ -5057,7 +5057,7 @@ exports[`sections should be browsable by the section buttons and show validation
                         class="MuiTableCell-root MuiTableCell-body"
                       >
                         <div
-                          class="MuiFormControl-root MuiTextField-root makeStyles-root-245 makeStyles-minDifferenceField-225"
+                          class="MuiFormControl-root MuiTextField-root makeStyles-root-247 makeStyles-minDifferenceField-227"
                         >
                           <div
                             class="MuiInputBase-root MuiOutlinedInput-root Mui-error Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
@@ -5076,10 +5076,10 @@ exports[`sections should be browsable by the section buttons and show validation
                               value="0"
                             />
                             <div
-                              class="MuiInputAdornment-root makeStyles-adornment-247 MuiInputAdornment-positionEnd"
+                              class="MuiInputAdornment-root makeStyles-adornment-249 MuiInputAdornment-positionEnd"
                             >
                               <p
-                                class="MuiTypography-root makeStyles-tooltipped-246 MuiTypography-body1 MuiTypography-colorTextSecondary"
+                                class="MuiTypography-root makeStyles-tooltipped-248 MuiTypography-body1 MuiTypography-colorTextSecondary"
                                 title="Percentage Points"
                               >
                                 pp
@@ -5087,11 +5087,11 @@ exports[`sections should be browsable by the section buttons and show validation
                             </div>
                             <fieldset
                               aria-hidden="true"
-                              class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
+                              class="PrivateNotchedOutline-root-196 MuiOutlinedInput-notchedOutline"
                               style="padding-left: 8px;"
                             >
                               <legend
-                                class="PrivateNotchedOutline-legend-195"
+                                class="PrivateNotchedOutline-legend-197"
                                 style="width: 0.01px;"
                               >
                                 <span>
@@ -5145,22 +5145,22 @@ exports[`sections should be browsable by the section buttons and show validation
                 </table>
               </div>
               <div
-                class="makeStyles-tableContainer-237"
+                class="makeStyles-tableContainer-239"
               >
                 <div
-                  class="ag-theme-alpine makeStyles-root-249"
+                  class="ag-theme-alpine makeStyles-root-251"
                 >
                   <div
-                    class="makeStyles-toolbar-250"
+                    class="makeStyles-toolbar-252"
                   >
                     <div
-                      class="makeStyles-rootFullWidth-253"
+                      class="makeStyles-rootFullWidth-255"
                     >
                       <div
-                        class="makeStyles-search-254"
+                        class="makeStyles-search-256 makeStyles-searchBorder-257"
                       >
                         <div
-                          class="makeStyles-searchIcon-255"
+                          class="makeStyles-searchIcon-258"
                         >
                           <svg
                             aria-hidden="true"
@@ -5174,11 +5174,11 @@ exports[`sections should be browsable by the section buttons and show validation
                           </svg>
                         </div>
                         <div
-                          class="MuiInputBase-root makeStyles-inputRootFullWidth-256"
+                          class="MuiInputBase-root makeStyles-inputRootFullWidth-259"
                         >
                           <input
                             aria-label="Search"
-                            class="MuiInputBase-input makeStyles-inputInputFullWidth-257"
+                            class="MuiInputBase-input makeStyles-inputInputFullWidth-260"
                             placeholder="Search…"
                             type="text"
                             value=""
@@ -5202,7 +5202,7 @@ exports[`sections should be browsable by the section buttons and show validation
                     </div>
                   </div>
                   <div
-                    class="ag-theme-alpine makeStyles-gridContainer-251"
+                    class="ag-theme-alpine makeStyles-gridContainer-253"
                   >
                     <div
                       style="height: auto; flex: 1;"
@@ -5388,7 +5388,7 @@ exports[`sections should be browsable by the section buttons and show validation
                                     <div
                                       aria-colindex="2"
                                       aria-sort="none"
-                                      class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-248"
+                                      class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-250"
                                       col-id="name"
                                       role="columnheader"
                                       style="width: 465px; left: 34px;"
@@ -7067,7 +7067,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-227 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-229 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -7105,7 +7105,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-228 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-230 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -7126,13 +7126,13 @@ exports[`sections should be browsable by the section buttons and show validation
                   class="MuiAlert-message"
                 >
                   <div
-                    class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-260 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+                    class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-263 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
                   >
                     <div
                       aria-controls="attr-window-panel-content"
                       aria-disabled="false"
                       aria-expanded="false"
-                      class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-261"
+                      class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-264"
                       id="attr-window-panel"
                       role="button"
                       tabindex="0"
@@ -7196,7 +7196,7 @@ exports[`sections should be browsable by the section buttons and show validation
                                 is the window of time after exposure to an experiment that we capture metric events for a participant (exposure can be from either assignment or specified exposure events). The refund window is the window of time after a purchase event. Revenue metrics will automatically deduct transactions that have been refunded within the metric’s refund window.
                                 <br />
                                 <div
-                                  class="makeStyles-attributionWindowDiagram-229"
+                                  class="makeStyles-attributionWindowDiagram-231"
                                 >
                                   <svg>
                                     attribution_window.svg
@@ -7215,7 +7215,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-230 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-232 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -7236,13 +7236,13 @@ exports[`sections should be browsable by the section buttons and show validation
                   class="MuiAlert-message"
                 >
                   <div
-                    class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-260 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+                    class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-263 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
                   >
                     <div
                       aria-controls="min-diff-panel-content"
                       aria-disabled="false"
                       aria-expanded="false"
-                      class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-261"
+                      class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-264"
                       id="min-diff-panel"
                       role="button"
                       tabindex="0"
@@ -7306,7 +7306,7 @@ exports[`sections should be browsable by the section buttons and show validation
                                 are absolute differences from the baseline (not relative). For example, if the baseline conversion rate is 5%, a minimum difference of 0.5 pp is equivalent to a 10% relative change.
                                 <br />
                                 <div
-                                  class="makeStyles-minDiffDiagram-231"
+                                  class="makeStyles-minDiffDiagram-233"
                                 >
                                   <svg>
                                     min_diffs.svg
@@ -7322,7 +7322,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-232 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-234 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -7352,7 +7352,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <h4
-                class="MuiTypography-root makeStyles-exposureEventsTitle-233 MuiTypography-h4"
+                class="MuiTypography-root makeStyles-exposureEventsTitle-235 MuiTypography-h4"
               >
                 Exposure Events
               </h4>
@@ -7385,11 +7385,11 @@ exports[`sections should be browsable by the section buttons and show validation
                 </table>
               </div>
               <div
-                class="makeStyles-addMetric-238"
+                class="makeStyles-addMetric-240"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-239"
+                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-241"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -7414,7 +7414,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </button>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-234 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-236 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -7448,7 +7448,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-235 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-237 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -7479,7 +7479,7 @@ exports[`sections should be browsable by the section buttons and show validation
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-116"
+            class="makeStyles-formPartActions-117"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -7520,10 +7520,10 @@ exports[`sections should be browsable by the section buttons and show validation
 exports[`sections should be browsable by the section buttons and show validation errors without crashing 6`] = `
 <div>
   <div
-    class="makeStyles-root-112"
+    class="makeStyles-root-113"
   >
     <div
-      class="MuiPaper-root makeStyles-navigation-113 MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root makeStyles-navigation-114 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-horizontal MuiPaper-elevation0"
@@ -7780,7 +7780,7 @@ exports[`sections should be browsable by the section buttons and show validation
     </div>
     <div>
       <form
-        class="makeStyles-form-114"
+        class="makeStyles-form-115"
         novalidate=""
       >
         <button
@@ -7790,13 +7790,13 @@ exports[`sections should be browsable by the section buttons and show validation
           type="submit"
         />
         <div
-          class="makeStyles-formPart-115"
+          class="makeStyles-formPart-116"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-117 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-118 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-279"
+              class="makeStyles-root-282"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -7804,7 +7804,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 Define Your Audience
               </h4>
               <div
-                class="makeStyles-row-280"
+                class="makeStyles-row-283"
               >
                 <fieldset
                   class="MuiFormControl-root"
@@ -7860,7 +7860,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </fieldset>
               </div>
               <div
-                class="makeStyles-row-280"
+                class="makeStyles-row-283"
               >
                 <fieldset
                   class="MuiFormControl-root"
@@ -7892,19 +7892,19 @@ exports[`sections should be browsable by the section buttons and show validation
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-241 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-243 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
                       >
                         <span
                           class="MuiIconButton-label"
                         >
                           <input
-                            class="PrivateSwitchBase-input-244"
+                            class="PrivateSwitchBase-input-246"
                             name="experiment.existingUsersAllowed"
                             type="radio"
                             value="false"
                           />
                           <div
-                            class="PrivateRadioButtonIcon-root-289"
+                            class="PrivateRadioButtonIcon-root-292"
                           >
                             <svg
                               aria-hidden="true"
@@ -7918,7 +7918,7 @@ exports[`sections should be browsable by the section buttons and show validation
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-290"
+                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-293"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
@@ -7943,20 +7943,20 @@ exports[`sections should be browsable by the section buttons and show validation
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-241 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-242 Mui-checked MuiIconButton-colorSecondary"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-243 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-244 Mui-checked MuiIconButton-colorSecondary"
                       >
                         <span
                           class="MuiIconButton-label"
                         >
                           <input
                             checked=""
-                            class="PrivateSwitchBase-input-244"
+                            class="PrivateSwitchBase-input-246"
                             name="experiment.existingUsersAllowed"
                             type="radio"
                             value="true"
                           />
                           <div
-                            class="PrivateRadioButtonIcon-root-289 PrivateRadioButtonIcon-checked-291"
+                            class="PrivateRadioButtonIcon-root-292 PrivateRadioButtonIcon-checked-294"
                           >
                             <svg
                               aria-hidden="true"
@@ -7970,7 +7970,7 @@ exports[`sections should be browsable by the section buttons and show validation
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-290"
+                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-293"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
@@ -7994,10 +7994,10 @@ exports[`sections should be browsable by the section buttons and show validation
                 </fieldset>
               </div>
               <div
-                class="makeStyles-row-280"
+                class="makeStyles-row-283"
               >
                 <fieldset
-                  class="MuiFormControl-root makeStyles-segmentationFieldSet-282"
+                  class="MuiFormControl-root makeStyles-segmentationFieldSet-285"
                 >
                   <label
                     class="MuiFormLabel-root"
@@ -8006,7 +8006,7 @@ exports[`sections should be browsable by the section buttons and show validation
                     Targeting
                   </label>
                   <p
-                    class="MuiFormHelperText-root makeStyles-segmentationHelperText-281"
+                    class="MuiFormHelperText-root makeStyles-segmentationHelperText-284"
                   >
                     Who should see this experiment? 
                     <br />
@@ -8014,7 +8014,7 @@ exports[`sections should be browsable by the section buttons and show validation
                   </p>
                   <div
                     aria-label="include-or-exclude-segments"
-                    class="MuiFormGroup-root makeStyles-segmentationExclusionState-283"
+                    class="MuiFormGroup-root makeStyles-segmentationExclusionState-286"
                     role="radiogroup"
                   >
                     <label
@@ -8022,20 +8022,20 @@ exports[`sections should be browsable by the section buttons and show validation
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-241 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-242 Mui-checked MuiIconButton-colorSecondary"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-243 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-244 Mui-checked MuiIconButton-colorSecondary"
                       >
                         <span
                           class="MuiIconButton-label"
                         >
                           <input
                             checked=""
-                            class="PrivateSwitchBase-input-244"
+                            class="PrivateSwitchBase-input-246"
                             name="non-formik-segment-exclusion-state-include"
                             type="radio"
                             value="include"
                           />
                           <div
-                            class="PrivateRadioButtonIcon-root-289 PrivateRadioButtonIcon-checked-291"
+                            class="PrivateRadioButtonIcon-root-292 PrivateRadioButtonIcon-checked-294"
                           >
                             <svg
                               aria-hidden="true"
@@ -8049,7 +8049,7 @@ exports[`sections should be browsable by the section buttons and show validation
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-290"
+                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-293"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
@@ -8074,19 +8074,19 @@ exports[`sections should be browsable by the section buttons and show validation
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-241 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-243 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
                       >
                         <span
                           class="MuiIconButton-label"
                         >
                           <input
-                            class="PrivateSwitchBase-input-244"
+                            class="PrivateSwitchBase-input-246"
                             name="non-formik-segment-exclusion-state-exclude"
                             type="radio"
                             value="exclude"
                           />
                           <div
-                            class="PrivateRadioButtonIcon-root-289"
+                            class="PrivateRadioButtonIcon-root-292"
                           >
                             <svg
                               aria-hidden="true"
@@ -8100,7 +8100,7 @@ exports[`sections should be browsable by the section buttons and show validation
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-290"
+                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-293"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
@@ -8201,11 +8201,11 @@ exports[`sections should be browsable by the section buttons and show validation
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
+                          class="PrivateNotchedOutline-root-196 MuiOutlinedInput-notchedOutline"
                           style="padding-left: 8px;"
                         >
                           <legend
-                            class="PrivateNotchedOutline-legend-195"
+                            class="PrivateNotchedOutline-legend-197"
                             style="width: 0.01px;"
                           >
                             <span>
@@ -8219,10 +8219,10 @@ exports[`sections should be browsable by the section buttons and show validation
                 </fieldset>
               </div>
               <div
-                class="makeStyles-row-280"
+                class="makeStyles-row-283"
               >
                 <fieldset
-                  class="MuiFormControl-root makeStyles-segmentationFieldSet-282"
+                  class="MuiFormControl-root makeStyles-segmentationFieldSet-285"
                 >
                   <label
                     class="MuiFormLabel-root"
@@ -8231,7 +8231,7 @@ exports[`sections should be browsable by the section buttons and show validation
                     Variations
                   </label>
                   <p
-                    class="MuiFormHelperText-root makeStyles-segmentationHelperText-281"
+                    class="MuiFormHelperText-root makeStyles-segmentationHelperText-284"
                   >
                     Set the percentage of traffic allocated to each variation. Percentages may sum to less than 100 to avoid allocating the entire userbase. 
                     <br />
@@ -8241,7 +8241,7 @@ exports[`sections should be browsable by the section buttons and show validation
                     class="MuiTableContainer-root"
                   >
                     <table
-                      class="MuiTable-root makeStyles-variants-288"
+                      class="MuiTable-root makeStyles-variants-291"
                     >
                       <thead
                         class="MuiTableHead-root"
@@ -8282,7 +8282,7 @@ exports[`sections should be browsable by the section buttons and show validation
                             class="MuiTableCell-root MuiTableCell-body"
                           >
                             <div
-                              class="MuiFormControl-root MuiTextField-root makeStyles-variationAllocatedPercentage-287"
+                              class="MuiFormControl-root MuiTextField-root makeStyles-variationAllocatedPercentage-290"
                             >
                               <div
                                 class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
@@ -8309,11 +8309,11 @@ exports[`sections should be browsable by the section buttons and show validation
                                 </div>
                                 <fieldset
                                   aria-hidden="true"
-                                  class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
+                                  class="PrivateNotchedOutline-root-196 MuiOutlinedInput-notchedOutline"
                                   style="padding-left: 8px;"
                                 >
                                   <legend
-                                    class="PrivateNotchedOutline-legend-195"
+                                    class="PrivateNotchedOutline-legend-197"
                                     style="width: 0.01px;"
                                   >
                                     <span>
@@ -8351,11 +8351,11 @@ exports[`sections should be browsable by the section buttons and show validation
                                 />
                                 <fieldset
                                   aria-hidden="true"
-                                  class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
+                                  class="PrivateNotchedOutline-root-196 MuiOutlinedInput-notchedOutline"
                                   style="padding-left: 8px;"
                                 >
                                   <legend
-                                    class="PrivateNotchedOutline-legend-195"
+                                    class="PrivateNotchedOutline-legend-197"
                                     style="width: 0.01px;"
                                   >
                                     <span>
@@ -8370,7 +8370,7 @@ exports[`sections should be browsable by the section buttons and show validation
                             class="MuiTableCell-root MuiTableCell-body"
                           >
                             <div
-                              class="MuiFormControl-root MuiTextField-root makeStyles-variationAllocatedPercentage-287"
+                              class="MuiFormControl-root MuiTextField-root makeStyles-variationAllocatedPercentage-290"
                             >
                               <div
                                 class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
@@ -8397,11 +8397,11 @@ exports[`sections should be browsable by the section buttons and show validation
                                 </div>
                                 <fieldset
                                   aria-hidden="true"
-                                  class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
+                                  class="PrivateNotchedOutline-root-196 MuiOutlinedInput-notchedOutline"
                                   style="padding-left: 8px;"
                                 >
                                   <legend
-                                    class="PrivateNotchedOutline-legend-195"
+                                    class="PrivateNotchedOutline-legend-197"
                                     style="width: 0.01px;"
                                   >
                                     <span>
@@ -8424,7 +8424,7 @@ exports[`sections should be browsable by the section buttons and show validation
                             colspan="3"
                           >
                             <div
-                              class="MuiPaper-root MuiAlert-root MuiAlert-standardWarning makeStyles-abnWarning-284 MuiPaper-elevation0"
+                              class="MuiPaper-root MuiAlert-root MuiAlert-standardWarning makeStyles-abnWarning-287 MuiPaper-elevation0"
                               role="alert"
                             >
                               <div
@@ -8458,11 +8458,11 @@ exports[`sections should be browsable by the section buttons and show validation
                                   Please do not set up such experiments in production without consulting the ExPlat team first.
                                 </p>
                                 <div
-                                  class="makeStyles-addVariation-285"
+                                  class="makeStyles-addVariation-288"
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    class="MuiSvgIcon-root makeStyles-addVariationIcon-286"
+                                    class="MuiSvgIcon-root makeStyles-addVariationIcon-289"
                                     focusable="false"
                                     viewBox="0 0 24 24"
                                   >
@@ -8498,7 +8498,7 @@ exports[`sections should be browsable by the section buttons and show validation
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-116"
+            class="makeStyles-formPartActions-117"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -8539,10 +8539,10 @@ exports[`sections should be browsable by the section buttons and show validation
 exports[`skipping to submit should check all sections 1`] = `
 <div>
   <div
-    class="makeStyles-root-316"
+    class="makeStyles-root-319"
   >
     <div
-      class="MuiPaper-root makeStyles-navigation-317 MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root makeStyles-navigation-320 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-horizontal MuiPaper-elevation0"
@@ -8789,7 +8789,7 @@ exports[`skipping to submit should check all sections 1`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-318"
+        class="makeStyles-form-321"
         novalidate=""
       >
         <button
@@ -8799,10 +8799,10 @@ exports[`skipping to submit should check all sections 1`] = `
           type="submit"
         />
         <div
-          class="makeStyles-formPart-319"
+          class="makeStyles-formPart-322"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-321 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-324 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <h4
               class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -8838,7 +8838,7 @@ exports[`skipping to submit should check all sections 1`] = `
             </p>
           </div>
           <div
-            class="makeStyles-formPartActions-320"
+            class="makeStyles-formPartActions-323"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -8855,7 +8855,7 @@ exports[`skipping to submit should check all sections 1`] = `
               />
             </button>
             <div
-              class="makeStyles-root-330"
+              class="makeStyles-root-333"
             >
               <button
                 class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary Mui-disabled Mui-disabled"

--- a/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/ExperimentForm.test.tsx.snap
@@ -421,10 +421,10 @@ exports[`renders as expected 1`] = `
 exports[`sections should be browsable by the section buttons and show validation errors without crashing 1`] = `
 <div>
   <div
-    class="makeStyles-root-82"
+    class="makeStyles-root-112"
   >
     <div
-      class="MuiPaper-root makeStyles-navigation-83 MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root makeStyles-navigation-113 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-horizontal MuiPaper-elevation0"
@@ -711,7 +711,7 @@ exports[`sections should be browsable by the section buttons and show validation
     </div>
     <div>
       <form
-        class="makeStyles-form-84"
+        class="makeStyles-form-114"
         novalidate=""
       >
         <button
@@ -721,13 +721,13 @@ exports[`sections should be browsable by the section buttons and show validation
           type="submit"
         />
         <div
-          class="makeStyles-formPart-85"
+          class="makeStyles-formPart-115"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-87 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-117 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-88"
+              class="makeStyles-root-118"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -773,7 +773,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-p2EntryField-89"
+                class="MuiFormControl-root MuiTextField-root makeStyles-p2EntryField-119"
               >
                 <label
                   class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
@@ -797,10 +797,10 @@ exports[`sections should be browsable by the section buttons and show validation
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-91 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-121 MuiOutlinedInput-notchedOutline"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legendLabelled-93 PrivateNotchedOutline-legendNotched-94"
+                      class="PrivateNotchedOutline-legendLabelled-123 PrivateNotchedOutline-legendNotched-124"
                     >
                       <span>
                         Your Post's URL
@@ -812,7 +812,7 @@ exports[`sections should be browsable by the section buttons and show validation
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-86"
+            class="makeStyles-formPartActions-116"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -839,10 +839,10 @@ exports[`sections should be browsable by the section buttons and show validation
 exports[`sections should be browsable by the section buttons and show validation errors without crashing 2`] = `
 <div>
   <div
-    class="makeStyles-root-82"
+    class="makeStyles-root-112"
   >
     <div
-      class="MuiPaper-root makeStyles-navigation-83 MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root makeStyles-navigation-113 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-horizontal MuiPaper-elevation0"
@@ -1089,7 +1089,7 @@ exports[`sections should be browsable by the section buttons and show validation
     </div>
     <div>
       <form
-        class="makeStyles-form-84"
+        class="makeStyles-form-114"
         novalidate=""
       >
         <button
@@ -1099,10 +1099,10 @@ exports[`sections should be browsable by the section buttons and show validation
           type="submit"
         />
         <div
-          class="makeStyles-formPart-85"
+          class="makeStyles-formPart-115"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-87 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-117 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <h4
               class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1138,7 +1138,7 @@ exports[`sections should be browsable by the section buttons and show validation
             </p>
           </div>
           <div
-            class="makeStyles-formPartActions-86"
+            class="makeStyles-formPartActions-116"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -1155,7 +1155,7 @@ exports[`sections should be browsable by the section buttons and show validation
               />
             </button>
             <div
-              class="makeStyles-root-96"
+              class="makeStyles-root-126"
             >
               <button
                 class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary Mui-disabled Mui-disabled"
@@ -1181,10 +1181,10 @@ exports[`sections should be browsable by the section buttons and show validation
 exports[`sections should be browsable by the section buttons and show validation errors without crashing 3`] = `
 <div>
   <div
-    class="makeStyles-root-82"
+    class="makeStyles-root-112"
   >
     <div
-      class="MuiPaper-root makeStyles-navigation-83 MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root makeStyles-navigation-113 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-horizontal MuiPaper-elevation0"
@@ -1441,7 +1441,7 @@ exports[`sections should be browsable by the section buttons and show validation
     </div>
     <div>
       <form
-        class="makeStyles-form-84"
+        class="makeStyles-form-114"
         novalidate=""
       >
         <button
@@ -1451,13 +1451,13 @@ exports[`sections should be browsable by the section buttons and show validation
           type="submit"
         />
         <div
-          class="makeStyles-formPart-85"
+          class="makeStyles-formPart-115"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-87 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-117 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-98"
+              class="makeStyles-root-128"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1527,130 +1527,1929 @@ exports[`sections should be browsable by the section buttons and show validation
                 </table>
               </div>
               <div
-                class="makeStyles-addMetric-118"
+                class="makeStyles-tableContainer-148"
               >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-119"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                  />
-                </svg>
                 <div
-                  class="MuiFormControl-root makeStyles-addMetricSelect-100"
+                  class="ag-theme-alpine makeStyles-root-152"
                 >
                   <div
-                    aria-expanded="false"
-                    aria-label="Select a metric"
-                    class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-                    error="At least one metric assignment is required."
-                    role="combobox"
+                    class="makeStyles-toolbar-153"
                   >
                     <div
-                      class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                      class="makeStyles-rootFullWidth-156"
                     >
                       <div
-                        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiAutocomplete-inputRoot Mui-error Mui-error MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+                        class="makeStyles-search-157"
                       >
-                        <input
-                          aria-autocomplete="list"
-                          aria-describedby="add-metric-select-helper-text"
-                          aria-invalid="true"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          class="MuiInputBase-input MuiInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd"
-                          id="add-metric-select"
-                          placeholder="Select a metric"
-                          required=""
-                          spellcheck="false"
-                          type="text"
-                          value=""
-                        />
                         <div
-                          class="MuiAutocomplete-endAdornment"
+                          class="makeStyles-searchIcon-158"
                         >
-                          <button
-                            aria-label="Clear"
-                            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
-                            tabindex="-1"
-                            title="Clear"
-                            type="button"
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root"
+                            focusable="false"
+                            viewBox="0 0 24 24"
                           >
-                            <span
-                              class="MuiIconButton-label"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              class="MuiTouchRipple-root"
+                            <path
+                              d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
                             />
-                          </button>
-                          <button
-                            aria-label="Open"
-                            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
-                            tabindex="-1"
-                            title="Open"
-                            type="button"
-                          >
-                            <span
-                              class="MuiIconButton-label"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M7 10l5 5 5-5z"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              class="MuiTouchRipple-root"
-                            />
-                          </button>
+                          </svg>
+                        </div>
+                        <div
+                          class="MuiInputBase-root makeStyles-inputRootFullWidth-159"
+                        >
+                          <input
+                            aria-label="Search"
+                            class="MuiInputBase-input makeStyles-inputInputFullWidth-160"
+                            placeholder="Search…"
+                            type="text"
+                            value=""
+                          />
                         </div>
                       </div>
-                      <p
-                        class="MuiFormHelperText-root Mui-error Mui-required"
-                        id="add-metric-select-helper-text"
+                      <button
+                        class="MuiButtonBase-root MuiButton-root MuiButton-text"
+                        tabindex="0"
+                        type="button"
                       >
-                        At least one metric assignment is required.
-                      </p>
+                        <span
+                          class="MuiButton-label"
+                        >
+                           Reset 
+                        </span>
+                        <span
+                          class="MuiTouchRipple-root"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="ag-theme-alpine makeStyles-gridContainer-154"
+                  >
+                    <div
+                      style="height: auto; flex: 1;"
+                    >
+                      <div
+                        class="ag-root-wrapper ag-layout-normal ag-ltr"
+                        ref="eRootWrapper"
+                      >
+                        
+                
+                
+                        <div
+                          class="ag-root-wrapper-body ag-layout-normal ag-focus-managed"
+                          ref="rootWrapperBody"
+                        >
+                          <div
+                            class="ag-tab-guard ag-tab-guard-top"
+                            role="presentation"
+                            tabindex="0"
+                          />
+                          
+                    
+                          <!--AG-GRID-COMP-->
+                          <div
+                            aria-colcount="7"
+                            aria-rowcount="21"
+                            class="ag-root ag-unselectable ag-layout-normal"
+                            ref="gridPanel"
+                            role="grid"
+                            unselectable="on"
+                          >
+                            
+        
+                            <!--AG-HEADER-ROOT-->
+                            <div
+                              class="ag-header ag-focus-managed ag-pivot-off"
+                              ref="headerRoot"
+                              role="presentation"
+                              style="height: 49px; min-height: 49px;"
+                              unselectable="on"
+                            >
+                              
+            
+                              <div
+                                class="ag-pinned-left-header ag-hidden"
+                                ref="ePinnedLeftHeader"
+                                role="presentation"
+                                style="width: 0px; max-width: 0px; min-width: 0px;"
+                              >
+                                <div
+                                  aria-rowindex="1"
+                                  class="ag-header-row ag-header-row-column"
+                                  role="row"
+                                  style="top: 0px; height: 48px; width: 0px;"
+                                />
+                              </div>
+                              
+            
+                              <div
+                                class="ag-header-viewport"
+                                ref="eHeaderViewport"
+                                role="presentation"
+                              >
+                                
+                
+                                <div
+                                  class="ag-header-container"
+                                  ref="eHeaderContainer"
+                                  role="rowgroup"
+                                  style="width: 1199px;"
+                                >
+                                  <div
+                                    aria-rowindex="1"
+                                    class="ag-header-row ag-header-row-column"
+                                    role="row"
+                                    style="top: 0px; height: 48px; width: 1199px;"
+                                  >
+                                    <div
+                                      aria-colindex="1"
+                                      class="ag-header-cell ag-focus-managed"
+                                      col-id="__detail-button-col__"
+                                      role="columnheader"
+                                      style="width: 34px; left: 0px;"
+                                      tabindex="-1"
+                                      unselectable="on"
+                                    >
+                                      
+            
+                                      <div
+                                        class="ag-header-cell-resize ag-hidden"
+                                        ref="eResize"
+                                        role="presentation"
+                                      />
+                                      
+            
+                                      <!--AG-CHECKBOX-->
+                                      <div
+                                        class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                                        ref="cbSelectAll"
+                                        role="presentation"
+                                      >
+                                        
+                
+                                        <div
+                                          class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                          ref="eLabel"
+                                          role="presentation"
+                                        />
+                                        
+                
+                                        <div
+                                          class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                          ref="eWrapper"
+                                          role="presentation"
+                                        >
+                                          
+                    
+                                          <input
+                                            aria-label="Press Space to toggle all rows selection (unchecked)"
+                                            class="ag-input-field-input ag-checkbox-input"
+                                            id="ag-128-input"
+                                            ref="eInput"
+                                            tabindex="-1"
+                                            type="checkbox"
+                                          />
+                                          
+                
+                                        </div>
+                                        
+            
+                                      </div>
+                                      
+        
+                                      <div
+                                        class="ag-cell-label-container"
+                                        role="presentation"
+                                      >
+                                        
+            
+                                        
+            
+                                        <div
+                                          class="ag-header-cell-label"
+                                          ref="eLabel"
+                                          role="presentation"
+                                          unselectable="on"
+                                        >
+                                          
+                
+                                          <span
+                                            class="ag-header-cell-text"
+                                            ref="eText"
+                                            unselectable="on"
+                                          />
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                            ref="eFilter"
+                                          >
+                                            <span
+                                              class="ag-icon ag-icon-filter"
+                                              role="presentation"
+                                              unselectable="on"
+                                            />
+                                          </span>
+                                          
+                
+                                          
+                
+                                          
+                
+                                          
+                
+                                          
+            
+                                        </div>
+                                        
+        
+                                      </div>
+                                    </div>
+                                    <div
+                                      aria-colindex="2"
+                                      aria-sort="none"
+                                      class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-151"
+                                      col-id="name"
+                                      role="columnheader"
+                                      style="width: 465px; left: 34px;"
+                                      tabindex="-1"
+                                      unselectable="on"
+                                    >
+                                      
+            
+                                      <div
+                                        class="ag-header-cell-resize"
+                                        ref="eResize"
+                                        role="presentation"
+                                      />
+                                      
+            
+                                      <!--AG-CHECKBOX-->
+                                      <div
+                                        class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                                        ref="cbSelectAll"
+                                        role="presentation"
+                                      >
+                                        
+                
+                                        <div
+                                          class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                          ref="eLabel"
+                                          role="presentation"
+                                        />
+                                        
+                
+                                        <div
+                                          class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                          ref="eWrapper"
+                                          role="presentation"
+                                        >
+                                          
+                    
+                                          <input
+                                            aria-label="Press Space to toggle all rows selection (unchecked)"
+                                            class="ag-input-field-input ag-checkbox-input"
+                                            id="ag-131-input"
+                                            ref="eInput"
+                                            tabindex="-1"
+                                            type="checkbox"
+                                          />
+                                          
+                
+                                        </div>
+                                        
+            
+                                      </div>
+                                      
+        
+                                      <div
+                                        class="ag-cell-label-container ag-header-cell-sorted-none"
+                                        role="presentation"
+                                      >
+                                        
+            
+                                        <span
+                                          aria-hidden="true"
+                                          class="ag-header-icon ag-header-cell-menu-button"
+                                          ref="eMenu"
+                                        >
+                                          <span
+                                            class="ag-icon ag-icon-menu"
+                                            role="presentation"
+                                            unselectable="on"
+                                          />
+                                        </span>
+                                        
+            
+                                        <div
+                                          class="ag-header-cell-label"
+                                          ref="eLabel"
+                                          role="presentation"
+                                          unselectable="on"
+                                        >
+                                          
+                
+                                          <span
+                                            class="ag-header-cell-text"
+                                            ref="eText"
+                                            unselectable="on"
+                                          >
+                                            Name
+                                          </span>
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                            ref="eFilter"
+                                          >
+                                            <span
+                                              class="ag-icon ag-icon-filter"
+                                              role="presentation"
+                                              unselectable="on"
+                                            />
+                                          </span>
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-sort-order ag-hidden"
+                                            ref="eSortOrder"
+                                          />
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-sort-ascending-icon ag-hidden"
+                                            ref="eSortAsc"
+                                          >
+                                            <span
+                                              class="ag-icon ag-icon-asc"
+                                              role="presentation"
+                                              unselectable="on"
+                                            />
+                                          </span>
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-sort-descending-icon ag-hidden"
+                                            ref="eSortDesc"
+                                          >
+                                            <span
+                                              class="ag-icon ag-icon-desc"
+                                              role="presentation"
+                                              unselectable="on"
+                                            />
+                                          </span>
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-sort-none-icon ag-hidden"
+                                            ref="eSortNone"
+                                          >
+                                            <span
+                                              class="ag-icon ag-icon-none"
+                                              role="presentation"
+                                              unselectable="on"
+                                            />
+                                          </span>
+                                          
+            
+                                        </div>
+                                        
+        
+                                      </div>
+                                    </div>
+                                    <div
+                                      aria-colindex="3"
+                                      aria-sort="none"
+                                      class="ag-header-cell ag-focus-managed ag-header-cell-sortable"
+                                      col-id="description"
+                                      role="columnheader"
+                                      style="width: 550px; left: 499px;"
+                                      tabindex="-1"
+                                      unselectable="on"
+                                    >
+                                      
+            
+                                      <div
+                                        class="ag-header-cell-resize"
+                                        ref="eResize"
+                                        role="presentation"
+                                      />
+                                      
+            
+                                      <!--AG-CHECKBOX-->
+                                      <div
+                                        class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                                        ref="cbSelectAll"
+                                        role="presentation"
+                                      >
+                                        
+                
+                                        <div
+                                          class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                          ref="eLabel"
+                                          role="presentation"
+                                        />
+                                        
+                
+                                        <div
+                                          class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                          ref="eWrapper"
+                                          role="presentation"
+                                        >
+                                          
+                    
+                                          <input
+                                            aria-label="Press Space to toggle all rows selection (unchecked)"
+                                            class="ag-input-field-input ag-checkbox-input"
+                                            id="ag-134-input"
+                                            ref="eInput"
+                                            tabindex="-1"
+                                            type="checkbox"
+                                          />
+                                          
+                
+                                        </div>
+                                        
+            
+                                      </div>
+                                      
+        
+                                      <div
+                                        class="ag-cell-label-container ag-header-cell-sorted-none"
+                                        role="presentation"
+                                      >
+                                        
+            
+                                        <span
+                                          aria-hidden="true"
+                                          class="ag-header-icon ag-header-cell-menu-button"
+                                          ref="eMenu"
+                                        >
+                                          <span
+                                            class="ag-icon ag-icon-menu"
+                                            role="presentation"
+                                            unselectable="on"
+                                          />
+                                        </span>
+                                        
+            
+                                        <div
+                                          class="ag-header-cell-label"
+                                          ref="eLabel"
+                                          role="presentation"
+                                          unselectable="on"
+                                        >
+                                          
+                
+                                          <span
+                                            class="ag-header-cell-text"
+                                            ref="eText"
+                                            unselectable="on"
+                                          >
+                                            Description
+                                          </span>
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                            ref="eFilter"
+                                          >
+                                            <span
+                                              class="ag-icon ag-icon-filter"
+                                              role="presentation"
+                                              unselectable="on"
+                                            />
+                                          </span>
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-sort-order ag-hidden"
+                                            ref="eSortOrder"
+                                          />
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-sort-ascending-icon ag-hidden"
+                                            ref="eSortAsc"
+                                          >
+                                            <span
+                                              class="ag-icon ag-icon-asc"
+                                              role="presentation"
+                                              unselectable="on"
+                                            />
+                                          </span>
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-sort-descending-icon ag-hidden"
+                                            ref="eSortDesc"
+                                          >
+                                            <span
+                                              class="ag-icon ag-icon-desc"
+                                              role="presentation"
+                                              unselectable="on"
+                                            />
+                                          </span>
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-sort-none-icon ag-hidden"
+                                            ref="eSortNone"
+                                          >
+                                            <span
+                                              class="ag-icon ag-icon-none"
+                                              role="presentation"
+                                              unselectable="on"
+                                            />
+                                          </span>
+                                          
+            
+                                        </div>
+                                        
+        
+                                      </div>
+                                    </div>
+                                    <div
+                                      aria-colindex="7"
+                                      class="ag-header-cell ag-focus-managed"
+                                      col-id="metrics-assign--actions"
+                                      role="columnheader"
+                                      style="width: 150px; left: 1049px;"
+                                      tabindex="-1"
+                                      unselectable="on"
+                                    >
+                                      
+            
+                                      <div
+                                        class="ag-header-cell-resize ag-hidden"
+                                        ref="eResize"
+                                        role="presentation"
+                                      />
+                                      
+            
+                                      <!--AG-CHECKBOX-->
+                                      <div
+                                        class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                                        ref="cbSelectAll"
+                                        role="presentation"
+                                      >
+                                        
+                
+                                        <div
+                                          class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                          ref="eLabel"
+                                          role="presentation"
+                                        />
+                                        
+                
+                                        <div
+                                          class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                          ref="eWrapper"
+                                          role="presentation"
+                                        >
+                                          
+                    
+                                          <input
+                                            aria-label="Press Space to toggle all rows selection (unchecked)"
+                                            class="ag-input-field-input ag-checkbox-input"
+                                            id="ag-137-input"
+                                            ref="eInput"
+                                            tabindex="-1"
+                                            type="checkbox"
+                                          />
+                                          
+                
+                                        </div>
+                                        
+            
+                                      </div>
+                                      
+        
+                                      <div
+                                        class="ag-cell-label-container"
+                                        role="presentation"
+                                      >
+                                        
+            
+                                        
+            
+                                        <div
+                                          class="ag-header-cell-label"
+                                          ref="eLabel"
+                                          role="presentation"
+                                          unselectable="on"
+                                        >
+                                          
+                
+                                          <span
+                                            class="ag-header-cell-text"
+                                            ref="eText"
+                                            unselectable="on"
+                                          >
+                                            Actions
+                                          </span>
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                            ref="eFilter"
+                                          >
+                                            <span
+                                              class="ag-icon ag-icon-filter"
+                                              role="presentation"
+                                              unselectable="on"
+                                            />
+                                          </span>
+                                          
+                
+                                          
+                
+                                          
+                
+                                          
+                
+                                          
+            
+                                        </div>
+                                        
+        
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                                
+            
+                              </div>
+                              
+            
+                              <div
+                                class="ag-pinned-right-header ag-hidden"
+                                ref="ePinnedRightHeader"
+                                role="presentation"
+                                style="width: 0px; max-width: 0px; min-width: 0px;"
+                              >
+                                <div
+                                  aria-rowindex="1"
+                                  class="ag-header-row ag-header-row-column"
+                                  role="row"
+                                  style="top: 0px; height: 48px; width: 0px;"
+                                />
+                              </div>
+                              
+        
+                            </div>
+                            
+        
+                            <div
+                              class="ag-floating-top"
+                              ref="eTop"
+                              role="presentation"
+                              style="min-height: 0px; height: 0px; display: none; overflow-y: hidden;"
+                              unselectable="on"
+                            >
+                              
+            
+                              <div
+                                class="ag-pinned-left-floating-top ag-hidden"
+                                ref="eLeftTop"
+                                role="presentation"
+                                unselectable="on"
+                              />
+                              
+            
+                              <div
+                                class="ag-floating-top-viewport"
+                                ref="eTopViewport"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <div
+                                  class="ag-floating-top-container"
+                                  ref="eTopContainer"
+                                  role="presentation"
+                                  style="width: 1199px;"
+                                  unselectable="on"
+                                />
+                                
+            
+                              </div>
+                              
+            
+                              <div
+                                class="ag-pinned-right-floating-top ag-hidden"
+                                ref="eRightTop"
+                                role="presentation"
+                                unselectable="on"
+                              />
+                              
+            
+                              <div
+                                class="ag-floating-top-full-width-container ag-hidden"
+                                ref="eTopFullWidthContainer"
+                                role="presentation"
+                                unselectable="on"
+                              />
+                              
+        
+                            </div>
+                            
+        
+                            <div
+                              class="ag-body-viewport ag-layout-normal ag-row-no-animation"
+                              ref="eBodyViewport"
+                              role="presentation"
+                            >
+                              
+            
+                              <div
+                                class="ag-pinned-left-cols-container ag-hidden"
+                                ref="eLeftContainer"
+                                role="presentation"
+                                style="height: 840px;"
+                                unselectable="on"
+                              >
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="2"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                                  comp-id="183"
+                                  role="row"
+                                  row-id="metric_1"
+                                  row-index="0"
+                                  style="height: 42px; transform: translateY(0px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="3"
+                                  class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="188"
+                                  role="row"
+                                  row-id="metric_2"
+                                  row-index="1"
+                                  style="height: 42px; transform: translateY(42px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="4"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="193"
+                                  role="row"
+                                  row-id="metric_3"
+                                  row-index="2"
+                                  style="height: 42px; transform: translateY(84px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="5"
+                                  class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="198"
+                                  role="row"
+                                  row-id="metric_4"
+                                  row-index="3"
+                                  style="height: 42px; transform: translateY(126px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="6"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="203"
+                                  role="row"
+                                  row-id="metric_5"
+                                  row-index="4"
+                                  style="height: 42px; transform: translateY(168px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="7"
+                                  class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="208"
+                                  role="row"
+                                  row-id="metric_6"
+                                  row-index="5"
+                                  style="height: 42px; transform: translateY(210px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="8"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="213"
+                                  role="row"
+                                  row-id="metric_7"
+                                  row-index="6"
+                                  style="height: 42px; transform: translateY(252px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="9"
+                                  class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="218"
+                                  role="row"
+                                  row-id="metric_8"
+                                  row-index="7"
+                                  style="height: 42px; transform: translateY(294px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="10"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="223"
+                                  role="row"
+                                  row-id="metric_9"
+                                  row-index="8"
+                                  style="height: 42px; transform: translateY(336px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="11"
+                                  class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="228"
+                                  role="row"
+                                  row-id="metric_10"
+                                  row-index="9"
+                                  style="height: 42px; transform: translateY(378px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="12"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="233"
+                                  role="row"
+                                  row-id="metric_11"
+                                  row-index="10"
+                                  style="height: 42px; transform: translateY(420px); "
+                                />
+                              </div>
+                              
+            
+                              <div
+                                class="ag-center-cols-clipper"
+                                ref="eCenterColsClipper"
+                                role="presentation"
+                                style="height: 840px;"
+                                unselectable="on"
+                              >
+                                
+                
+                                <div
+                                  class="ag-center-cols-viewport"
+                                  ref="eCenterViewport"
+                                  role="presentation"
+                                  style="height: calc(100% + 0px);"
+                                >
+                                  
+                    
+                                  <div
+                                    class="ag-center-cols-container"
+                                    ref="eCenterContainer"
+                                    role="rowgroup"
+                                    style="width: 1199px; height: 840px;"
+                                    unselectable="on"
+                                  >
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="2"
+                                      class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                                      comp-id="183"
+                                      role="row"
+                                      row-id="metric_1"
+                                      row-index="0"
+                                      style="height: 42px; transform: translateY(0px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="184"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="185"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="186"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 1
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="187"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="3"
+                                      class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                      comp-id="188"
+                                      role="row"
+                                      row-id="metric_2"
+                                      row-index="1"
+                                      style="height: 42px; transform: translateY(42px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="189"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="190"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="191"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 2
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="192"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="4"
+                                      class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                      comp-id="193"
+                                      role="row"
+                                      row-id="metric_3"
+                                      row-index="2"
+                                      style="height: 42px; transform: translateY(84px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="194"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="195"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="196"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 3
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="197"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="5"
+                                      class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                      comp-id="198"
+                                      role="row"
+                                      row-id="metric_4"
+                                      row-index="3"
+                                      style="height: 42px; transform: translateY(126px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="199"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="200"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="201"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 4
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="202"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="6"
+                                      class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                      comp-id="203"
+                                      role="row"
+                                      row-id="metric_5"
+                                      row-index="4"
+                                      style="height: 42px; transform: translateY(168px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="204"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="205"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="206"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 5
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="207"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="7"
+                                      class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                      comp-id="208"
+                                      role="row"
+                                      row-id="metric_6"
+                                      row-index="5"
+                                      style="height: 42px; transform: translateY(210px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="209"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="210"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="211"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 6
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="212"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="8"
+                                      class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                      comp-id="213"
+                                      role="row"
+                                      row-id="metric_7"
+                                      row-index="6"
+                                      style="height: 42px; transform: translateY(252px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="214"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="215"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="216"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 7
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="217"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="9"
+                                      class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                      comp-id="218"
+                                      role="row"
+                                      row-id="metric_8"
+                                      row-index="7"
+                                      style="height: 42px; transform: translateY(294px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="219"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="220"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="221"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 8
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="222"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="10"
+                                      class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                      comp-id="223"
+                                      role="row"
+                                      row-id="metric_9"
+                                      row-index="8"
+                                      style="height: 42px; transform: translateY(336px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="224"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="225"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="226"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 9
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="227"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="11"
+                                      class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                      comp-id="228"
+                                      role="row"
+                                      row-id="metric_10"
+                                      row-index="9"
+                                      style="height: 42px; transform: translateY(378px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="229"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="230"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="231"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 10
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="232"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="12"
+                                      class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                      comp-id="233"
+                                      role="row"
+                                      row-id="metric_11"
+                                      row-index="10"
+                                      style="height: 42px; transform: translateY(420px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="234"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="235"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="236"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 11
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="237"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                  </div>
+                                  
+                
+                                </div>
+                                
+            
+                              </div>
+                              
+            
+                              <div
+                                class="ag-pinned-right-cols-container ag-hidden"
+                                ref="eRightContainer"
+                                role="presentation"
+                                style="height: 840px;"
+                                unselectable="on"
+                              >
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="2"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                                  comp-id="183"
+                                  role="row"
+                                  row-id="metric_1"
+                                  row-index="0"
+                                  style="height: 42px; transform: translateY(0px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="3"
+                                  class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="188"
+                                  role="row"
+                                  row-id="metric_2"
+                                  row-index="1"
+                                  style="height: 42px; transform: translateY(42px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="4"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="193"
+                                  role="row"
+                                  row-id="metric_3"
+                                  row-index="2"
+                                  style="height: 42px; transform: translateY(84px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="5"
+                                  class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="198"
+                                  role="row"
+                                  row-id="metric_4"
+                                  row-index="3"
+                                  style="height: 42px; transform: translateY(126px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="6"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="203"
+                                  role="row"
+                                  row-id="metric_5"
+                                  row-index="4"
+                                  style="height: 42px; transform: translateY(168px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="7"
+                                  class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="208"
+                                  role="row"
+                                  row-id="metric_6"
+                                  row-index="5"
+                                  style="height: 42px; transform: translateY(210px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="8"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="213"
+                                  role="row"
+                                  row-id="metric_7"
+                                  row-index="6"
+                                  style="height: 42px; transform: translateY(252px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="9"
+                                  class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="218"
+                                  role="row"
+                                  row-id="metric_8"
+                                  row-index="7"
+                                  style="height: 42px; transform: translateY(294px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="10"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="223"
+                                  role="row"
+                                  row-id="metric_9"
+                                  row-index="8"
+                                  style="height: 42px; transform: translateY(336px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="11"
+                                  class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="228"
+                                  role="row"
+                                  row-id="metric_10"
+                                  row-index="9"
+                                  style="height: 42px; transform: translateY(378px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="12"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="233"
+                                  role="row"
+                                  row-id="metric_11"
+                                  row-index="10"
+                                  style="height: 42px; transform: translateY(420px); "
+                                />
+                              </div>
+                              
+            
+                              <div
+                                class="ag-full-width-container"
+                                ref="eFullWidthContainer"
+                                role="presentation"
+                                style="height: 840px;"
+                                unselectable="on"
+                              />
+                              
+        
+                            </div>
+                            
+        
+                            <div
+                              class="ag-floating-bottom"
+                              ref="eBottom"
+                              role="presentation"
+                              style="min-height: 0px; height: 0px; display: none; overflow-y: hidden;"
+                              unselectable="on"
+                            >
+                              
+            
+                              <div
+                                class="ag-pinned-left-floating-bottom ag-hidden"
+                                ref="eLeftBottom"
+                                role="presentation"
+                                unselectable="on"
+                              />
+                              
+            
+                              <div
+                                class="ag-floating-bottom-viewport"
+                                ref="eBottomViewport"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <div
+                                  class="ag-floating-bottom-container"
+                                  ref="eBottomContainer"
+                                  role="presentation"
+                                  style="width: 1199px;"
+                                  unselectable="on"
+                                />
+                                
+            
+                              </div>
+                              
+            
+                              <div
+                                class="ag-pinned-right-floating-bottom ag-hidden"
+                                ref="eRightBottom"
+                                role="presentation"
+                                unselectable="on"
+                              />
+                              
+            
+                              <div
+                                class="ag-floating-bottom-full-width-container ag-hidden"
+                                ref="eBottomFullWidthContainer"
+                                role="presentation"
+                                unselectable="on"
+                              />
+                              
+        
+                            </div>
+                            
+        
+                            <div
+                              aria-hidden="true"
+                              class="ag-body-horizontal-scroll"
+                              ref="eHorizontalScrollBody"
+                              style="height: 0px; max-height: 0px; min-height: 0px;"
+                            >
+                              
+            
+                              <div
+                                class="ag-horizontal-left-spacer"
+                                ref="eHorizontalLeftSpacer"
+                                style="width: 0px; max-width: 0px; min-width: 0px;"
+                              />
+                              
+            
+                              <div
+                                class="ag-body-horizontal-scroll-viewport"
+                                ref="eBodyHorizontalScrollViewport"
+                                style="height: 0px; max-height: 0px; min-height: 0px;"
+                              >
+                                
+                
+                                <div
+                                  class="ag-body-horizontal-scroll-container"
+                                  ref="eBodyHorizontalScrollContainer"
+                                  style="width: 1199px; height: 0px; max-height: 0px; min-height: 0px;"
+                                />
+                                
+            
+                              </div>
+                              
+            
+                              <div
+                                class="ag-horizontal-right-spacer"
+                                ref="eHorizontalRightSpacer"
+                                style="width: 0px; max-width: 0px; min-width: 0px;"
+                              />
+                              
+        
+                            </div>
+                            
+        
+                            <!--AG-OVERLAY-WRAPPER-->
+                            <div
+                              aria-hidden="true"
+                              class="ag-overlay ag-hidden"
+                              ref="overlayWrapper"
+                            >
+                              
+            
+                              <div
+                                class="ag-overlay-panel"
+                              >
+                                
+                
+                                <div
+                                  class="ag-overlay-wrapper ag-layout-normal"
+                                  ref="eOverlayWrapper"
+                                />
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                            
+    
+                          </div>
+                          
+                    
+                
+                          <div
+                            class="ag-tab-guard ag-tab-guard-bottom"
+                            role="presentation"
+                            tabindex="0"
+                          />
+                        </div>
+                        
+                
+                
+                        <!--AG-PAGINATION-->
+                        <div
+                          aria-describedby="ag-123-start-page ag-123-start-page-number ag-123-of-page ag-123-of-page-number ag-123-first-row ag-123-to ag-123-last-row ag-123-of ag-123-row-count"
+                          aria-live="polite"
+                          class="ag-paging-panel ag-unselectable ag-hidden"
+                          id="ag-123"
+                        >
+                          
+                
+                          <span
+                            aria-hidden="true"
+                            class="ag-paging-row-summary-panel"
+                          >
+                            
+                    
+                            <span
+                              class="ag-paging-row-summary-panel-number"
+                              id="ag-123-first-row"
+                              ref="lbFirstRowOnPage"
+                            />
+                            
+                    
+                            <span
+                              id="ag-123-to"
+                            >
+                              to
+                            </span>
+                            
+                    
+                            <span
+                              class="ag-paging-row-summary-panel-number"
+                              id="ag-123-last-row"
+                              ref="lbLastRowOnPage"
+                            />
+                            
+                    
+                            <span
+                              id="ag-123-of"
+                            >
+                              of
+                            </span>
+                            
+                    
+                            <span
+                              class="ag-paging-row-summary-panel-number"
+                              id="ag-123-row-count"
+                              ref="lbRecordCount"
+                            />
+                            
+                
+                          </span>
+                          
+                
+                          <span
+                            class="ag-paging-page-summary-panel"
+                            role="presentation"
+                          >
+                            
+                    
+                            <div
+                              aria-label="First Page"
+                              class="ag-paging-button"
+                              ref="btFirst"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <span
+                                class="ag-icon ag-icon-first"
+                                role="presentation"
+                                unselectable="on"
+                              />
+                            </div>
+                            
+                    
+                            <div
+                              aria-label="Previous Page"
+                              class="ag-paging-button"
+                              ref="btPrevious"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <span
+                                class="ag-icon ag-icon-previous"
+                                role="presentation"
+                                unselectable="on"
+                              />
+                            </div>
+                            
+                    
+                            <span
+                              aria-hidden="true"
+                              class="ag-paging-description"
+                            >
+                              
+                        
+                              <span
+                                id="ag-123-start-page"
+                              >
+                                Page
+                              </span>
+                              
+                        
+                              <span
+                                class="ag-paging-number"
+                                id="ag-123-start-page-number"
+                                ref="lbCurrent"
+                              />
+                              
+                        
+                              <span
+                                id="ag-123-of-page"
+                              >
+                                of
+                              </span>
+                              
+                        
+                              <span
+                                class="ag-paging-number"
+                                id="ag-123-of-page-number"
+                                ref="lbTotal"
+                              />
+                              
+                    
+                            </span>
+                            
+                    
+                            <div
+                              aria-label="Next Page"
+                              class="ag-paging-button"
+                              ref="btNext"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <span
+                                class="ag-icon ag-icon-next"
+                                role="presentation"
+                                unselectable="on"
+                              />
+                            </div>
+                            
+                    
+                            <div
+                              aria-label="Last Page"
+                              class="ag-paging-button"
+                              ref="btLast"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <span
+                                class="ag-icon ag-icon-last"
+                                role="presentation"
+                                unselectable="on"
+                              />
+                            </div>
+                            
+                
+                          </span>
+                          
+            
+                        </div>
+                        
+                
+            
+                      </div>
                     </div>
                   </div>
                 </div>
-                <button
-                  aria-label="Add metric"
-                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiButton-label"
-                  >
-                    Assign
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
-                  />
-                </button>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-108 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-138 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -1688,7 +3487,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-109 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-139 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -1709,13 +3508,13 @@ exports[`sections should be browsable by the section buttons and show validation
                   class="MuiAlert-message"
                 >
                   <div
-                    class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-120 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+                    class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-163 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
                   >
                     <div
                       aria-controls="attr-window-panel-content"
                       aria-disabled="false"
                       aria-expanded="false"
-                      class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-121"
+                      class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-164"
                       id="attr-window-panel"
                       role="button"
                       tabindex="0"
@@ -1779,7 +3578,7 @@ exports[`sections should be browsable by the section buttons and show validation
                                 is the window of time after exposure to an experiment that we capture metric events for a participant (exposure can be from either assignment or specified exposure events). The refund window is the window of time after a purchase event. Revenue metrics will automatically deduct transactions that have been refunded within the metric’s refund window.
                                 <br />
                                 <div
-                                  class="makeStyles-attributionWindowDiagram-110"
+                                  class="makeStyles-attributionWindowDiagram-140"
                                 >
                                   <svg>
                                     attribution_window.svg
@@ -1798,7 +3597,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-111 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-141 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -1819,13 +3618,13 @@ exports[`sections should be browsable by the section buttons and show validation
                   class="MuiAlert-message"
                 >
                   <div
-                    class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-120 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+                    class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-163 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
                   >
                     <div
                       aria-controls="min-diff-panel-content"
                       aria-disabled="false"
                       aria-expanded="false"
-                      class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-121"
+                      class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-164"
                       id="min-diff-panel"
                       role="button"
                       tabindex="0"
@@ -1889,7 +3688,7 @@ exports[`sections should be browsable by the section buttons and show validation
                                 are absolute differences from the baseline (not relative). For example, if the baseline conversion rate is 5%, a minimum difference of 0.5 pp is equivalent to a 10% relative change.
                                 <br />
                                 <div
-                                  class="makeStyles-minDiffDiagram-112"
+                                  class="makeStyles-minDiffDiagram-142"
                                 >
                                   <svg>
                                     min_diffs.svg
@@ -1905,7 +3704,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-113 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-143 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -1935,7 +3734,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <h4
-                class="MuiTypography-root makeStyles-exposureEventsTitle-114 MuiTypography-h4"
+                class="MuiTypography-root makeStyles-exposureEventsTitle-144 MuiTypography-h4"
               >
                 Exposure Events
               </h4>
@@ -1968,11 +3767,11 @@ exports[`sections should be browsable by the section buttons and show validation
                 </table>
               </div>
               <div
-                class="makeStyles-addMetric-118"
+                class="makeStyles-addMetric-149"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-119"
+                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-150"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -1997,7 +3796,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </button>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-115 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-145 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -2031,7 +3830,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-116 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-146 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -2062,7 +3861,7 @@ exports[`sections should be browsable by the section buttons and show validation
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-86"
+            class="makeStyles-formPartActions-116"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -2103,10 +3902,10 @@ exports[`sections should be browsable by the section buttons and show validation
 exports[`sections should be browsable by the section buttons and show validation errors without crashing 4`] = `
 <div>
   <div
-    class="makeStyles-root-82"
+    class="makeStyles-root-112"
   >
     <div
-      class="MuiPaper-root makeStyles-navigation-83 MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root makeStyles-navigation-113 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-horizontal MuiPaper-elevation0"
@@ -2363,7 +4162,7 @@ exports[`sections should be browsable by the section buttons and show validation
     </div>
     <div>
       <form
-        class="makeStyles-form-84"
+        class="makeStyles-form-114"
         novalidate=""
       >
         <button
@@ -2373,13 +4172,13 @@ exports[`sections should be browsable by the section buttons and show validation
           type="submit"
         />
         <div
-          class="makeStyles-formPart-85"
+          class="makeStyles-formPart-115"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-87 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-117 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-134"
+              class="makeStyles-root-213"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -2387,7 +4186,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 Basic Info
               </h4>
               <div
-                class="makeStyles-row-135"
+                class="makeStyles-row-214"
               >
                 <div
                   class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -2423,10 +4222,10 @@ exports[`sections should be browsable by the section buttons and show validation
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-123 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-125 PrivateNotchedOutline-legendNotched-126"
+                        class="PrivateNotchedOutline-legendLabelled-196 PrivateNotchedOutline-legendNotched-197"
                       >
                         <span>
                           Experiment name
@@ -2444,7 +4243,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="makeStyles-row-135"
+                class="makeStyles-row-214"
               >
                 <div
                   class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -2479,10 +4278,10 @@ exports[`sections should be browsable by the section buttons and show validation
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-123 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-125 PrivateNotchedOutline-legendNotched-126"
+                        class="PrivateNotchedOutline-legendLabelled-196 PrivateNotchedOutline-legendNotched-197"
                       >
                         <span>
                           Experiment description
@@ -2500,10 +4299,10 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="makeStyles-row-135"
+                class="makeStyles-row-214"
               >
                 <div
-                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-137"
+                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-216"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-error Mui-error Mui-required Mui-required"
@@ -2537,10 +4336,10 @@ exports[`sections should be browsable by the section buttons and show validation
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-123 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-125 PrivateNotchedOutline-legendNotched-126"
+                        class="PrivateNotchedOutline-legendLabelled-196 PrivateNotchedOutline-legendNotched-197"
                       >
                         <span>
                           Start date (UTC)
@@ -2557,12 +4356,12 @@ exports[`sections should be browsable by the section buttons and show validation
                   </p>
                 </div>
                 <span
-                  class="makeStyles-through-136"
+                  class="makeStyles-through-215"
                 >
                    through 
                 </span>
                 <div
-                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-137"
+                  class="MuiFormControl-root MuiTextField-root makeStyles-datePicker-216"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-error Mui-error Mui-required Mui-required"
@@ -2594,10 +4393,10 @@ exports[`sections should be browsable by the section buttons and show validation
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="PrivateNotchedOutline-root-123 MuiOutlinedInput-notchedOutline"
+                      class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-125 PrivateNotchedOutline-legendNotched-126"
+                        class="PrivateNotchedOutline-legendLabelled-196 PrivateNotchedOutline-legendNotched-197"
                       >
                         <span>
                           End date (UTC)
@@ -2643,7 +4442,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="makeStyles-row-135"
+                class="makeStyles-row-214"
               >
                 <div
                   aria-expanded="false"
@@ -2751,10 +4550,10 @@ exports[`sections should be browsable by the section buttons and show validation
                       </div>
                       <fieldset
                         aria-hidden="true"
-                        class="PrivateNotchedOutline-root-123 MuiOutlinedInput-notchedOutline"
+                        class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
                       >
                         <legend
-                          class="PrivateNotchedOutline-legendLabelled-125 PrivateNotchedOutline-legendNotched-126"
+                          class="PrivateNotchedOutline-legendLabelled-196 PrivateNotchedOutline-legendNotched-197"
                         >
                           <span>
                             Owner
@@ -2775,7 +4574,7 @@ exports[`sections should be browsable by the section buttons and show validation
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-86"
+            class="makeStyles-formPartActions-116"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -2816,10 +4615,10 @@ exports[`sections should be browsable by the section buttons and show validation
 exports[`sections should be browsable by the section buttons and show validation errors without crashing 5`] = `
 <div>
   <div
-    class="makeStyles-root-82"
+    class="makeStyles-root-112"
   >
     <div
-      class="MuiPaper-root makeStyles-navigation-83 MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root makeStyles-navigation-113 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-horizontal MuiPaper-elevation0"
@@ -3076,7 +4875,7 @@ exports[`sections should be browsable by the section buttons and show validation
     </div>
     <div>
       <form
-        class="makeStyles-form-84"
+        class="makeStyles-form-114"
         novalidate=""
       >
         <button
@@ -3086,13 +4885,13 @@ exports[`sections should be browsable by the section buttons and show validation
           type="submit"
         />
         <div
-          class="makeStyles-formPart-85"
+          class="makeStyles-formPart-115"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-87 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-117 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-138"
+              class="makeStyles-root-217"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -3148,17 +4947,17 @@ exports[`sections should be browsable by the section buttons and show validation
                       class="MuiTableRow-root"
                     >
                       <td
-                        class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-143"
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-222"
                       >
                         <span
-                          class="makeStyles-metricName-144 makeStyles-tooltipped-145"
-                          title="This is metric 10"
+                          class="makeStyles-metricName-223 makeStyles-tooltipped-224"
+                          title="This is metric 1"
                         >
-                          metric_10
+                          metric_1
                         </span>
                         <br />
                         <span
-                          class="makeStyles-root-160 makeStyles-monospaced-142"
+                          class="makeStyles-root-240 makeStyles-monospaced-221"
                         >
                           primary
                         </span>
@@ -3167,7 +4966,7 @@ exports[`sections should be browsable by the section buttons and show validation
                         class="MuiTableCell-root MuiTableCell-body"
                       >
                         <div
-                          class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-141 Mui-error Mui-error"
+                          class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-220 Mui-error Mui-error"
                         >
                           <div
                             aria-haspopup="listbox"
@@ -3199,11 +4998,11 @@ exports[`sections should be browsable by the section buttons and show validation
                           </svg>
                           <fieldset
                             aria-hidden="true"
-                            class="PrivateNotchedOutline-root-123 MuiOutlinedInput-notchedOutline"
+                            class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
                             style="padding-left: 8px;"
                           >
                             <legend
-                              class="PrivateNotchedOutline-legend-124"
+                              class="PrivateNotchedOutline-legend-195"
                               style="width: 0.01px;"
                             >
                               <span>
@@ -3219,7 +5018,7 @@ exports[`sections should be browsable by the section buttons and show validation
                         </p>
                       </td>
                       <td
-                        class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-147"
+                        class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-226"
                       >
                         <span
                           class="MuiSwitch-root"
@@ -3227,7 +5026,7 @@ exports[`sections should be browsable by the section buttons and show validation
                           <span
                             aria-disabled="false"
                             aria-label="Change Expected"
-                            class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-161 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-162 Mui-checked"
+                            class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-241 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-242 Mui-checked"
                             variant="outlined"
                           >
                             <span
@@ -3235,7 +5034,7 @@ exports[`sections should be browsable by the section buttons and show validation
                             >
                               <input
                                 checked=""
-                                class="PrivateSwitchBase-input-164 MuiSwitch-input"
+                                class="PrivateSwitchBase-input-244 MuiSwitch-input"
                                 id="experiment.metricAssignments[0].changeExpected"
                                 name="experiment.metricAssignments[0].changeExpected"
                                 type="checkbox"
@@ -3258,7 +5057,7 @@ exports[`sections should be browsable by the section buttons and show validation
                         class="MuiTableCell-root MuiTableCell-body"
                       >
                         <div
-                          class="MuiFormControl-root MuiTextField-root makeStyles-root-165 makeStyles-minDifferenceField-146"
+                          class="MuiFormControl-root MuiTextField-root makeStyles-root-245 makeStyles-minDifferenceField-225"
                         >
                           <div
                             class="MuiInputBase-root MuiOutlinedInput-root Mui-error Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
@@ -3269,28 +5068,30 @@ exports[`sections should be browsable by the section buttons and show validation
                               aria-label="Minimum Difference"
                               class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
                               id="experiment.metricAssignments[0].minDifference"
+                              max="100"
                               min="0"
                               name="experiment.metricAssignments[0].minDifference"
-                              placeholder="1.30"
+                              placeholder="5.4"
                               type="number"
-                              value=""
+                              value="0"
                             />
                             <div
-                              class="MuiInputAdornment-root makeStyles-adornment-167 MuiInputAdornment-positionEnd"
+                              class="MuiInputAdornment-root makeStyles-adornment-247 MuiInputAdornment-positionEnd"
                             >
                               <p
-                                class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
+                                class="MuiTypography-root makeStyles-tooltipped-246 MuiTypography-body1 MuiTypography-colorTextSecondary"
+                                title="Percentage Points"
                               >
-                                USD
+                                pp
                               </p>
                             </div>
                             <fieldset
                               aria-hidden="true"
-                              class="PrivateNotchedOutline-root-123 MuiOutlinedInput-notchedOutline"
+                              class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
                               style="padding-left: 8px;"
                             >
                               <legend
-                                class="PrivateNotchedOutline-legend-124"
+                                class="PrivateNotchedOutline-legend-195"
                                 style="width: 0.01px;"
                               >
                                 <span>
@@ -3300,7 +5101,7 @@ exports[`sections should be browsable by the section buttons and show validation
                             </fieldset>
                           </div>
                           <p
-                            class="MuiFormHelperText-root MuiFormHelperText-contained Mui-error"
+                            class="MuiFormHelperText-root MuiFormHelperText-contained Mui-error MuiFormHelperText-filled"
                             id="experiment.metricAssignments[0].minDifference-helper-text"
                           >
                             This field is required
@@ -3344,122 +5145,1929 @@ exports[`sections should be browsable by the section buttons and show validation
                 </table>
               </div>
               <div
-                class="makeStyles-addMetric-158"
+                class="makeStyles-tableContainer-237"
               >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-159"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                  />
-                </svg>
                 <div
-                  class="MuiFormControl-root makeStyles-addMetricSelect-140"
+                  class="ag-theme-alpine makeStyles-root-249"
                 >
                   <div
-                    aria-expanded="false"
-                    aria-label="Select a metric"
-                    class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-                    role="combobox"
+                    class="makeStyles-toolbar-250"
                   >
                     <div
-                      class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                      class="makeStyles-rootFullWidth-253"
                     >
                       <div
-                        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+                        class="makeStyles-search-254"
                       >
-                        <input
-                          aria-autocomplete="list"
-                          aria-invalid="false"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          class="MuiInputBase-input MuiInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd"
-                          id="add-metric-select"
-                          placeholder="Select a metric"
-                          required=""
-                          spellcheck="false"
-                          type="text"
-                          value=""
-                        />
                         <div
-                          class="MuiAutocomplete-endAdornment"
+                          class="makeStyles-searchIcon-255"
                         >
-                          <button
-                            aria-label="Clear"
-                            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
-                            tabindex="-1"
-                            title="Clear"
-                            type="button"
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root"
+                            focusable="false"
+                            viewBox="0 0 24 24"
                           >
-                            <span
-                              class="MuiIconButton-label"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              class="MuiTouchRipple-root"
+                            <path
+                              d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
                             />
-                          </button>
-                          <button
-                            aria-label="Open"
-                            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
-                            tabindex="-1"
-                            title="Open"
-                            type="button"
-                          >
-                            <span
-                              class="MuiIconButton-label"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M7 10l5 5 5-5z"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              class="MuiTouchRipple-root"
-                            />
-                          </button>
+                          </svg>
                         </div>
+                        <div
+                          class="MuiInputBase-root makeStyles-inputRootFullWidth-256"
+                        >
+                          <input
+                            aria-label="Search"
+                            class="MuiInputBase-input makeStyles-inputInputFullWidth-257"
+                            placeholder="Search…"
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                      <button
+                        class="MuiButtonBase-root MuiButton-root MuiButton-text"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <span
+                          class="MuiButton-label"
+                        >
+                           Reset 
+                        </span>
+                        <span
+                          class="MuiTouchRipple-root"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="ag-theme-alpine makeStyles-gridContainer-251"
+                  >
+                    <div
+                      style="height: auto; flex: 1;"
+                    >
+                      <div
+                        class="ag-root-wrapper ag-layout-normal ag-ltr"
+                        ref="eRootWrapper"
+                      >
+                        
+                
+                
+                        <div
+                          class="ag-root-wrapper-body ag-layout-normal ag-focus-managed"
+                          ref="rootWrapperBody"
+                        >
+                          <div
+                            class="ag-tab-guard ag-tab-guard-top"
+                            role="presentation"
+                            tabindex="0"
+                          />
+                          
+                    
+                          <!--AG-GRID-COMP-->
+                          <div
+                            aria-colcount="7"
+                            aria-rowcount="21"
+                            class="ag-root ag-unselectable ag-layout-normal"
+                            ref="gridPanel"
+                            role="grid"
+                            unselectable="on"
+                          >
+                            
+        
+                            <!--AG-HEADER-ROOT-->
+                            <div
+                              class="ag-header ag-focus-managed ag-pivot-off"
+                              ref="headerRoot"
+                              role="presentation"
+                              style="height: 49px; min-height: 49px;"
+                              unselectable="on"
+                            >
+                              
+            
+                              <div
+                                class="ag-pinned-left-header ag-hidden"
+                                ref="ePinnedLeftHeader"
+                                role="presentation"
+                                style="width: 0px; max-width: 0px; min-width: 0px;"
+                              >
+                                <div
+                                  aria-rowindex="1"
+                                  class="ag-header-row ag-header-row-column"
+                                  role="row"
+                                  style="top: 0px; height: 48px; width: 0px;"
+                                />
+                              </div>
+                              
+            
+                              <div
+                                class="ag-header-viewport"
+                                ref="eHeaderViewport"
+                                role="presentation"
+                              >
+                                
+                
+                                <div
+                                  class="ag-header-container"
+                                  ref="eHeaderContainer"
+                                  role="rowgroup"
+                                  style="width: 1199px;"
+                                >
+                                  <div
+                                    aria-rowindex="1"
+                                    class="ag-header-row ag-header-row-column"
+                                    role="row"
+                                    style="top: 0px; height: 48px; width: 1199px;"
+                                  >
+                                    <div
+                                      aria-colindex="1"
+                                      class="ag-header-cell ag-focus-managed"
+                                      col-id="__detail-button-col__"
+                                      role="columnheader"
+                                      style="width: 34px; left: 0px;"
+                                      tabindex="-1"
+                                      unselectable="on"
+                                    >
+                                      
+            
+                                      <div
+                                        class="ag-header-cell-resize ag-hidden"
+                                        ref="eResize"
+                                        role="presentation"
+                                      />
+                                      
+            
+                                      <!--AG-CHECKBOX-->
+                                      <div
+                                        class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                                        ref="cbSelectAll"
+                                        role="presentation"
+                                      >
+                                        
+                
+                                        <div
+                                          class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                          ref="eLabel"
+                                          role="presentation"
+                                        />
+                                        
+                
+                                        <div
+                                          class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                          ref="eWrapper"
+                                          role="presentation"
+                                        >
+                                          
+                    
+                                          <input
+                                            aria-label="Press Space to toggle all rows selection (unchecked)"
+                                            class="ag-input-field-input ag-checkbox-input"
+                                            id="ag-319-input"
+                                            ref="eInput"
+                                            tabindex="-1"
+                                            type="checkbox"
+                                          />
+                                          
+                
+                                        </div>
+                                        
+            
+                                      </div>
+                                      
+        
+                                      <div
+                                        class="ag-cell-label-container"
+                                        role="presentation"
+                                      >
+                                        
+            
+                                        
+            
+                                        <div
+                                          class="ag-header-cell-label"
+                                          ref="eLabel"
+                                          role="presentation"
+                                          unselectable="on"
+                                        >
+                                          
+                
+                                          <span
+                                            class="ag-header-cell-text"
+                                            ref="eText"
+                                            unselectable="on"
+                                          />
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                            ref="eFilter"
+                                          >
+                                            <span
+                                              class="ag-icon ag-icon-filter"
+                                              role="presentation"
+                                              unselectable="on"
+                                            />
+                                          </span>
+                                          
+                
+                                          
+                
+                                          
+                
+                                          
+                
+                                          
+            
+                                        </div>
+                                        
+        
+                                      </div>
+                                    </div>
+                                    <div
+                                      aria-colindex="2"
+                                      aria-sort="none"
+                                      class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-248"
+                                      col-id="name"
+                                      role="columnheader"
+                                      style="width: 465px; left: 34px;"
+                                      tabindex="-1"
+                                      unselectable="on"
+                                    >
+                                      
+            
+                                      <div
+                                        class="ag-header-cell-resize"
+                                        ref="eResize"
+                                        role="presentation"
+                                      />
+                                      
+            
+                                      <!--AG-CHECKBOX-->
+                                      <div
+                                        class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                                        ref="cbSelectAll"
+                                        role="presentation"
+                                      >
+                                        
+                
+                                        <div
+                                          class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                          ref="eLabel"
+                                          role="presentation"
+                                        />
+                                        
+                
+                                        <div
+                                          class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                          ref="eWrapper"
+                                          role="presentation"
+                                        >
+                                          
+                    
+                                          <input
+                                            aria-label="Press Space to toggle all rows selection (unchecked)"
+                                            class="ag-input-field-input ag-checkbox-input"
+                                            id="ag-322-input"
+                                            ref="eInput"
+                                            tabindex="-1"
+                                            type="checkbox"
+                                          />
+                                          
+                
+                                        </div>
+                                        
+            
+                                      </div>
+                                      
+        
+                                      <div
+                                        class="ag-cell-label-container ag-header-cell-sorted-none"
+                                        role="presentation"
+                                      >
+                                        
+            
+                                        <span
+                                          aria-hidden="true"
+                                          class="ag-header-icon ag-header-cell-menu-button"
+                                          ref="eMenu"
+                                        >
+                                          <span
+                                            class="ag-icon ag-icon-menu"
+                                            role="presentation"
+                                            unselectable="on"
+                                          />
+                                        </span>
+                                        
+            
+                                        <div
+                                          class="ag-header-cell-label"
+                                          ref="eLabel"
+                                          role="presentation"
+                                          unselectable="on"
+                                        >
+                                          
+                
+                                          <span
+                                            class="ag-header-cell-text"
+                                            ref="eText"
+                                            unselectable="on"
+                                          >
+                                            Name
+                                          </span>
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                            ref="eFilter"
+                                          >
+                                            <span
+                                              class="ag-icon ag-icon-filter"
+                                              role="presentation"
+                                              unselectable="on"
+                                            />
+                                          </span>
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-sort-order ag-hidden"
+                                            ref="eSortOrder"
+                                          />
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-sort-ascending-icon ag-hidden"
+                                            ref="eSortAsc"
+                                          >
+                                            <span
+                                              class="ag-icon ag-icon-asc"
+                                              role="presentation"
+                                              unselectable="on"
+                                            />
+                                          </span>
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-sort-descending-icon ag-hidden"
+                                            ref="eSortDesc"
+                                          >
+                                            <span
+                                              class="ag-icon ag-icon-desc"
+                                              role="presentation"
+                                              unselectable="on"
+                                            />
+                                          </span>
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-sort-none-icon ag-hidden"
+                                            ref="eSortNone"
+                                          >
+                                            <span
+                                              class="ag-icon ag-icon-none"
+                                              role="presentation"
+                                              unselectable="on"
+                                            />
+                                          </span>
+                                          
+            
+                                        </div>
+                                        
+        
+                                      </div>
+                                    </div>
+                                    <div
+                                      aria-colindex="3"
+                                      aria-sort="none"
+                                      class="ag-header-cell ag-focus-managed ag-header-cell-sortable"
+                                      col-id="description"
+                                      role="columnheader"
+                                      style="width: 550px; left: 499px;"
+                                      tabindex="-1"
+                                      unselectable="on"
+                                    >
+                                      
+            
+                                      <div
+                                        class="ag-header-cell-resize"
+                                        ref="eResize"
+                                        role="presentation"
+                                      />
+                                      
+            
+                                      <!--AG-CHECKBOX-->
+                                      <div
+                                        class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                                        ref="cbSelectAll"
+                                        role="presentation"
+                                      >
+                                        
+                
+                                        <div
+                                          class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                          ref="eLabel"
+                                          role="presentation"
+                                        />
+                                        
+                
+                                        <div
+                                          class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                          ref="eWrapper"
+                                          role="presentation"
+                                        >
+                                          
+                    
+                                          <input
+                                            aria-label="Press Space to toggle all rows selection (unchecked)"
+                                            class="ag-input-field-input ag-checkbox-input"
+                                            id="ag-325-input"
+                                            ref="eInput"
+                                            tabindex="-1"
+                                            type="checkbox"
+                                          />
+                                          
+                
+                                        </div>
+                                        
+            
+                                      </div>
+                                      
+        
+                                      <div
+                                        class="ag-cell-label-container ag-header-cell-sorted-none"
+                                        role="presentation"
+                                      >
+                                        
+            
+                                        <span
+                                          aria-hidden="true"
+                                          class="ag-header-icon ag-header-cell-menu-button"
+                                          ref="eMenu"
+                                        >
+                                          <span
+                                            class="ag-icon ag-icon-menu"
+                                            role="presentation"
+                                            unselectable="on"
+                                          />
+                                        </span>
+                                        
+            
+                                        <div
+                                          class="ag-header-cell-label"
+                                          ref="eLabel"
+                                          role="presentation"
+                                          unselectable="on"
+                                        >
+                                          
+                
+                                          <span
+                                            class="ag-header-cell-text"
+                                            ref="eText"
+                                            unselectable="on"
+                                          >
+                                            Description
+                                          </span>
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                            ref="eFilter"
+                                          >
+                                            <span
+                                              class="ag-icon ag-icon-filter"
+                                              role="presentation"
+                                              unselectable="on"
+                                            />
+                                          </span>
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-sort-order ag-hidden"
+                                            ref="eSortOrder"
+                                          />
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-sort-ascending-icon ag-hidden"
+                                            ref="eSortAsc"
+                                          >
+                                            <span
+                                              class="ag-icon ag-icon-asc"
+                                              role="presentation"
+                                              unselectable="on"
+                                            />
+                                          </span>
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-sort-descending-icon ag-hidden"
+                                            ref="eSortDesc"
+                                          >
+                                            <span
+                                              class="ag-icon ag-icon-desc"
+                                              role="presentation"
+                                              unselectable="on"
+                                            />
+                                          </span>
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-sort-none-icon ag-hidden"
+                                            ref="eSortNone"
+                                          >
+                                            <span
+                                              class="ag-icon ag-icon-none"
+                                              role="presentation"
+                                              unselectable="on"
+                                            />
+                                          </span>
+                                          
+            
+                                        </div>
+                                        
+        
+                                      </div>
+                                    </div>
+                                    <div
+                                      aria-colindex="7"
+                                      class="ag-header-cell ag-focus-managed"
+                                      col-id="metrics-assign--actions"
+                                      role="columnheader"
+                                      style="width: 150px; left: 1049px;"
+                                      tabindex="-1"
+                                      unselectable="on"
+                                    >
+                                      
+            
+                                      <div
+                                        class="ag-header-cell-resize ag-hidden"
+                                        ref="eResize"
+                                        role="presentation"
+                                      />
+                                      
+            
+                                      <!--AG-CHECKBOX-->
+                                      <div
+                                        class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                                        ref="cbSelectAll"
+                                        role="presentation"
+                                      >
+                                        
+                
+                                        <div
+                                          class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                          ref="eLabel"
+                                          role="presentation"
+                                        />
+                                        
+                
+                                        <div
+                                          class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                          ref="eWrapper"
+                                          role="presentation"
+                                        >
+                                          
+                    
+                                          <input
+                                            aria-label="Press Space to toggle all rows selection (unchecked)"
+                                            class="ag-input-field-input ag-checkbox-input"
+                                            id="ag-328-input"
+                                            ref="eInput"
+                                            tabindex="-1"
+                                            type="checkbox"
+                                          />
+                                          
+                
+                                        </div>
+                                        
+            
+                                      </div>
+                                      
+        
+                                      <div
+                                        class="ag-cell-label-container"
+                                        role="presentation"
+                                      >
+                                        
+            
+                                        
+            
+                                        <div
+                                          class="ag-header-cell-label"
+                                          ref="eLabel"
+                                          role="presentation"
+                                          unselectable="on"
+                                        >
+                                          
+                
+                                          <span
+                                            class="ag-header-cell-text"
+                                            ref="eText"
+                                            unselectable="on"
+                                          >
+                                            Actions
+                                          </span>
+                                          
+                
+                                          <span
+                                            aria-hidden="true"
+                                            class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                            ref="eFilter"
+                                          >
+                                            <span
+                                              class="ag-icon ag-icon-filter"
+                                              role="presentation"
+                                              unselectable="on"
+                                            />
+                                          </span>
+                                          
+                
+                                          
+                
+                                          
+                
+                                          
+                
+                                          
+            
+                                        </div>
+                                        
+        
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                                
+            
+                              </div>
+                              
+            
+                              <div
+                                class="ag-pinned-right-header ag-hidden"
+                                ref="ePinnedRightHeader"
+                                role="presentation"
+                                style="width: 0px; max-width: 0px; min-width: 0px;"
+                              >
+                                <div
+                                  aria-rowindex="1"
+                                  class="ag-header-row ag-header-row-column"
+                                  role="row"
+                                  style="top: 0px; height: 48px; width: 0px;"
+                                />
+                              </div>
+                              
+        
+                            </div>
+                            
+        
+                            <div
+                              class="ag-floating-top"
+                              ref="eTop"
+                              role="presentation"
+                              style="min-height: 0px; height: 0px; display: none; overflow-y: hidden;"
+                              unselectable="on"
+                            >
+                              
+            
+                              <div
+                                class="ag-pinned-left-floating-top ag-hidden"
+                                ref="eLeftTop"
+                                role="presentation"
+                                unselectable="on"
+                              />
+                              
+            
+                              <div
+                                class="ag-floating-top-viewport"
+                                ref="eTopViewport"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <div
+                                  class="ag-floating-top-container"
+                                  ref="eTopContainer"
+                                  role="presentation"
+                                  style="width: 1199px;"
+                                  unselectable="on"
+                                />
+                                
+            
+                              </div>
+                              
+            
+                              <div
+                                class="ag-pinned-right-floating-top ag-hidden"
+                                ref="eRightTop"
+                                role="presentation"
+                                unselectable="on"
+                              />
+                              
+            
+                              <div
+                                class="ag-floating-top-full-width-container ag-hidden"
+                                ref="eTopFullWidthContainer"
+                                role="presentation"
+                                unselectable="on"
+                              />
+                              
+        
+                            </div>
+                            
+        
+                            <div
+                              class="ag-body-viewport ag-layout-normal ag-row-no-animation"
+                              ref="eBodyViewport"
+                              role="presentation"
+                            >
+                              
+            
+                              <div
+                                class="ag-pinned-left-cols-container ag-hidden"
+                                ref="eLeftContainer"
+                                role="presentation"
+                                style="height: 840px;"
+                                unselectable="on"
+                              >
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="2"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                                  comp-id="374"
+                                  role="row"
+                                  row-id="metric_1"
+                                  row-index="0"
+                                  style="height: 42px; transform: translateY(0px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="3"
+                                  class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="379"
+                                  role="row"
+                                  row-id="metric_2"
+                                  row-index="1"
+                                  style="height: 42px; transform: translateY(42px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="4"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="384"
+                                  role="row"
+                                  row-id="metric_3"
+                                  row-index="2"
+                                  style="height: 42px; transform: translateY(84px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="5"
+                                  class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="389"
+                                  role="row"
+                                  row-id="metric_4"
+                                  row-index="3"
+                                  style="height: 42px; transform: translateY(126px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="6"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="394"
+                                  role="row"
+                                  row-id="metric_5"
+                                  row-index="4"
+                                  style="height: 42px; transform: translateY(168px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="7"
+                                  class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="399"
+                                  role="row"
+                                  row-id="metric_6"
+                                  row-index="5"
+                                  style="height: 42px; transform: translateY(210px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="8"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="404"
+                                  role="row"
+                                  row-id="metric_7"
+                                  row-index="6"
+                                  style="height: 42px; transform: translateY(252px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="9"
+                                  class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="409"
+                                  role="row"
+                                  row-id="metric_8"
+                                  row-index="7"
+                                  style="height: 42px; transform: translateY(294px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="10"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="414"
+                                  role="row"
+                                  row-id="metric_9"
+                                  row-index="8"
+                                  style="height: 42px; transform: translateY(336px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="11"
+                                  class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="419"
+                                  role="row"
+                                  row-id="metric_10"
+                                  row-index="9"
+                                  style="height: 42px; transform: translateY(378px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="12"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="424"
+                                  role="row"
+                                  row-id="metric_11"
+                                  row-index="10"
+                                  style="height: 42px; transform: translateY(420px); "
+                                />
+                              </div>
+                              
+            
+                              <div
+                                class="ag-center-cols-clipper"
+                                ref="eCenterColsClipper"
+                                role="presentation"
+                                style="height: 840px;"
+                                unselectable="on"
+                              >
+                                
+                
+                                <div
+                                  class="ag-center-cols-viewport"
+                                  ref="eCenterViewport"
+                                  role="presentation"
+                                  style="height: calc(100% + 0px);"
+                                >
+                                  
+                    
+                                  <div
+                                    class="ag-center-cols-container"
+                                    ref="eCenterContainer"
+                                    role="rowgroup"
+                                    style="width: 1199px; height: 840px;"
+                                    unselectable="on"
+                                  >
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="2"
+                                      class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                                      comp-id="374"
+                                      role="row"
+                                      row-id="metric_1"
+                                      row-index="0"
+                                      style="height: 42px; transform: translateY(0px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="375"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="376"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="377"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 1
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="378"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="3"
+                                      class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                      comp-id="379"
+                                      role="row"
+                                      row-id="metric_2"
+                                      row-index="1"
+                                      style="height: 42px; transform: translateY(42px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="380"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="381"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="382"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 2
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="383"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="4"
+                                      class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                      comp-id="384"
+                                      role="row"
+                                      row-id="metric_3"
+                                      row-index="2"
+                                      style="height: 42px; transform: translateY(84px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="385"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="386"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="387"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 3
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="388"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="5"
+                                      class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                      comp-id="389"
+                                      role="row"
+                                      row-id="metric_4"
+                                      row-index="3"
+                                      style="height: 42px; transform: translateY(126px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="390"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="391"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="392"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 4
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="393"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="6"
+                                      class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                      comp-id="394"
+                                      role="row"
+                                      row-id="metric_5"
+                                      row-index="4"
+                                      style="height: 42px; transform: translateY(168px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="395"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="396"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="397"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 5
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="398"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="7"
+                                      class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                      comp-id="399"
+                                      role="row"
+                                      row-id="metric_6"
+                                      row-index="5"
+                                      style="height: 42px; transform: translateY(210px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="400"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="401"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="402"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 6
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="403"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="8"
+                                      class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                      comp-id="404"
+                                      role="row"
+                                      row-id="metric_7"
+                                      row-index="6"
+                                      style="height: 42px; transform: translateY(252px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="405"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="406"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="407"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 7
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="408"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="9"
+                                      class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                      comp-id="409"
+                                      role="row"
+                                      row-id="metric_8"
+                                      row-index="7"
+                                      style="height: 42px; transform: translateY(294px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="410"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="411"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="412"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 8
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="413"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="10"
+                                      class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                      comp-id="414"
+                                      role="row"
+                                      row-id="metric_9"
+                                      row-index="8"
+                                      style="height: 42px; transform: translateY(336px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="415"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="416"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="417"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 9
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="418"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="11"
+                                      class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                      comp-id="419"
+                                      role="row"
+                                      row-id="metric_10"
+                                      row-index="9"
+                                      style="height: 42px; transform: translateY(378px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="420"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="421"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="422"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 10
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="423"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-label="Press SPACE to select this row."
+                                      aria-rowindex="12"
+                                      class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                      comp-id="424"
+                                      role="row"
+                                      row-id="metric_11"
+                                      row-index="10"
+                                      style="height: 42px; transform: translateY(420px); "
+                                    >
+                                      <div
+                                        aria-colindex="1"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="__detail-button-col__"
+                                        comp-id="425"
+                                        role="gridcell"
+                                        style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="2"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="name"
+                                        comp-id="426"
+                                        role="gridcell"
+                                        style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                      <div
+                                        aria-colindex="3"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="description"
+                                        comp-id="427"
+                                        role="gridcell"
+                                        style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      >
+                                        This is metric 11
+                                      </div>
+                                      <div
+                                        aria-colindex="7"
+                                        class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                                        col-id="metrics-assign--actions"
+                                        comp-id="428"
+                                        role="gridcell"
+                                        style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                                        tabindex="-1"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                  </div>
+                                  
+                
+                                </div>
+                                
+            
+                              </div>
+                              
+            
+                              <div
+                                class="ag-pinned-right-cols-container ag-hidden"
+                                ref="eRightContainer"
+                                role="presentation"
+                                style="height: 840px;"
+                                unselectable="on"
+                              >
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="2"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                                  comp-id="374"
+                                  role="row"
+                                  row-id="metric_1"
+                                  row-index="0"
+                                  style="height: 42px; transform: translateY(0px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="3"
+                                  class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="379"
+                                  role="row"
+                                  row-id="metric_2"
+                                  row-index="1"
+                                  style="height: 42px; transform: translateY(42px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="4"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="384"
+                                  role="row"
+                                  row-id="metric_3"
+                                  row-index="2"
+                                  style="height: 42px; transform: translateY(84px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="5"
+                                  class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="389"
+                                  role="row"
+                                  row-id="metric_4"
+                                  row-index="3"
+                                  style="height: 42px; transform: translateY(126px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="6"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="394"
+                                  role="row"
+                                  row-id="metric_5"
+                                  row-index="4"
+                                  style="height: 42px; transform: translateY(168px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="7"
+                                  class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="399"
+                                  role="row"
+                                  row-id="metric_6"
+                                  row-index="5"
+                                  style="height: 42px; transform: translateY(210px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="8"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="404"
+                                  role="row"
+                                  row-id="metric_7"
+                                  row-index="6"
+                                  style="height: 42px; transform: translateY(252px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="9"
+                                  class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="409"
+                                  role="row"
+                                  row-id="metric_8"
+                                  row-index="7"
+                                  style="height: 42px; transform: translateY(294px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="10"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="414"
+                                  role="row"
+                                  row-id="metric_9"
+                                  row-index="8"
+                                  style="height: 42px; transform: translateY(336px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="11"
+                                  class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="419"
+                                  role="row"
+                                  row-id="metric_10"
+                                  row-index="9"
+                                  style="height: 42px; transform: translateY(378px); "
+                                />
+                                <div
+                                  aria-label="Press SPACE to select this row."
+                                  aria-rowindex="12"
+                                  class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute"
+                                  comp-id="424"
+                                  role="row"
+                                  row-id="metric_11"
+                                  row-index="10"
+                                  style="height: 42px; transform: translateY(420px); "
+                                />
+                              </div>
+                              
+            
+                              <div
+                                class="ag-full-width-container"
+                                ref="eFullWidthContainer"
+                                role="presentation"
+                                style="height: 840px;"
+                                unselectable="on"
+                              />
+                              
+        
+                            </div>
+                            
+        
+                            <div
+                              class="ag-floating-bottom"
+                              ref="eBottom"
+                              role="presentation"
+                              style="min-height: 0px; height: 0px; display: none; overflow-y: hidden;"
+                              unselectable="on"
+                            >
+                              
+            
+                              <div
+                                class="ag-pinned-left-floating-bottom ag-hidden"
+                                ref="eLeftBottom"
+                                role="presentation"
+                                unselectable="on"
+                              />
+                              
+            
+                              <div
+                                class="ag-floating-bottom-viewport"
+                                ref="eBottomViewport"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <div
+                                  class="ag-floating-bottom-container"
+                                  ref="eBottomContainer"
+                                  role="presentation"
+                                  style="width: 1199px;"
+                                  unselectable="on"
+                                />
+                                
+            
+                              </div>
+                              
+            
+                              <div
+                                class="ag-pinned-right-floating-bottom ag-hidden"
+                                ref="eRightBottom"
+                                role="presentation"
+                                unselectable="on"
+                              />
+                              
+            
+                              <div
+                                class="ag-floating-bottom-full-width-container ag-hidden"
+                                ref="eBottomFullWidthContainer"
+                                role="presentation"
+                                unselectable="on"
+                              />
+                              
+        
+                            </div>
+                            
+        
+                            <div
+                              aria-hidden="true"
+                              class="ag-body-horizontal-scroll"
+                              ref="eHorizontalScrollBody"
+                              style="height: 0px; max-height: 0px; min-height: 0px;"
+                            >
+                              
+            
+                              <div
+                                class="ag-horizontal-left-spacer"
+                                ref="eHorizontalLeftSpacer"
+                                style="width: 0px; max-width: 0px; min-width: 0px;"
+                              />
+                              
+            
+                              <div
+                                class="ag-body-horizontal-scroll-viewport"
+                                ref="eBodyHorizontalScrollViewport"
+                                style="height: 0px; max-height: 0px; min-height: 0px;"
+                              >
+                                
+                
+                                <div
+                                  class="ag-body-horizontal-scroll-container"
+                                  ref="eBodyHorizontalScrollContainer"
+                                  style="width: 1199px; height: 0px; max-height: 0px; min-height: 0px;"
+                                />
+                                
+            
+                              </div>
+                              
+            
+                              <div
+                                class="ag-horizontal-right-spacer"
+                                ref="eHorizontalRightSpacer"
+                                style="width: 0px; max-width: 0px; min-width: 0px;"
+                              />
+                              
+        
+                            </div>
+                            
+        
+                            <!--AG-OVERLAY-WRAPPER-->
+                            <div
+                              aria-hidden="true"
+                              class="ag-overlay ag-hidden"
+                              ref="overlayWrapper"
+                            >
+                              
+            
+                              <div
+                                class="ag-overlay-panel"
+                              >
+                                
+                
+                                <div
+                                  class="ag-overlay-wrapper ag-layout-normal"
+                                  ref="eOverlayWrapper"
+                                />
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                            
+    
+                          </div>
+                          
+                    
+                
+                          <div
+                            class="ag-tab-guard ag-tab-guard-bottom"
+                            role="presentation"
+                            tabindex="0"
+                          />
+                        </div>
+                        
+                
+                
+                        <!--AG-PAGINATION-->
+                        <div
+                          aria-describedby="ag-314-start-page ag-314-start-page-number ag-314-of-page ag-314-of-page-number ag-314-first-row ag-314-to ag-314-last-row ag-314-of ag-314-row-count"
+                          aria-live="polite"
+                          class="ag-paging-panel ag-unselectable ag-hidden"
+                          id="ag-314"
+                        >
+                          
+                
+                          <span
+                            aria-hidden="true"
+                            class="ag-paging-row-summary-panel"
+                          >
+                            
+                    
+                            <span
+                              class="ag-paging-row-summary-panel-number"
+                              id="ag-314-first-row"
+                              ref="lbFirstRowOnPage"
+                            />
+                            
+                    
+                            <span
+                              id="ag-314-to"
+                            >
+                              to
+                            </span>
+                            
+                    
+                            <span
+                              class="ag-paging-row-summary-panel-number"
+                              id="ag-314-last-row"
+                              ref="lbLastRowOnPage"
+                            />
+                            
+                    
+                            <span
+                              id="ag-314-of"
+                            >
+                              of
+                            </span>
+                            
+                    
+                            <span
+                              class="ag-paging-row-summary-panel-number"
+                              id="ag-314-row-count"
+                              ref="lbRecordCount"
+                            />
+                            
+                
+                          </span>
+                          
+                
+                          <span
+                            class="ag-paging-page-summary-panel"
+                            role="presentation"
+                          >
+                            
+                    
+                            <div
+                              aria-label="First Page"
+                              class="ag-paging-button"
+                              ref="btFirst"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <span
+                                class="ag-icon ag-icon-first"
+                                role="presentation"
+                                unselectable="on"
+                              />
+                            </div>
+                            
+                    
+                            <div
+                              aria-label="Previous Page"
+                              class="ag-paging-button"
+                              ref="btPrevious"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <span
+                                class="ag-icon ag-icon-previous"
+                                role="presentation"
+                                unselectable="on"
+                              />
+                            </div>
+                            
+                    
+                            <span
+                              aria-hidden="true"
+                              class="ag-paging-description"
+                            >
+                              
+                        
+                              <span
+                                id="ag-314-start-page"
+                              >
+                                Page
+                              </span>
+                              
+                        
+                              <span
+                                class="ag-paging-number"
+                                id="ag-314-start-page-number"
+                                ref="lbCurrent"
+                              />
+                              
+                        
+                              <span
+                                id="ag-314-of-page"
+                              >
+                                of
+                              </span>
+                              
+                        
+                              <span
+                                class="ag-paging-number"
+                                id="ag-314-of-page-number"
+                                ref="lbTotal"
+                              />
+                              
+                    
+                            </span>
+                            
+                    
+                            <div
+                              aria-label="Next Page"
+                              class="ag-paging-button"
+                              ref="btNext"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <span
+                                class="ag-icon ag-icon-next"
+                                role="presentation"
+                                unselectable="on"
+                              />
+                            </div>
+                            
+                    
+                            <div
+                              aria-label="Last Page"
+                              class="ag-paging-button"
+                              ref="btLast"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <span
+                                class="ag-icon ag-icon-last"
+                                role="presentation"
+                                unselectable="on"
+                              />
+                            </div>
+                            
+                
+                          </span>
+                          
+            
+                        </div>
+                        
+                
+            
                       </div>
                     </div>
                   </div>
                 </div>
-                <button
-                  aria-label="Add metric"
-                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiButton-label"
-                  >
-                    Assign
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
-                  />
-                </button>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-148 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-227 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -3497,7 +7105,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-149 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-228 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -3518,13 +7126,13 @@ exports[`sections should be browsable by the section buttons and show validation
                   class="MuiAlert-message"
                 >
                   <div
-                    class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-168 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+                    class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-260 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
                   >
                     <div
                       aria-controls="attr-window-panel-content"
                       aria-disabled="false"
                       aria-expanded="false"
-                      class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-169"
+                      class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-261"
                       id="attr-window-panel"
                       role="button"
                       tabindex="0"
@@ -3588,7 +7196,7 @@ exports[`sections should be browsable by the section buttons and show validation
                                 is the window of time after exposure to an experiment that we capture metric events for a participant (exposure can be from either assignment or specified exposure events). The refund window is the window of time after a purchase event. Revenue metrics will automatically deduct transactions that have been refunded within the metric’s refund window.
                                 <br />
                                 <div
-                                  class="makeStyles-attributionWindowDiagram-150"
+                                  class="makeStyles-attributionWindowDiagram-229"
                                 >
                                   <svg>
                                     attribution_window.svg
@@ -3607,7 +7215,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-151 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-230 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -3628,13 +7236,13 @@ exports[`sections should be browsable by the section buttons and show validation
                   class="MuiAlert-message"
                 >
                   <div
-                    class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-168 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+                    class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-260 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
                   >
                     <div
                       aria-controls="min-diff-panel-content"
                       aria-disabled="false"
                       aria-expanded="false"
-                      class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-169"
+                      class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-261"
                       id="min-diff-panel"
                       role="button"
                       tabindex="0"
@@ -3698,7 +7306,7 @@ exports[`sections should be browsable by the section buttons and show validation
                                 are absolute differences from the baseline (not relative). For example, if the baseline conversion rate is 5%, a minimum difference of 0.5 pp is equivalent to a 10% relative change.
                                 <br />
                                 <div
-                                  class="makeStyles-minDiffDiagram-152"
+                                  class="makeStyles-minDiffDiagram-231"
                                 >
                                   <svg>
                                     min_diffs.svg
@@ -3714,7 +7322,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-153 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-232 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -3744,7 +7352,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <h4
-                class="MuiTypography-root makeStyles-exposureEventsTitle-154 MuiTypography-h4"
+                class="MuiTypography-root makeStyles-exposureEventsTitle-233 MuiTypography-h4"
               >
                 Exposure Events
               </h4>
@@ -3777,11 +7385,11 @@ exports[`sections should be browsable by the section buttons and show validation
                 </table>
               </div>
               <div
-                class="makeStyles-addMetric-158"
+                class="makeStyles-addMetric-238"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-159"
+                  class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-239"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -3806,7 +7414,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </button>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-155 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-234 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -3840,7 +7448,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-156 MuiPaper-elevation0"
+                class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-235 MuiPaper-elevation0"
                 role="alert"
               >
                 <div
@@ -3871,7 +7479,7 @@ exports[`sections should be browsable by the section buttons and show validation
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-86"
+            class="makeStyles-formPartActions-116"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -3912,10 +7520,10 @@ exports[`sections should be browsable by the section buttons and show validation
 exports[`sections should be browsable by the section buttons and show validation errors without crashing 6`] = `
 <div>
   <div
-    class="makeStyles-root-82"
+    class="makeStyles-root-112"
   >
     <div
-      class="MuiPaper-root makeStyles-navigation-83 MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root makeStyles-navigation-113 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-horizontal MuiPaper-elevation0"
@@ -4172,7 +7780,7 @@ exports[`sections should be browsable by the section buttons and show validation
     </div>
     <div>
       <form
-        class="makeStyles-form-84"
+        class="makeStyles-form-114"
         novalidate=""
       >
         <button
@@ -4182,13 +7790,13 @@ exports[`sections should be browsable by the section buttons and show validation
           type="submit"
         />
         <div
-          class="makeStyles-formPart-85"
+          class="makeStyles-formPart-115"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-87 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-117 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-root-170"
+              class="makeStyles-root-279"
             >
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -4196,7 +7804,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 Define Your Audience
               </h4>
               <div
-                class="makeStyles-row-171"
+                class="makeStyles-row-280"
               >
                 <fieldset
                   class="MuiFormControl-root"
@@ -4252,7 +7860,7 @@ exports[`sections should be browsable by the section buttons and show validation
                 </fieldset>
               </div>
               <div
-                class="makeStyles-row-171"
+                class="makeStyles-row-280"
               >
                 <fieldset
                   class="MuiFormControl-root"
@@ -4284,19 +7892,19 @@ exports[`sections should be browsable by the section buttons and show validation
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-161 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-241 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
                       >
                         <span
                           class="MuiIconButton-label"
                         >
                           <input
-                            class="PrivateSwitchBase-input-164"
+                            class="PrivateSwitchBase-input-244"
                             name="experiment.existingUsersAllowed"
                             type="radio"
                             value="false"
                           />
                           <div
-                            class="PrivateRadioButtonIcon-root-180"
+                            class="PrivateRadioButtonIcon-root-289"
                           >
                             <svg
                               aria-hidden="true"
@@ -4310,7 +7918,7 @@ exports[`sections should be browsable by the section buttons and show validation
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-181"
+                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-290"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
@@ -4335,20 +7943,20 @@ exports[`sections should be browsable by the section buttons and show validation
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-161 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-162 Mui-checked MuiIconButton-colorSecondary"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-241 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-242 Mui-checked MuiIconButton-colorSecondary"
                       >
                         <span
                           class="MuiIconButton-label"
                         >
                           <input
                             checked=""
-                            class="PrivateSwitchBase-input-164"
+                            class="PrivateSwitchBase-input-244"
                             name="experiment.existingUsersAllowed"
                             type="radio"
                             value="true"
                           />
                           <div
-                            class="PrivateRadioButtonIcon-root-180 PrivateRadioButtonIcon-checked-182"
+                            class="PrivateRadioButtonIcon-root-289 PrivateRadioButtonIcon-checked-291"
                           >
                             <svg
                               aria-hidden="true"
@@ -4362,7 +7970,7 @@ exports[`sections should be browsable by the section buttons and show validation
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-181"
+                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-290"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
@@ -4386,10 +7994,10 @@ exports[`sections should be browsable by the section buttons and show validation
                 </fieldset>
               </div>
               <div
-                class="makeStyles-row-171"
+                class="makeStyles-row-280"
               >
                 <fieldset
-                  class="MuiFormControl-root makeStyles-segmentationFieldSet-173"
+                  class="MuiFormControl-root makeStyles-segmentationFieldSet-282"
                 >
                   <label
                     class="MuiFormLabel-root"
@@ -4398,7 +8006,7 @@ exports[`sections should be browsable by the section buttons and show validation
                     Targeting
                   </label>
                   <p
-                    class="MuiFormHelperText-root makeStyles-segmentationHelperText-172"
+                    class="MuiFormHelperText-root makeStyles-segmentationHelperText-281"
                   >
                     Who should see this experiment? 
                     <br />
@@ -4406,7 +8014,7 @@ exports[`sections should be browsable by the section buttons and show validation
                   </p>
                   <div
                     aria-label="include-or-exclude-segments"
-                    class="MuiFormGroup-root makeStyles-segmentationExclusionState-174"
+                    class="MuiFormGroup-root makeStyles-segmentationExclusionState-283"
                     role="radiogroup"
                   >
                     <label
@@ -4414,20 +8022,20 @@ exports[`sections should be browsable by the section buttons and show validation
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-161 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-162 Mui-checked MuiIconButton-colorSecondary"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-241 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-242 Mui-checked MuiIconButton-colorSecondary"
                       >
                         <span
                           class="MuiIconButton-label"
                         >
                           <input
                             checked=""
-                            class="PrivateSwitchBase-input-164"
+                            class="PrivateSwitchBase-input-244"
                             name="non-formik-segment-exclusion-state-include"
                             type="radio"
                             value="include"
                           />
                           <div
-                            class="PrivateRadioButtonIcon-root-180 PrivateRadioButtonIcon-checked-182"
+                            class="PrivateRadioButtonIcon-root-289 PrivateRadioButtonIcon-checked-291"
                           >
                             <svg
                               aria-hidden="true"
@@ -4441,7 +8049,7 @@ exports[`sections should be browsable by the section buttons and show validation
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-181"
+                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-290"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
@@ -4466,19 +8074,19 @@ exports[`sections should be browsable by the section buttons and show validation
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-161 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-241 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
                       >
                         <span
                           class="MuiIconButton-label"
                         >
                           <input
-                            class="PrivateSwitchBase-input-164"
+                            class="PrivateSwitchBase-input-244"
                             name="non-formik-segment-exclusion-state-exclude"
                             type="radio"
                             value="exclude"
                           />
                           <div
-                            class="PrivateRadioButtonIcon-root-180"
+                            class="PrivateRadioButtonIcon-root-289"
                           >
                             <svg
                               aria-hidden="true"
@@ -4492,7 +8100,7 @@ exports[`sections should be browsable by the section buttons and show validation
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-181"
+                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-290"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
@@ -4593,11 +8201,11 @@ exports[`sections should be browsable by the section buttons and show validation
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="PrivateNotchedOutline-root-123 MuiOutlinedInput-notchedOutline"
+                          class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
                           style="padding-left: 8px;"
                         >
                           <legend
-                            class="PrivateNotchedOutline-legend-124"
+                            class="PrivateNotchedOutline-legend-195"
                             style="width: 0.01px;"
                           >
                             <span>
@@ -4611,10 +8219,10 @@ exports[`sections should be browsable by the section buttons and show validation
                 </fieldset>
               </div>
               <div
-                class="makeStyles-row-171"
+                class="makeStyles-row-280"
               >
                 <fieldset
-                  class="MuiFormControl-root makeStyles-segmentationFieldSet-173"
+                  class="MuiFormControl-root makeStyles-segmentationFieldSet-282"
                 >
                   <label
                     class="MuiFormLabel-root"
@@ -4623,7 +8231,7 @@ exports[`sections should be browsable by the section buttons and show validation
                     Variations
                   </label>
                   <p
-                    class="MuiFormHelperText-root makeStyles-segmentationHelperText-172"
+                    class="MuiFormHelperText-root makeStyles-segmentationHelperText-281"
                   >
                     Set the percentage of traffic allocated to each variation. Percentages may sum to less than 100 to avoid allocating the entire userbase. 
                     <br />
@@ -4633,7 +8241,7 @@ exports[`sections should be browsable by the section buttons and show validation
                     class="MuiTableContainer-root"
                   >
                     <table
-                      class="MuiTable-root makeStyles-variants-179"
+                      class="MuiTable-root makeStyles-variants-288"
                     >
                       <thead
                         class="MuiTableHead-root"
@@ -4674,7 +8282,7 @@ exports[`sections should be browsable by the section buttons and show validation
                             class="MuiTableCell-root MuiTableCell-body"
                           >
                             <div
-                              class="MuiFormControl-root MuiTextField-root makeStyles-variationAllocatedPercentage-178"
+                              class="MuiFormControl-root MuiTextField-root makeStyles-variationAllocatedPercentage-287"
                             >
                               <div
                                 class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
@@ -4701,11 +8309,11 @@ exports[`sections should be browsable by the section buttons and show validation
                                 </div>
                                 <fieldset
                                   aria-hidden="true"
-                                  class="PrivateNotchedOutline-root-123 MuiOutlinedInput-notchedOutline"
+                                  class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
                                   style="padding-left: 8px;"
                                 >
                                   <legend
-                                    class="PrivateNotchedOutline-legend-124"
+                                    class="PrivateNotchedOutline-legend-195"
                                     style="width: 0.01px;"
                                   >
                                     <span>
@@ -4743,11 +8351,11 @@ exports[`sections should be browsable by the section buttons and show validation
                                 />
                                 <fieldset
                                   aria-hidden="true"
-                                  class="PrivateNotchedOutline-root-123 MuiOutlinedInput-notchedOutline"
+                                  class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
                                   style="padding-left: 8px;"
                                 >
                                   <legend
-                                    class="PrivateNotchedOutline-legend-124"
+                                    class="PrivateNotchedOutline-legend-195"
                                     style="width: 0.01px;"
                                   >
                                     <span>
@@ -4762,7 +8370,7 @@ exports[`sections should be browsable by the section buttons and show validation
                             class="MuiTableCell-root MuiTableCell-body"
                           >
                             <div
-                              class="MuiFormControl-root MuiTextField-root makeStyles-variationAllocatedPercentage-178"
+                              class="MuiFormControl-root MuiTextField-root makeStyles-variationAllocatedPercentage-287"
                             >
                               <div
                                 class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
@@ -4789,11 +8397,11 @@ exports[`sections should be browsable by the section buttons and show validation
                                 </div>
                                 <fieldset
                                   aria-hidden="true"
-                                  class="PrivateNotchedOutline-root-123 MuiOutlinedInput-notchedOutline"
+                                  class="PrivateNotchedOutline-root-194 MuiOutlinedInput-notchedOutline"
                                   style="padding-left: 8px;"
                                 >
                                   <legend
-                                    class="PrivateNotchedOutline-legend-124"
+                                    class="PrivateNotchedOutline-legend-195"
                                     style="width: 0.01px;"
                                   >
                                     <span>
@@ -4816,7 +8424,7 @@ exports[`sections should be browsable by the section buttons and show validation
                             colspan="3"
                           >
                             <div
-                              class="MuiPaper-root MuiAlert-root MuiAlert-standardWarning makeStyles-abnWarning-175 MuiPaper-elevation0"
+                              class="MuiPaper-root MuiAlert-root MuiAlert-standardWarning makeStyles-abnWarning-284 MuiPaper-elevation0"
                               role="alert"
                             >
                               <div
@@ -4850,11 +8458,11 @@ exports[`sections should be browsable by the section buttons and show validation
                                   Please do not set up such experiments in production without consulting the ExPlat team first.
                                 </p>
                                 <div
-                                  class="makeStyles-addVariation-176"
+                                  class="makeStyles-addVariation-285"
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    class="MuiSvgIcon-root makeStyles-addVariationIcon-177"
+                                    class="MuiSvgIcon-root makeStyles-addVariationIcon-286"
                                     focusable="false"
                                     viewBox="0 0 24 24"
                                   >
@@ -4890,7 +8498,7 @@ exports[`sections should be browsable by the section buttons and show validation
             </div>
           </div>
           <div
-            class="makeStyles-formPartActions-86"
+            class="makeStyles-formPartActions-116"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -4931,10 +8539,10 @@ exports[`sections should be browsable by the section buttons and show validation
 exports[`skipping to submit should check all sections 1`] = `
 <div>
   <div
-    class="makeStyles-root-207"
+    class="makeStyles-root-316"
   >
     <div
-      class="MuiPaper-root makeStyles-navigation-208 MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root makeStyles-navigation-317 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
         class="MuiPaper-root MuiStepper-root MuiStepper-horizontal MuiPaper-elevation0"
@@ -5181,7 +8789,7 @@ exports[`skipping to submit should check all sections 1`] = `
     </div>
     <div>
       <form
-        class="makeStyles-form-209"
+        class="makeStyles-form-318"
         novalidate=""
       >
         <button
@@ -5191,10 +8799,10 @@ exports[`skipping to submit should check all sections 1`] = `
           type="submit"
         />
         <div
-          class="makeStyles-formPart-210"
+          class="makeStyles-formPart-319"
         >
           <div
-            class="MuiPaper-root makeStyles-paper-212 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-paper-321 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <h4
               class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -5230,7 +8838,7 @@ exports[`skipping to submit should check all sections 1`] = `
             </p>
           </div>
           <div
-            class="makeStyles-formPartActions-211"
+            class="makeStyles-formPartActions-320"
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -5247,7 +8855,7 @@ exports[`skipping to submit should check all sections 1`] = `
               />
             </button>
             <div
-              class="makeStyles-root-221"
+              class="makeStyles-root-330"
             >
               <button
                 class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary Mui-disabled Mui-disabled"

--- a/src/components/experiments/wizard/__snapshots__/Metrics.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/Metrics.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`allows adding, editing and removing a Metric Assignment 1`] = `
 <div>
   <div
-    class="makeStyles-root-38"
+    class="makeStyles-root-39"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -73,22 +73,22 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-tableContainer-58"
+      class="makeStyles-tableContainer-59"
     >
       <div
-        class="ag-theme-alpine makeStyles-root-62"
+        class="ag-theme-alpine makeStyles-root-63"
       >
         <div
-          class="makeStyles-toolbar-63"
+          class="makeStyles-toolbar-64"
         >
           <div
-            class="makeStyles-rootFullWidth-66"
+            class="makeStyles-rootFullWidth-67"
           >
             <div
-              class="makeStyles-search-67"
+              class="makeStyles-search-68 makeStyles-searchBorder-69"
             >
               <div
-                class="makeStyles-searchIcon-68"
+                class="makeStyles-searchIcon-70"
               >
                 <svg
                   aria-hidden="true"
@@ -102,11 +102,11 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
                 </svg>
               </div>
               <div
-                class="MuiInputBase-root makeStyles-inputRootFullWidth-69"
+                class="MuiInputBase-root makeStyles-inputRootFullWidth-71"
               >
                 <input
                   aria-label="Search"
-                  class="MuiInputBase-input makeStyles-inputInputFullWidth-70"
+                  class="MuiInputBase-input makeStyles-inputInputFullWidth-72"
                   placeholder="Search…"
                   type="text"
                   value=""
@@ -130,7 +130,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
           </div>
         </div>
         <div
-          class="ag-theme-alpine makeStyles-gridContainer-64"
+          class="ag-theme-alpine makeStyles-gridContainer-65"
         >
           <div
             style="height: auto; flex: 1;"
@@ -316,7 +316,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
                           <div
                             aria-colindex="2"
                             aria-sort="none"
-                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-61"
+                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-62"
                             col-id="name"
                             role="columnheader"
                             style="width: 465px; left: 34px;"
@@ -1338,7 +1338,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-48 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-49 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1376,7 +1376,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-49 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-50 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1397,13 +1397,13 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-75 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="attr-window-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-76"
             id="attr-window-panel"
             role="button"
             tabindex="0"
@@ -1467,7 +1467,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
                       is the window of time after exposure to an experiment that we capture metric events for a participant (exposure can be from either assignment or specified exposure events). The refund window is the window of time after a purchase event. Revenue metrics will automatically deduct transactions that have been refunded within the metric’s refund window.
                       <br />
                       <div
-                        class="makeStyles-attributionWindowDiagram-50"
+                        class="makeStyles-attributionWindowDiagram-51"
                       >
                         <svg>
                           attribution_window.svg
@@ -1486,7 +1486,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-51 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-52 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1507,13 +1507,13 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-75 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="min-diff-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-76"
             id="min-diff-panel"
             role="button"
             tabindex="0"
@@ -1577,7 +1577,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
                       are absolute differences from the baseline (not relative). For example, if the baseline conversion rate is 5%, a minimum difference of 0.5 pp is equivalent to a 10% relative change.
                       <br />
                       <div
-                        class="makeStyles-minDiffDiagram-52"
+                        class="makeStyles-minDiffDiagram-53"
                       >
                         <svg>
                           min_diffs.svg
@@ -1593,7 +1593,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-53 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-54 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1623,7 +1623,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-54 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-55 MuiTypography-h4"
     >
       Exposure Events
     </h4>
@@ -1656,11 +1656,11 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-59"
+      class="makeStyles-addMetric-60"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-60"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-61"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1685,7 +1685,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-55 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-56 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1719,7 +1719,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-56 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-57 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1754,7 +1754,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
 exports[`allows adding, editing and removing a Metric Assignment 2`] = `
 <div>
   <div
-    class="makeStyles-root-38"
+    class="makeStyles-root-39"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1810,17 +1810,17 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
             class="MuiTableRow-root"
           >
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-43"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-44"
             >
               <span
-                class="makeStyles-metricName-44 makeStyles-tooltipped-45"
+                class="makeStyles-metricName-45 makeStyles-tooltipped-46"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-root-85 makeStyles-monospaced-42"
+                class="makeStyles-root-87 makeStyles-monospaced-43"
               >
                 primary
               </span>
@@ -1829,7 +1829,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-41"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-42"
               >
                 <div
                   aria-haspopup="listbox"
@@ -1861,11 +1861,11 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-86 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-88 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-87"
+                    class="PrivateNotchedOutline-legend-89"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -1876,7 +1876,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-47"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-48"
             >
               <span
                 class="MuiSwitch-root"
@@ -1884,7 +1884,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-90 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-91 Mui-checked"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-92 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-93 Mui-checked"
                   variant="outlined"
                 >
                   <span
@@ -1892,7 +1892,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input-93 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-95 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -1915,7 +1915,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-root-94 makeStyles-minDifferenceField-46"
+                class="MuiFormControl-root MuiTextField-root makeStyles-root-96 makeStyles-minDifferenceField-47"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
@@ -1932,7 +1932,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
                     value=""
                   />
                   <div
-                    class="MuiInputAdornment-root makeStyles-adornment-96 MuiInputAdornment-positionEnd"
+                    class="MuiInputAdornment-root makeStyles-adornment-98 MuiInputAdornment-positionEnd"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
@@ -1942,11 +1942,11 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
                   </div>
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-86 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-88 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-87"
+                      class="PrivateNotchedOutline-legend-89"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -1994,22 +1994,22 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </table>
     </div>
     <div
-      class="makeStyles-tableContainer-58"
+      class="makeStyles-tableContainer-59"
     >
       <div
-        class="ag-theme-alpine makeStyles-root-62"
+        class="ag-theme-alpine makeStyles-root-63"
       >
         <div
-          class="makeStyles-toolbar-63"
+          class="makeStyles-toolbar-64"
         >
           <div
-            class="makeStyles-rootFullWidth-66"
+            class="makeStyles-rootFullWidth-67"
           >
             <div
-              class="makeStyles-search-67"
+              class="makeStyles-search-68 makeStyles-searchBorder-69"
             >
               <div
-                class="makeStyles-searchIcon-68"
+                class="makeStyles-searchIcon-70"
               >
                 <svg
                   aria-hidden="true"
@@ -2023,11 +2023,11 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
                 </svg>
               </div>
               <div
-                class="MuiInputBase-root makeStyles-inputRootFullWidth-69"
+                class="MuiInputBase-root makeStyles-inputRootFullWidth-71"
               >
                 <input
                   aria-label="Search"
-                  class="MuiInputBase-input makeStyles-inputInputFullWidth-70"
+                  class="MuiInputBase-input makeStyles-inputInputFullWidth-72"
                   placeholder="Search…"
                   type="text"
                   value=""
@@ -2051,7 +2051,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
           </div>
         </div>
         <div
-          class="ag-theme-alpine makeStyles-gridContainer-64"
+          class="ag-theme-alpine makeStyles-gridContainer-65"
         >
           <div
             style="height: auto; flex: 1;"
@@ -2237,7 +2237,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
                           <div
                             aria-colindex="2"
                             aria-sort="ascending"
-                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-61"
+                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-62"
                             col-id="name"
                             role="columnheader"
                             style="width: 465px; left: 34px;"
@@ -2824,7 +2824,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
                               >
                                 <button
                                   aria-label="Toggle Button"
-                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-75 makeStyles-notRotated-77 MuiIconButton-sizeSmall"
+                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-77 makeStyles-notRotated-79 MuiIconButton-sizeSmall"
                                   tabindex="0"
                                   type="button"
                                 >
@@ -2862,7 +2862,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
                                 class="ag-react-container"
                               >
                                 <div
-                                  class="makeStyles-metricName-78"
+                                  class="makeStyles-metricName-80"
                                   title="asdf_7d_refund"
                                 >
                                   asdf_7d_refund
@@ -2895,11 +2895,11 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
                                 class="ag-react-container"
                               >
                                 <div
-                                  class="makeStyles-root-79"
+                                  class="makeStyles-root-81"
                                 >
                                   <button
                                     aria-label="Assign metric"
-                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-83 MuiButton-contained makeStyles-noWrap-80 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-85 MuiButton-contained makeStyles-noWrap-82 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
                                     tabindex="0"
                                     type="button"
                                   >
@@ -2955,7 +2955,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
                               >
                                 <button
                                   aria-label="Toggle Button"
-                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-75 makeStyles-notRotated-77 MuiIconButton-sizeSmall"
+                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-77 makeStyles-notRotated-79 MuiIconButton-sizeSmall"
                                   tabindex="0"
                                   type="button"
                                 >
@@ -2993,7 +2993,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
                                 class="ag-react-container"
                               >
                                 <div
-                                  class="makeStyles-metricName-78"
+                                  class="makeStyles-metricName-80"
                                   title="registration_start"
                                 >
                                   registration_start
@@ -3026,11 +3026,11 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
                                 class="ag-react-container"
                               >
                                 <div
-                                  class="makeStyles-root-79"
+                                  class="makeStyles-root-81"
                                 >
                                   <button
                                     aria-label="Assign metric"
-                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-84 MuiButton-contained makeStyles-noWrap-80 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-86 MuiButton-contained makeStyles-noWrap-82 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
                                     tabindex="0"
                                     type="button"
                                   >
@@ -3417,7 +3417,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-48 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-49 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -3455,7 +3455,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-49 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-50 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -3476,13 +3476,13 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-75 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="attr-window-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-76"
             id="attr-window-panel"
             role="button"
             tabindex="0"
@@ -3546,7 +3546,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
                       is the window of time after exposure to an experiment that we capture metric events for a participant (exposure can be from either assignment or specified exposure events). The refund window is the window of time after a purchase event. Revenue metrics will automatically deduct transactions that have been refunded within the metric’s refund window.
                       <br />
                       <div
-                        class="makeStyles-attributionWindowDiagram-50"
+                        class="makeStyles-attributionWindowDiagram-51"
                       >
                         <svg>
                           attribution_window.svg
@@ -3565,7 +3565,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-51 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-52 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -3586,13 +3586,13 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-75 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="min-diff-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-76"
             id="min-diff-panel"
             role="button"
             tabindex="0"
@@ -3656,7 +3656,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
                       are absolute differences from the baseline (not relative). For example, if the baseline conversion rate is 5%, a minimum difference of 0.5 pp is equivalent to a 10% relative change.
                       <br />
                       <div
-                        class="makeStyles-minDiffDiagram-52"
+                        class="makeStyles-minDiffDiagram-53"
                       >
                         <svg>
                           min_diffs.svg
@@ -3672,7 +3672,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-53 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-54 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -3702,7 +3702,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-54 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-55 MuiTypography-h4"
     >
       Exposure Events
     </h4>
@@ -3735,11 +3735,11 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-59"
+      class="makeStyles-addMetric-60"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-60"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-61"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -3764,7 +3764,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-55 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-56 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -3798,7 +3798,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-56 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-57 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -3835,7 +3835,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
   aria-hidden="true"
 >
   <div
-    class="makeStyles-root-38"
+    class="makeStyles-root-39"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -3891,17 +3891,17 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
             class="MuiTableRow-root"
           >
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-43"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-44"
             >
               <span
-                class="makeStyles-metricName-44 makeStyles-tooltipped-45"
+                class="makeStyles-metricName-45 makeStyles-tooltipped-46"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-root-85 makeStyles-monospaced-42"
+                class="makeStyles-root-87 makeStyles-monospaced-43"
               >
                 primary
               </span>
@@ -3910,7 +3910,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-41"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-42"
               >
                 <div
                   aria-haspopup="listbox"
@@ -3942,11 +3942,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-86 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-88 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-87"
+                    class="PrivateNotchedOutline-legend-89"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -3957,7 +3957,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-47"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-48"
             >
               <span
                 class="MuiSwitch-root"
@@ -3965,7 +3965,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-90 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-91 Mui-checked"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-92 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-93 Mui-checked"
                   variant="outlined"
                 >
                   <span
@@ -3973,7 +3973,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input-93 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-95 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -3996,7 +3996,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-root-94 makeStyles-minDifferenceField-46"
+                class="MuiFormControl-root MuiTextField-root makeStyles-root-96 makeStyles-minDifferenceField-47"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
@@ -4013,7 +4013,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                     value="0.01"
                   />
                   <div
-                    class="MuiInputAdornment-root makeStyles-adornment-96 MuiInputAdornment-positionEnd"
+                    class="MuiInputAdornment-root makeStyles-adornment-98 MuiInputAdornment-positionEnd"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
@@ -4023,11 +4023,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                   </div>
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-86 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-88 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-87"
+                      class="PrivateNotchedOutline-legend-89"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -4075,22 +4075,22 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </table>
     </div>
     <div
-      class="makeStyles-tableContainer-58"
+      class="makeStyles-tableContainer-59"
     >
       <div
-        class="ag-theme-alpine makeStyles-root-62"
+        class="ag-theme-alpine makeStyles-root-63"
       >
         <div
-          class="makeStyles-toolbar-63"
+          class="makeStyles-toolbar-64"
         >
           <div
-            class="makeStyles-rootFullWidth-66"
+            class="makeStyles-rootFullWidth-67"
           >
             <div
-              class="makeStyles-search-67"
+              class="makeStyles-search-68 makeStyles-searchBorder-69"
             >
               <div
-                class="makeStyles-searchIcon-68"
+                class="makeStyles-searchIcon-70"
               >
                 <svg
                   aria-hidden="true"
@@ -4104,11 +4104,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                 </svg>
               </div>
               <div
-                class="MuiInputBase-root makeStyles-inputRootFullWidth-69"
+                class="MuiInputBase-root makeStyles-inputRootFullWidth-71"
               >
                 <input
                   aria-label="Search"
-                  class="MuiInputBase-input makeStyles-inputInputFullWidth-70"
+                  class="MuiInputBase-input makeStyles-inputInputFullWidth-72"
                   placeholder="Search…"
                   type="text"
                   value=""
@@ -4132,7 +4132,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
           </div>
         </div>
         <div
-          class="ag-theme-alpine makeStyles-gridContainer-64"
+          class="ag-theme-alpine makeStyles-gridContainer-65"
         >
           <div
             style="height: auto; flex: 1;"
@@ -4318,7 +4318,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                           <div
                             aria-colindex="2"
                             aria-sort="ascending"
-                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-61"
+                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-62"
                             col-id="name"
                             role="columnheader"
                             style="width: 465px; left: 34px;"
@@ -4905,7 +4905,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                               >
                                 <button
                                   aria-label="Toggle Button"
-                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-75 makeStyles-notRotated-77 MuiIconButton-sizeSmall"
+                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-77 makeStyles-notRotated-79 MuiIconButton-sizeSmall"
                                   tabindex="0"
                                   type="button"
                                 >
@@ -4943,7 +4943,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                                 class="ag-react-container"
                               >
                                 <div
-                                  class="makeStyles-metricName-78"
+                                  class="makeStyles-metricName-80"
                                   title="asdf_7d_refund"
                                 >
                                   asdf_7d_refund
@@ -4976,11 +4976,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                                 class="ag-react-container"
                               >
                                 <div
-                                  class="makeStyles-root-79"
+                                  class="makeStyles-root-81"
                                 >
                                   <button
                                     aria-label="Assign metric"
-                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-83 MuiButton-contained makeStyles-noWrap-80 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-85 MuiButton-contained makeStyles-noWrap-82 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
                                     tabindex="0"
                                     type="button"
                                   >
@@ -5036,7 +5036,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                               >
                                 <button
                                   aria-label="Toggle Button"
-                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-75 makeStyles-notRotated-77 MuiIconButton-sizeSmall"
+                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-77 makeStyles-notRotated-79 MuiIconButton-sizeSmall"
                                   tabindex="0"
                                   type="button"
                                 >
@@ -5074,7 +5074,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                                 class="ag-react-container"
                               >
                                 <div
-                                  class="makeStyles-metricName-78"
+                                  class="makeStyles-metricName-80"
                                   title="registration_start"
                                 >
                                   registration_start
@@ -5107,11 +5107,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                                 class="ag-react-container"
                               >
                                 <div
-                                  class="makeStyles-root-79"
+                                  class="makeStyles-root-81"
                                 >
                                   <button
                                     aria-label="Assign metric"
-                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-84 MuiButton-contained makeStyles-noWrap-80 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-86 MuiButton-contained makeStyles-noWrap-82 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
                                     tabindex="0"
                                     type="button"
                                   >
@@ -5498,7 +5498,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-48 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-49 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -5536,7 +5536,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-49 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-50 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -5557,13 +5557,13 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-75 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="attr-window-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-76"
             id="attr-window-panel"
             role="button"
             tabindex="0"
@@ -5627,7 +5627,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                       is the window of time after exposure to an experiment that we capture metric events for a participant (exposure can be from either assignment or specified exposure events). The refund window is the window of time after a purchase event. Revenue metrics will automatically deduct transactions that have been refunded within the metric’s refund window.
                       <br />
                       <div
-                        class="makeStyles-attributionWindowDiagram-50"
+                        class="makeStyles-attributionWindowDiagram-51"
                       >
                         <svg>
                           attribution_window.svg
@@ -5646,7 +5646,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-51 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-52 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -5667,13 +5667,13 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-75 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="min-diff-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-76"
             id="min-diff-panel"
             role="button"
             tabindex="0"
@@ -5737,7 +5737,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                       are absolute differences from the baseline (not relative). For example, if the baseline conversion rate is 5%, a minimum difference of 0.5 pp is equivalent to a 10% relative change.
                       <br />
                       <div
-                        class="makeStyles-minDiffDiagram-52"
+                        class="makeStyles-minDiffDiagram-53"
                       >
                         <svg>
                           min_diffs.svg
@@ -5753,7 +5753,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-53 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-54 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -5783,7 +5783,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-54 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-55 MuiTypography-h4"
     >
       Exposure Events
     </h4>
@@ -5816,11 +5816,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-59"
+      class="makeStyles-addMetric-60"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-60"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-61"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -5845,7 +5845,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-55 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-56 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -5879,7 +5879,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-56 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-57 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -5914,7 +5914,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
 exports[`allows adding, editing and removing a Metric Assignment 4`] = `
 <div>
   <div
-    class="makeStyles-root-38"
+    class="makeStyles-root-39"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -5970,17 +5970,17 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
             class="MuiTableRow-root"
           >
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-43"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-44"
             >
               <span
-                class="makeStyles-metricName-44 makeStyles-tooltipped-45"
+                class="makeStyles-metricName-45 makeStyles-tooltipped-46"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-root-85 makeStyles-monospaced-42"
+                class="makeStyles-root-87 makeStyles-monospaced-43"
               >
                 primary
               </span>
@@ -5989,7 +5989,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-41"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-42"
               >
                 <div
                   aria-haspopup="listbox"
@@ -6021,11 +6021,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-86 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-88 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-87"
+                    class="PrivateNotchedOutline-legend-89"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -6036,7 +6036,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-47"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-48"
             >
               <span
                 class="MuiSwitch-root"
@@ -6044,7 +6044,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-90 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-91 Mui-checked"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-92 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-93 Mui-checked"
                   variant="outlined"
                 >
                   <span
@@ -6052,7 +6052,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input-93 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-95 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -6075,7 +6075,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-root-94 makeStyles-minDifferenceField-46"
+                class="MuiFormControl-root MuiTextField-root makeStyles-root-96 makeStyles-minDifferenceField-47"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
@@ -6092,7 +6092,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                     value="0.01"
                   />
                   <div
-                    class="MuiInputAdornment-root makeStyles-adornment-96 MuiInputAdornment-positionEnd"
+                    class="MuiInputAdornment-root makeStyles-adornment-98 MuiInputAdornment-positionEnd"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
@@ -6102,11 +6102,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                   </div>
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-86 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-88 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-87"
+                      class="PrivateNotchedOutline-legend-89"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -6154,22 +6154,22 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </table>
     </div>
     <div
-      class="makeStyles-tableContainer-58"
+      class="makeStyles-tableContainer-59"
     >
       <div
-        class="ag-theme-alpine makeStyles-root-62"
+        class="ag-theme-alpine makeStyles-root-63"
       >
         <div
-          class="makeStyles-toolbar-63"
+          class="makeStyles-toolbar-64"
         >
           <div
-            class="makeStyles-rootFullWidth-66"
+            class="makeStyles-rootFullWidth-67"
           >
             <div
-              class="makeStyles-search-67"
+              class="makeStyles-search-68 makeStyles-searchBorder-69"
             >
               <div
-                class="makeStyles-searchIcon-68"
+                class="makeStyles-searchIcon-70"
               >
                 <svg
                   aria-hidden="true"
@@ -6183,11 +6183,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                 </svg>
               </div>
               <div
-                class="MuiInputBase-root makeStyles-inputRootFullWidth-69"
+                class="MuiInputBase-root makeStyles-inputRootFullWidth-71"
               >
                 <input
                   aria-label="Search"
-                  class="MuiInputBase-input makeStyles-inputInputFullWidth-70"
+                  class="MuiInputBase-input makeStyles-inputInputFullWidth-72"
                   placeholder="Search…"
                   type="text"
                   value=""
@@ -6211,7 +6211,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
           </div>
         </div>
         <div
-          class="ag-theme-alpine makeStyles-gridContainer-64"
+          class="ag-theme-alpine makeStyles-gridContainer-65"
         >
           <div
             style="height: auto; flex: 1;"
@@ -6397,7 +6397,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                           <div
                             aria-colindex="2"
                             aria-sort="ascending"
-                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-61"
+                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-62"
                             col-id="name"
                             role="columnheader"
                             style="width: 465px; left: 34px;"
@@ -6984,7 +6984,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                               >
                                 <button
                                   aria-label="Toggle Button"
-                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-75 makeStyles-notRotated-77 MuiIconButton-sizeSmall"
+                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-77 makeStyles-notRotated-79 MuiIconButton-sizeSmall"
                                   tabindex="0"
                                   type="button"
                                 >
@@ -7022,7 +7022,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                                 class="ag-react-container"
                               >
                                 <div
-                                  class="makeStyles-metricName-78"
+                                  class="makeStyles-metricName-80"
                                   title="asdf_7d_refund"
                                 >
                                   asdf_7d_refund
@@ -7055,11 +7055,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                                 class="ag-react-container"
                               >
                                 <div
-                                  class="makeStyles-root-79"
+                                  class="makeStyles-root-81"
                                 >
                                   <button
                                     aria-label="Assign metric"
-                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-83 MuiButton-contained makeStyles-noWrap-80 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-85 MuiButton-contained makeStyles-noWrap-82 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
                                     tabindex="0"
                                     type="button"
                                   >
@@ -7115,7 +7115,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                               >
                                 <button
                                   aria-label="Toggle Button"
-                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-75 makeStyles-notRotated-77 MuiIconButton-sizeSmall"
+                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-77 makeStyles-notRotated-79 MuiIconButton-sizeSmall"
                                   tabindex="0"
                                   type="button"
                                 >
@@ -7153,7 +7153,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                                 class="ag-react-container"
                               >
                                 <div
-                                  class="makeStyles-metricName-78"
+                                  class="makeStyles-metricName-80"
                                   title="registration_start"
                                 >
                                   registration_start
@@ -7186,11 +7186,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                                 class="ag-react-container"
                               >
                                 <div
-                                  class="makeStyles-root-79"
+                                  class="makeStyles-root-81"
                                 >
                                   <button
                                     aria-label="Assign metric"
-                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-84 MuiButton-contained makeStyles-noWrap-80 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-86 MuiButton-contained makeStyles-noWrap-82 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
                                     tabindex="0"
                                     type="button"
                                   >
@@ -7577,7 +7577,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-48 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-49 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -7615,7 +7615,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-49 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-50 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -7636,13 +7636,13 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-75 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="attr-window-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-76"
             id="attr-window-panel"
             role="button"
             tabindex="0"
@@ -7706,7 +7706,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                       is the window of time after exposure to an experiment that we capture metric events for a participant (exposure can be from either assignment or specified exposure events). The refund window is the window of time after a purchase event. Revenue metrics will automatically deduct transactions that have been refunded within the metric’s refund window.
                       <br />
                       <div
-                        class="makeStyles-attributionWindowDiagram-50"
+                        class="makeStyles-attributionWindowDiagram-51"
                       >
                         <svg>
                           attribution_window.svg
@@ -7725,7 +7725,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-51 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-52 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -7746,13 +7746,13 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-75 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="min-diff-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-76"
             id="min-diff-panel"
             role="button"
             tabindex="0"
@@ -7816,7 +7816,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                       are absolute differences from the baseline (not relative). For example, if the baseline conversion rate is 5%, a minimum difference of 0.5 pp is equivalent to a 10% relative change.
                       <br />
                       <div
-                        class="makeStyles-minDiffDiagram-52"
+                        class="makeStyles-minDiffDiagram-53"
                       >
                         <svg>
                           min_diffs.svg
@@ -7832,7 +7832,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-53 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-54 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -7862,7 +7862,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-54 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-55 MuiTypography-h4"
     >
       Exposure Events
     </h4>
@@ -7895,11 +7895,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-59"
+      class="makeStyles-addMetric-60"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-60"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-61"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -7924,7 +7924,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-55 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-56 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -7958,7 +7958,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-56 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-57 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -7993,7 +7993,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
 exports[`allows adding, editing and removing a Metric Assignment 5`] = `
 <div>
   <div
-    class="makeStyles-root-38"
+    class="makeStyles-root-39"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -8063,22 +8063,22 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </table>
     </div>
     <div
-      class="makeStyles-tableContainer-58"
+      class="makeStyles-tableContainer-59"
     >
       <div
-        class="ag-theme-alpine makeStyles-root-62"
+        class="ag-theme-alpine makeStyles-root-63"
       >
         <div
-          class="makeStyles-toolbar-63"
+          class="makeStyles-toolbar-64"
         >
           <div
-            class="makeStyles-rootFullWidth-66"
+            class="makeStyles-rootFullWidth-67"
           >
             <div
-              class="makeStyles-search-67"
+              class="makeStyles-search-68 makeStyles-searchBorder-69"
             >
               <div
-                class="makeStyles-searchIcon-68"
+                class="makeStyles-searchIcon-70"
               >
                 <svg
                   aria-hidden="true"
@@ -8092,11 +8092,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                 </svg>
               </div>
               <div
-                class="MuiInputBase-root makeStyles-inputRootFullWidth-69"
+                class="MuiInputBase-root makeStyles-inputRootFullWidth-71"
               >
                 <input
                   aria-label="Search"
-                  class="MuiInputBase-input makeStyles-inputInputFullWidth-70"
+                  class="MuiInputBase-input makeStyles-inputInputFullWidth-72"
                   placeholder="Search…"
                   type="text"
                   value=""
@@ -8120,7 +8120,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
           </div>
         </div>
         <div
-          class="ag-theme-alpine makeStyles-gridContainer-64"
+          class="ag-theme-alpine makeStyles-gridContainer-65"
         >
           <div
             style="height: auto; flex: 1;"
@@ -8306,7 +8306,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                           <div
                             aria-colindex="2"
                             aria-sort="ascending"
-                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-61"
+                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-62"
                             col-id="name"
                             role="columnheader"
                             style="width: 465px; left: 34px;"
@@ -8893,7 +8893,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                               >
                                 <button
                                   aria-label="Toggle Button"
-                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-75 makeStyles-notRotated-77 MuiIconButton-sizeSmall"
+                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-77 makeStyles-notRotated-79 MuiIconButton-sizeSmall"
                                   tabindex="0"
                                   type="button"
                                 >
@@ -8931,7 +8931,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                                 class="ag-react-container"
                               >
                                 <div
-                                  class="makeStyles-metricName-78"
+                                  class="makeStyles-metricName-80"
                                   title="asdf_7d_refund"
                                 >
                                   asdf_7d_refund
@@ -8964,11 +8964,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                                 class="ag-react-container"
                               >
                                 <div
-                                  class="makeStyles-root-79"
+                                  class="makeStyles-root-81"
                                 >
                                   <button
                                     aria-label="Assign metric"
-                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-83 MuiButton-contained makeStyles-noWrap-80 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-85 MuiButton-contained makeStyles-noWrap-82 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
                                     tabindex="0"
                                     type="button"
                                   >
@@ -9024,7 +9024,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                               >
                                 <button
                                   aria-label="Toggle Button"
-                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-75 makeStyles-notRotated-77 MuiIconButton-sizeSmall"
+                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-77 makeStyles-notRotated-79 MuiIconButton-sizeSmall"
                                   tabindex="0"
                                   type="button"
                                 >
@@ -9062,7 +9062,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                                 class="ag-react-container"
                               >
                                 <div
-                                  class="makeStyles-metricName-78"
+                                  class="makeStyles-metricName-80"
                                   title="registration_start"
                                 >
                                   registration_start
@@ -9095,11 +9095,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                                 class="ag-react-container"
                               >
                                 <div
-                                  class="makeStyles-root-79"
+                                  class="makeStyles-root-81"
                                 >
                                   <button
                                     aria-label="Assign metric"
-                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-84 MuiButton-contained makeStyles-noWrap-80 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-86 MuiButton-contained makeStyles-noWrap-82 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
                                     tabindex="0"
                                     type="button"
                                   >
@@ -9486,7 +9486,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-48 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-49 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -9524,7 +9524,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-49 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-50 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -9545,13 +9545,13 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-75 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="attr-window-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-76"
             id="attr-window-panel"
             role="button"
             tabindex="0"
@@ -9615,7 +9615,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                       is the window of time after exposure to an experiment that we capture metric events for a participant (exposure can be from either assignment or specified exposure events). The refund window is the window of time after a purchase event. Revenue metrics will automatically deduct transactions that have been refunded within the metric’s refund window.
                       <br />
                       <div
-                        class="makeStyles-attributionWindowDiagram-50"
+                        class="makeStyles-attributionWindowDiagram-51"
                       >
                         <svg>
                           attribution_window.svg
@@ -9634,7 +9634,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-51 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-52 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -9655,13 +9655,13 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-75 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="min-diff-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-76"
             id="min-diff-panel"
             role="button"
             tabindex="0"
@@ -9725,7 +9725,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
                       are absolute differences from the baseline (not relative). For example, if the baseline conversion rate is 5%, a minimum difference of 0.5 pp is equivalent to a 10% relative change.
                       <br />
                       <div
-                        class="makeStyles-minDiffDiagram-52"
+                        class="makeStyles-minDiffDiagram-53"
                       >
                         <svg>
                           min_diffs.svg
@@ -9741,7 +9741,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-53 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-54 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -9771,7 +9771,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-54 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-55 MuiTypography-h4"
     >
       Exposure Events
     </h4>
@@ -9804,11 +9804,11 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-59"
+      class="makeStyles-addMetric-60"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-60"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-61"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -9833,7 +9833,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-55 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-56 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -9867,7 +9867,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-56 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-57 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -9902,7 +9902,7 @@ exports[`allows adding, editing and removing a Metric Assignment 5`] = `
 exports[`allows adding, editing and removing a Metric Assignment 6`] = `
 <div>
   <div
-    class="makeStyles-root-38"
+    class="makeStyles-root-39"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -9958,17 +9958,17 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
             class="MuiTableRow-root"
           >
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-43"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-44"
             >
               <span
-                class="makeStyles-metricName-44 makeStyles-tooltipped-45"
+                class="makeStyles-metricName-45 makeStyles-tooltipped-46"
                 title="string"
               >
                 registration_start
               </span>
               <br />
               <span
-                class="makeStyles-root-97 makeStyles-monospaced-42"
+                class="makeStyles-root-99 makeStyles-monospaced-43"
               >
                 primary
               </span>
@@ -9977,7 +9977,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-41"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-42"
               >
                 <div
                   aria-haspopup="listbox"
@@ -10009,11 +10009,11 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-98 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-100 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-99"
+                    class="PrivateNotchedOutline-legend-101"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -10024,7 +10024,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-47"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-48"
             >
               <span
                 class="MuiSwitch-root"
@@ -10032,7 +10032,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-102 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-103 Mui-checked"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-104 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-105 Mui-checked"
                   variant="outlined"
                 >
                   <span
@@ -10040,7 +10040,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input-105 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-107 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -10063,7 +10063,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-root-106 makeStyles-minDifferenceField-46"
+                class="MuiFormControl-root MuiTextField-root makeStyles-root-108 makeStyles-minDifferenceField-47"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
@@ -10081,10 +10081,10 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
                     value="0"
                   />
                   <div
-                    class="MuiInputAdornment-root makeStyles-adornment-108 MuiInputAdornment-positionEnd"
+                    class="MuiInputAdornment-root makeStyles-adornment-110 MuiInputAdornment-positionEnd"
                   >
                     <p
-                      class="MuiTypography-root makeStyles-tooltipped-107 MuiTypography-body1 MuiTypography-colorTextSecondary"
+                      class="MuiTypography-root makeStyles-tooltipped-109 MuiTypography-body1 MuiTypography-colorTextSecondary"
                       title="Percentage Points"
                     >
                       pp
@@ -10092,11 +10092,11 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
                   </div>
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-98 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-100 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-99"
+                      class="PrivateNotchedOutline-legend-101"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -10144,22 +10144,22 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </table>
     </div>
     <div
-      class="makeStyles-tableContainer-58"
+      class="makeStyles-tableContainer-59"
     >
       <div
-        class="ag-theme-alpine makeStyles-root-62"
+        class="ag-theme-alpine makeStyles-root-63"
       >
         <div
-          class="makeStyles-toolbar-63"
+          class="makeStyles-toolbar-64"
         >
           <div
-            class="makeStyles-rootFullWidth-66"
+            class="makeStyles-rootFullWidth-67"
           >
             <div
-              class="makeStyles-search-67"
+              class="makeStyles-search-68 makeStyles-searchBorder-69"
             >
               <div
-                class="makeStyles-searchIcon-68"
+                class="makeStyles-searchIcon-70"
               >
                 <svg
                   aria-hidden="true"
@@ -10173,11 +10173,11 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
                 </svg>
               </div>
               <div
-                class="MuiInputBase-root makeStyles-inputRootFullWidth-69"
+                class="MuiInputBase-root makeStyles-inputRootFullWidth-71"
               >
                 <input
                   aria-label="Search"
-                  class="MuiInputBase-input makeStyles-inputInputFullWidth-70"
+                  class="MuiInputBase-input makeStyles-inputInputFullWidth-72"
                   placeholder="Search…"
                   type="text"
                   value=""
@@ -10201,7 +10201,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
           </div>
         </div>
         <div
-          class="ag-theme-alpine makeStyles-gridContainer-64"
+          class="ag-theme-alpine makeStyles-gridContainer-65"
         >
           <div
             style="height: auto; flex: 1;"
@@ -10387,7 +10387,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
                           <div
                             aria-colindex="2"
                             aria-sort="ascending"
-                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-61"
+                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-62"
                             col-id="name"
                             role="columnheader"
                             style="width: 465px; left: 34px;"
@@ -10974,7 +10974,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
                               >
                                 <button
                                   aria-label="Toggle Button"
-                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-75 makeStyles-notRotated-77 MuiIconButton-sizeSmall"
+                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-77 makeStyles-notRotated-79 MuiIconButton-sizeSmall"
                                   tabindex="0"
                                   type="button"
                                 >
@@ -11012,7 +11012,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
                                 class="ag-react-container"
                               >
                                 <div
-                                  class="makeStyles-metricName-78"
+                                  class="makeStyles-metricName-80"
                                   title="asdf_7d_refund"
                                 >
                                   asdf_7d_refund
@@ -11045,11 +11045,11 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
                                 class="ag-react-container"
                               >
                                 <div
-                                  class="makeStyles-root-79"
+                                  class="makeStyles-root-81"
                                 >
                                   <button
                                     aria-label="Assign metric"
-                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-83 MuiButton-contained makeStyles-noWrap-80 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-85 MuiButton-contained makeStyles-noWrap-82 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
                                     tabindex="0"
                                     type="button"
                                   >
@@ -11105,7 +11105,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
                               >
                                 <button
                                   aria-label="Toggle Button"
-                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-75 makeStyles-notRotated-77 MuiIconButton-sizeSmall"
+                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-77 makeStyles-notRotated-79 MuiIconButton-sizeSmall"
                                   tabindex="0"
                                   type="button"
                                 >
@@ -11143,7 +11143,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
                                 class="ag-react-container"
                               >
                                 <div
-                                  class="makeStyles-metricName-78"
+                                  class="makeStyles-metricName-80"
                                   title="registration_start"
                                 >
                                   registration_start
@@ -11176,11 +11176,11 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
                                 class="ag-react-container"
                               >
                                 <div
-                                  class="makeStyles-root-79"
+                                  class="makeStyles-root-81"
                                 >
                                   <button
                                     aria-label="Assign metric"
-                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-84 MuiButton-contained makeStyles-noWrap-80 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-86 MuiButton-contained makeStyles-noWrap-82 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
                                     tabindex="0"
                                     type="button"
                                   >
@@ -11567,7 +11567,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-48 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-49 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -11605,7 +11605,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-49 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-50 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -11626,13 +11626,13 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-75 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="attr-window-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-76"
             id="attr-window-panel"
             role="button"
             tabindex="0"
@@ -11696,7 +11696,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
                       is the window of time after exposure to an experiment that we capture metric events for a participant (exposure can be from either assignment or specified exposure events). The refund window is the window of time after a purchase event. Revenue metrics will automatically deduct transactions that have been refunded within the metric’s refund window.
                       <br />
                       <div
-                        class="makeStyles-attributionWindowDiagram-50"
+                        class="makeStyles-attributionWindowDiagram-51"
                       >
                         <svg>
                           attribution_window.svg
@@ -11715,7 +11715,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-51 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-52 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -11736,13 +11736,13 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-75 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="min-diff-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-76"
             id="min-diff-panel"
             role="button"
             tabindex="0"
@@ -11806,7 +11806,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
                       are absolute differences from the baseline (not relative). For example, if the baseline conversion rate is 5%, a minimum difference of 0.5 pp is equivalent to a 10% relative change.
                       <br />
                       <div
-                        class="makeStyles-minDiffDiagram-52"
+                        class="makeStyles-minDiffDiagram-53"
                       >
                         <svg>
                           min_diffs.svg
@@ -11822,7 +11822,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-53 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-54 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -11852,7 +11852,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-54 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-55 MuiTypography-h4"
     >
       Exposure Events
     </h4>
@@ -11885,11 +11885,11 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-59"
+      class="makeStyles-addMetric-60"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-60"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-61"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -11914,7 +11914,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-55 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-56 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -11948,7 +11948,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-56 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-57 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -12065,10 +12065,10 @@ exports[`renders as expected 1`] = `
             class="makeStyles-rootFullWidth-29"
           >
             <div
-              class="makeStyles-search-30"
+              class="makeStyles-search-30 makeStyles-searchBorder-31"
             >
               <div
-                class="makeStyles-searchIcon-31"
+                class="makeStyles-searchIcon-32"
               >
                 <svg
                   aria-hidden="true"
@@ -12082,11 +12082,11 @@ exports[`renders as expected 1`] = `
                 </svg>
               </div>
               <div
-                class="MuiInputBase-root makeStyles-inputRootFullWidth-32"
+                class="MuiInputBase-root makeStyles-inputRootFullWidth-33"
               >
                 <input
                   aria-label="Search"
-                  class="MuiInputBase-input makeStyles-inputInputFullWidth-33"
+                  class="MuiInputBase-input makeStyles-inputInputFullWidth-34"
                   placeholder="Search…"
                   type="text"
                   value=""
@@ -13377,13 +13377,13 @@ exports[`renders as expected 1`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-36 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-37 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="attr-window-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-37"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-38"
             id="attr-window-panel"
             role="button"
             tabindex="0"
@@ -13487,13 +13487,13 @@ exports[`renders as expected 1`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-36 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-37 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="min-diff-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-37"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-38"
             id="min-diff-panel"
             role="button"
             tabindex="0"

--- a/src/components/experiments/wizard/__snapshots__/Metrics.test.tsx.snap
+++ b/src/components/experiments/wizard/__snapshots__/Metrics.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`allows adding, editing and removing a Metric Assignment 1`] = `
 <div>
   <div
-    class="makeStyles-root-25"
+    class="makeStyles-root-38"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -73,122 +73,1272 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-45"
+      class="makeStyles-tableContainer-58"
     >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-46"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-        />
-      </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-27"
+        class="ag-theme-alpine makeStyles-root-62"
       >
         <div
-          aria-expanded="false"
-          aria-label="Select a metric"
-          class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-          role="combobox"
+          class="makeStyles-toolbar-63"
         >
           <div
-            class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+            class="makeStyles-rootFullWidth-66"
           >
             <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+              class="makeStyles-search-67"
             >
-              <input
-                aria-autocomplete="list"
-                aria-invalid="false"
-                autocapitalize="none"
-                autocomplete="off"
-                class="MuiInputBase-input MuiInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd"
-                id="add-metric-select"
-                placeholder="Select a metric"
-                required=""
-                spellcheck="false"
-                type="text"
-                value=""
-              />
               <div
-                class="MuiAutocomplete-endAdornment"
+                class="makeStyles-searchIcon-68"
               >
-                <button
-                  aria-label="Clear"
-                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
-                  tabindex="-1"
-                  title="Clear"
-                  type="button"
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
                 >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
+                  <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
                   />
-                </button>
-                <button
-                  aria-label="Open"
-                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
-                  tabindex="-1"
-                  title="Open"
-                  type="button"
-                >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M7 10l5 5 5-5z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
-                  />
-                </button>
+                </svg>
               </div>
+              <div
+                class="MuiInputBase-root makeStyles-inputRootFullWidth-69"
+              >
+                <input
+                  aria-label="Search"
+                  class="MuiInputBase-input makeStyles-inputInputFullWidth-70"
+                  placeholder="Search…"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                 Reset 
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+        </div>
+        <div
+          class="ag-theme-alpine makeStyles-gridContainer-64"
+        >
+          <div
+            style="height: auto; flex: 1;"
+          >
+            <div
+              class="ag-root-wrapper ag-layout-normal ag-ltr"
+              ref="eRootWrapper"
+            >
+              
+                
+                
+              <div
+                class="ag-root-wrapper-body ag-layout-normal ag-focus-managed"
+                ref="rootWrapperBody"
+              >
+                <div
+                  class="ag-tab-guard ag-tab-guard-top"
+                  role="presentation"
+                  tabindex="0"
+                />
+                
+                    
+                <!--AG-GRID-COMP-->
+                <div
+                  aria-colcount="7"
+                  aria-rowcount="3"
+                  class="ag-root ag-unselectable ag-layout-normal"
+                  ref="gridPanel"
+                  role="grid"
+                  unselectable="on"
+                >
+                  
+        
+                  <!--AG-HEADER-ROOT-->
+                  <div
+                    class="ag-header ag-focus-managed ag-pivot-off"
+                    ref="headerRoot"
+                    role="presentation"
+                    style="height: 49px; min-height: 49px;"
+                    unselectable="on"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-header ag-hidden"
+                      ref="ePinnedLeftHeader"
+                      role="presentation"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-column"
+                        role="row"
+                        style="top: 0px; height: 48px; width: 0px;"
+                      />
+                    </div>
+                    
+            
+                    <div
+                      class="ag-header-viewport"
+                      ref="eHeaderViewport"
+                      role="presentation"
+                    >
+                      
+                
+                      <div
+                        class="ag-header-container"
+                        ref="eHeaderContainer"
+                        role="rowgroup"
+                        style="width: 1199px;"
+                      >
+                        <div
+                          aria-rowindex="1"
+                          class="ag-header-row ag-header-row-column"
+                          role="row"
+                          style="top: 0px; height: 48px; width: 1199px;"
+                        >
+                          <div
+                            aria-colindex="1"
+                            class="ag-header-cell ag-focus-managed"
+                            col-id="__detail-button-col__"
+                            role="columnheader"
+                            style="width: 34px; left: 0px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize ag-hidden"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-47-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container"
+                              role="presentation"
+                            >
+                              
+            
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                />
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                
+                
+                                
+                
+                                
+                
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="2"
+                            aria-sort="none"
+                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-61"
+                            col-id="name"
+                            role="columnheader"
+                            style="width: 465px; left: 34px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-50-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container ag-header-cell-sorted-none"
+                              role="presentation"
+                            >
+                              
+            
+                              <span
+                                aria-hidden="true"
+                                class="ag-header-icon ag-header-cell-menu-button"
+                                ref="eMenu"
+                              >
+                                <span
+                                  class="ag-icon ag-icon-menu"
+                                  role="presentation"
+                                  unselectable="on"
+                                />
+                              </span>
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                >
+                                  Name
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-order ag-hidden"
+                                  ref="eSortOrder"
+                                />
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-ascending-icon ag-hidden"
+                                  ref="eSortAsc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-asc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-descending-icon ag-hidden"
+                                  ref="eSortDesc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-desc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-none-icon ag-hidden"
+                                  ref="eSortNone"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-none"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="3"
+                            aria-sort="none"
+                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable"
+                            col-id="description"
+                            role="columnheader"
+                            style="width: 550px; left: 499px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-53-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container ag-header-cell-sorted-none"
+                              role="presentation"
+                            >
+                              
+            
+                              <span
+                                aria-hidden="true"
+                                class="ag-header-icon ag-header-cell-menu-button"
+                                ref="eMenu"
+                              >
+                                <span
+                                  class="ag-icon ag-icon-menu"
+                                  role="presentation"
+                                  unselectable="on"
+                                />
+                              </span>
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                >
+                                  Description
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-order ag-hidden"
+                                  ref="eSortOrder"
+                                />
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-ascending-icon ag-hidden"
+                                  ref="eSortAsc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-asc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-descending-icon ag-hidden"
+                                  ref="eSortDesc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-desc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-none-icon ag-hidden"
+                                  ref="eSortNone"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-none"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="7"
+                            class="ag-header-cell ag-focus-managed"
+                            col-id="metrics-assign--actions"
+                            role="columnheader"
+                            style="width: 150px; left: 1049px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize ag-hidden"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-56-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container"
+                              role="presentation"
+                            >
+                              
+            
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                >
+                                  Actions
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                
+                
+                                
+                
+                                
+                
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-header ag-hidden"
+                      ref="ePinnedRightHeader"
+                      role="presentation"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-column"
+                        role="row"
+                        style="top: 0px; height: 48px; width: 0px;"
+                      />
+                    </div>
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    class="ag-floating-top"
+                    ref="eTop"
+                    role="presentation"
+                    style="min-height: 0px; height: 0px; display: none; overflow-y: hidden;"
+                    unselectable="on"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-floating-top ag-hidden"
+                      ref="eLeftTop"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-top-viewport"
+                      ref="eTopViewport"
+                      role="presentation"
+                      unselectable="on"
+                    >
+                      
+                
+                      <div
+                        class="ag-floating-top-container"
+                        ref="eTopContainer"
+                        role="presentation"
+                        style="width: 1199px;"
+                        unselectable="on"
+                      />
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-floating-top ag-hidden"
+                      ref="eRightTop"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-top-full-width-container ag-hidden"
+                      ref="eTopFullWidthContainer"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    class="ag-body-viewport ag-layout-normal ag-row-no-animation"
+                    ref="eBodyViewport"
+                    role="presentation"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-cols-container ag-hidden"
+                      ref="eLeftContainer"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    >
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="2"
+                        class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                        comp-id="66"
+                        role="row"
+                        row-id="asdf_7d_refund"
+                        row-index="0"
+                        style="height: 42px; transform: translateY(0px); "
+                      />
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="3"
+                        class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute ag-row-last"
+                        comp-id="71"
+                        role="row"
+                        row-id="registration_start"
+                        row-index="1"
+                        style="height: 42px; transform: translateY(42px); "
+                      />
+                    </div>
+                    
+            
+                    <div
+                      class="ag-center-cols-clipper"
+                      ref="eCenterColsClipper"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    >
+                      
+                
+                      <div
+                        class="ag-center-cols-viewport"
+                        ref="eCenterViewport"
+                        role="presentation"
+                        style="height: calc(100% + 0px);"
+                      >
+                        
+                    
+                        <div
+                          class="ag-center-cols-container"
+                          ref="eCenterContainer"
+                          role="rowgroup"
+                          style="width: 1199px; height: 84px;"
+                          unselectable="on"
+                        >
+                          <div
+                            aria-label="Press SPACE to select this row."
+                            aria-rowindex="2"
+                            class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                            comp-id="66"
+                            role="row"
+                            row-id="asdf_7d_refund"
+                            row-index="0"
+                            style="height: 42px; transform: translateY(0px); "
+                          >
+                            <div
+                              aria-colindex="1"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="__detail-button-col__"
+                              comp-id="67"
+                              role="gridcell"
+                              style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            />
+                            <div
+                              aria-colindex="2"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="name"
+                              comp-id="68"
+                              role="gridcell"
+                              style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            />
+                            <div
+                              aria-colindex="3"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="description"
+                              comp-id="69"
+                              role="gridcell"
+                              style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              string
+                            </div>
+                            <div
+                              aria-colindex="7"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="metrics-assign--actions"
+                              comp-id="70"
+                              role="gridcell"
+                              style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                              tabindex="-1"
+                              unselectable="on"
+                            />
+                          </div>
+                          <div
+                            aria-label="Press SPACE to select this row."
+                            aria-rowindex="3"
+                            class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute ag-row-last"
+                            comp-id="71"
+                            role="row"
+                            row-id="registration_start"
+                            row-index="1"
+                            style="height: 42px; transform: translateY(42px); "
+                          >
+                            <div
+                              aria-colindex="1"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="__detail-button-col__"
+                              comp-id="72"
+                              role="gridcell"
+                              style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            />
+                            <div
+                              aria-colindex="2"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="name"
+                              comp-id="73"
+                              role="gridcell"
+                              style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            />
+                            <div
+                              aria-colindex="3"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="description"
+                              comp-id="74"
+                              role="gridcell"
+                              style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              string
+                            </div>
+                            <div
+                              aria-colindex="7"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="metrics-assign--actions"
+                              comp-id="75"
+                              role="gridcell"
+                              style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                              tabindex="-1"
+                              unselectable="on"
+                            />
+                          </div>
+                        </div>
+                        
+                
+                      </div>
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-cols-container ag-hidden"
+                      ref="eRightContainer"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    >
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="2"
+                        class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                        comp-id="66"
+                        role="row"
+                        row-id="asdf_7d_refund"
+                        row-index="0"
+                        style="height: 42px; transform: translateY(0px); "
+                      />
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="3"
+                        class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute ag-row-last"
+                        comp-id="71"
+                        role="row"
+                        row-id="registration_start"
+                        row-index="1"
+                        style="height: 42px; transform: translateY(42px); "
+                      />
+                    </div>
+                    
+            
+                    <div
+                      class="ag-full-width-container"
+                      ref="eFullWidthContainer"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    class="ag-floating-bottom"
+                    ref="eBottom"
+                    role="presentation"
+                    style="min-height: 0px; height: 0px; display: none; overflow-y: hidden;"
+                    unselectable="on"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-floating-bottom ag-hidden"
+                      ref="eLeftBottom"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-bottom-viewport"
+                      ref="eBottomViewport"
+                      role="presentation"
+                      unselectable="on"
+                    >
+                      
+                
+                      <div
+                        class="ag-floating-bottom-container"
+                        ref="eBottomContainer"
+                        role="presentation"
+                        style="width: 1199px;"
+                        unselectable="on"
+                      />
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-floating-bottom ag-hidden"
+                      ref="eRightBottom"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-bottom-full-width-container ag-hidden"
+                      ref="eBottomFullWidthContainer"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    aria-hidden="true"
+                    class="ag-body-horizontal-scroll"
+                    ref="eHorizontalScrollBody"
+                    style="height: 0px; max-height: 0px; min-height: 0px;"
+                  >
+                    
+            
+                    <div
+                      class="ag-horizontal-left-spacer"
+                      ref="eHorizontalLeftSpacer"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    />
+                    
+            
+                    <div
+                      class="ag-body-horizontal-scroll-viewport"
+                      ref="eBodyHorizontalScrollViewport"
+                      style="height: 0px; max-height: 0px; min-height: 0px;"
+                    >
+                      
+                
+                      <div
+                        class="ag-body-horizontal-scroll-container"
+                        ref="eBodyHorizontalScrollContainer"
+                        style="width: 1199px; height: 0px; max-height: 0px; min-height: 0px;"
+                      />
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-horizontal-right-spacer"
+                      ref="eHorizontalRightSpacer"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <!--AG-OVERLAY-WRAPPER-->
+                  <div
+                    aria-hidden="true"
+                    class="ag-overlay ag-hidden"
+                    ref="overlayWrapper"
+                  >
+                    
+            
+                    <div
+                      class="ag-overlay-panel"
+                    >
+                      
+                
+                      <div
+                        class="ag-overlay-wrapper ag-layout-normal"
+                        ref="eOverlayWrapper"
+                      />
+                      
+            
+                    </div>
+                    
+        
+                  </div>
+                  
+    
+                </div>
+                
+                    
+                
+                <div
+                  class="ag-tab-guard ag-tab-guard-bottom"
+                  role="presentation"
+                  tabindex="0"
+                />
+              </div>
+              
+                
+                
+              <!--AG-PAGINATION-->
+              <div
+                aria-describedby="ag-42-start-page ag-42-start-page-number ag-42-of-page ag-42-of-page-number ag-42-first-row ag-42-to ag-42-last-row ag-42-of ag-42-row-count"
+                aria-live="polite"
+                class="ag-paging-panel ag-unselectable ag-hidden"
+                id="ag-42"
+              >
+                
+                
+                <span
+                  aria-hidden="true"
+                  class="ag-paging-row-summary-panel"
+                >
+                  
+                    
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    id="ag-42-first-row"
+                    ref="lbFirstRowOnPage"
+                  />
+                  
+                    
+                  <span
+                    id="ag-42-to"
+                  >
+                    to
+                  </span>
+                  
+                    
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    id="ag-42-last-row"
+                    ref="lbLastRowOnPage"
+                  />
+                  
+                    
+                  <span
+                    id="ag-42-of"
+                  >
+                    of
+                  </span>
+                  
+                    
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    id="ag-42-row-count"
+                    ref="lbRecordCount"
+                  />
+                  
+                
+                </span>
+                
+                
+                <span
+                  class="ag-paging-page-summary-panel"
+                  role="presentation"
+                >
+                  
+                    
+                  <div
+                    aria-label="First Page"
+                    class="ag-paging-button"
+                    ref="btFirst"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-first"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                    
+                  <div
+                    aria-label="Previous Page"
+                    class="ag-paging-button"
+                    ref="btPrevious"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-previous"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                    
+                  <span
+                    aria-hidden="true"
+                    class="ag-paging-description"
+                  >
+                    
+                        
+                    <span
+                      id="ag-42-start-page"
+                    >
+                      Page
+                    </span>
+                    
+                        
+                    <span
+                      class="ag-paging-number"
+                      id="ag-42-start-page-number"
+                      ref="lbCurrent"
+                    />
+                    
+                        
+                    <span
+                      id="ag-42-of-page"
+                    >
+                      of
+                    </span>
+                    
+                        
+                    <span
+                      class="ag-paging-number"
+                      id="ag-42-of-page-number"
+                      ref="lbTotal"
+                    />
+                    
+                    
+                  </span>
+                  
+                    
+                  <div
+                    aria-label="Next Page"
+                    class="ag-paging-button"
+                    ref="btNext"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-next"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                    
+                  <div
+                    aria-label="Last Page"
+                    class="ag-paging-button"
+                    ref="btLast"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-last"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                
+                </span>
+                
+            
+              </div>
+              
+                
+            
             </div>
           </div>
         </div>
       </div>
-      <button
-        aria-label="Add metric"
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiButton-label"
-        >
-          Assign
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-35 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-48 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -226,7 +1376,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-36 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-49 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -247,13 +1397,13 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-47 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="attr-window-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-48"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
             id="attr-window-panel"
             role="button"
             tabindex="0"
@@ -317,7 +1467,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
                       is the window of time after exposure to an experiment that we capture metric events for a participant (exposure can be from either assignment or specified exposure events). The refund window is the window of time after a purchase event. Revenue metrics will automatically deduct transactions that have been refunded within the metric’s refund window.
                       <br />
                       <div
-                        class="makeStyles-attributionWindowDiagram-37"
+                        class="makeStyles-attributionWindowDiagram-50"
                       >
                         <svg>
                           attribution_window.svg
@@ -336,7 +1486,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-38 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-51 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -357,13 +1507,13 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-47 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="min-diff-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-48"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
             id="min-diff-panel"
             role="button"
             tabindex="0"
@@ -427,7 +1577,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
                       are absolute differences from the baseline (not relative). For example, if the baseline conversion rate is 5%, a minimum difference of 0.5 pp is equivalent to a 10% relative change.
                       <br />
                       <div
-                        class="makeStyles-minDiffDiagram-39"
+                        class="makeStyles-minDiffDiagram-52"
                       >
                         <svg>
                           min_diffs.svg
@@ -443,7 +1593,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-40 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-53 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -473,7 +1623,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-41 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-54 MuiTypography-h4"
     >
       Exposure Events
     </h4>
@@ -506,11 +1656,11 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-45"
+      class="makeStyles-addMetric-59"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-46"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-60"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -535,7 +1685,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-42 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-55 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -569,7 +1719,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-43 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-56 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -604,7 +1754,7 @@ exports[`allows adding, editing and removing a Metric Assignment 1`] = `
 exports[`allows adding, editing and removing a Metric Assignment 2`] = `
 <div>
   <div
-    class="makeStyles-root-25"
+    class="makeStyles-root-38"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -660,93 +1810,163 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
             class="MuiTableRow-root"
           >
             <td
-              class="MuiTableCell-root MuiTableCell-body"
-              colspan="5"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-43"
             >
-              <p
-                class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter"
+              <span
+                class="makeStyles-metricName-44 makeStyles-tooltipped-45"
+                title="string"
               >
-                You don't have any metric assignments yet.
-              </p>
+                asdf_7d_refund
+              </span>
+              <br />
+              <span
+                class="makeStyles-root-85 makeStyles-monospaced-42"
+              >
+                primary
+              </span>
             </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    <div
-      class="makeStyles-addMetric-45"
-    >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-46"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-        />
-      </svg>
-      <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-27"
-      >
-        <div
-          aria-expanded="false"
-          aria-label="Select a metric"
-          class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-          role="combobox"
-        >
-          <div
-            class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
-          >
-            <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+            <td
+              class="MuiTableCell-root MuiTableCell-body"
             >
-              <input
-                aria-autocomplete="list"
-                aria-invalid="false"
-                autocapitalize="none"
-                autocomplete="off"
-                class="MuiInputBase-input MuiInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd"
-                id="add-metric-select"
-                placeholder="Select a metric"
-                required=""
-                spellcheck="false"
-                type="text"
-                value=""
-              />
               <div
-                class="MuiAutocomplete-endAdornment"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-41"
               >
-                <button
-                  aria-label="Clear"
-                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
+                <div
+                  aria-haspopup="listbox"
+                  aria-label="Attribution Window"
+                  aria-labelledby="experiment.metricAssignments[0].attributionWindowSeconds mui-component-select-experiment.metricAssignments[0].attributionWindowSeconds"
+                  class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
+                  id="mui-component-select-experiment.metricAssignments[0].attributionWindowSeconds"
+                  role="button"
+                  tabindex="0"
+                >
+                  -
+                </div>
+                <input
+                  aria-hidden="true"
+                  class="MuiSelect-nativeInput"
+                  name="experiment.metricAssignments[0].attributionWindowSeconds"
                   tabindex="-1"
-                  title="Clear"
-                  type="button"
+                  value=""
+                />
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M7 10l5 5 5-5z"
+                  />
+                </svg>
+                <fieldset
+                  aria-hidden="true"
+                  class="PrivateNotchedOutline-root-86 MuiOutlinedInput-notchedOutline"
+                  style="padding-left: 8px;"
+                >
+                  <legend
+                    class="PrivateNotchedOutline-legend-87"
+                    style="width: 0.01px;"
+                  >
+                    <span>
+                      ​
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-47"
+            >
+              <span
+                class="MuiSwitch-root"
+              >
+                <span
+                  aria-disabled="false"
+                  aria-label="Change Expected"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-90 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-91 Mui-checked"
+                  variant="outlined"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                      />
-                    </svg>
+                    <input
+                      checked=""
+                      class="PrivateSwitchBase-input-93 MuiSwitch-input"
+                      id="experiment.metricAssignments[0].changeExpected"
+                      name="experiment.metricAssignments[0].changeExpected"
+                      type="checkbox"
+                      value="true"
+                    />
+                    <span
+                      class="MuiSwitch-thumb"
+                    />
                   </span>
                   <span
                     class="MuiTouchRipple-root"
                   />
-                </button>
+                </span>
+                <span
+                  class="MuiSwitch-track"
+                />
+              </span>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body"
+            >
+              <div
+                class="MuiFormControl-root MuiTextField-root makeStyles-root-94 makeStyles-minDifferenceField-46"
+              >
+                <div
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+                >
+                  <input
+                    aria-invalid="false"
+                    aria-label="Minimum Difference"
+                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+                    id="experiment.metricAssignments[0].minDifference"
+                    min="0"
+                    name="experiment.metricAssignments[0].minDifference"
+                    placeholder="1.30"
+                    type="number"
+                    value=""
+                  />
+                  <div
+                    class="MuiInputAdornment-root makeStyles-adornment-96 MuiInputAdornment-positionEnd"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
+                    >
+                      USD
+                    </p>
+                  </div>
+                  <fieldset
+                    aria-hidden="true"
+                    class="PrivateNotchedOutline-root-86 MuiOutlinedInput-notchedOutline"
+                    style="padding-left: 8px;"
+                  >
+                    <legend
+                      class="PrivateNotchedOutline-legend-87"
+                      style="width: 0.01px;"
+                    >
+                      <span>
+                        ​
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body"
+            >
+              <div>
                 <button
-                  aria-label="Open"
-                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
-                  tabindex="-1"
-                  title="Open"
+                  aria-controls="menu"
+                  aria-haspopup="true"
+                  aria-label="more"
+                  class="MuiButtonBase-root MuiIconButton-root"
+                  tabindex="0"
                   type="button"
                 >
                   <span
@@ -759,7 +1979,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
                       viewBox="0 0 24 24"
                     >
                       <path
-                        d="M7 10l5 5 5-5z"
+                        d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
                       />
                     </svg>
                   </span>
@@ -768,28 +1988,1436 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
                   />
                 </button>
               </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div
+      class="makeStyles-tableContainer-58"
+    >
+      <div
+        class="ag-theme-alpine makeStyles-root-62"
+      >
+        <div
+          class="makeStyles-toolbar-63"
+        >
+          <div
+            class="makeStyles-rootFullWidth-66"
+          >
+            <div
+              class="makeStyles-search-67"
+            >
+              <div
+                class="makeStyles-searchIcon-68"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                  />
+                </svg>
+              </div>
+              <div
+                class="MuiInputBase-root makeStyles-inputRootFullWidth-69"
+              >
+                <input
+                  aria-label="Search"
+                  class="MuiInputBase-input makeStyles-inputInputFullWidth-70"
+                  placeholder="Search…"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                 Reset 
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+        </div>
+        <div
+          class="ag-theme-alpine makeStyles-gridContainer-64"
+        >
+          <div
+            style="height: auto; flex: 1;"
+          >
+            <div
+              class="ag-root-wrapper ag-layout-normal ag-ltr"
+              ref="eRootWrapper"
+            >
+              
+                
+                
+              <div
+                class="ag-root-wrapper-body ag-layout-normal ag-focus-managed"
+                ref="rootWrapperBody"
+              >
+                <div
+                  class="ag-tab-guard ag-tab-guard-top"
+                  role="presentation"
+                  tabindex="0"
+                />
+                
+                    
+                <!--AG-GRID-COMP-->
+                <div
+                  aria-colcount="7"
+                  aria-rowcount="3"
+                  class="ag-root ag-unselectable ag-layout-normal"
+                  ref="gridPanel"
+                  role="grid"
+                  unselectable="on"
+                >
+                  
+        
+                  <!--AG-HEADER-ROOT-->
+                  <div
+                    class="ag-header ag-focus-managed ag-pivot-off"
+                    ref="headerRoot"
+                    role="presentation"
+                    style="height: 49px; min-height: 49px;"
+                    unselectable="on"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-header ag-hidden"
+                      ref="ePinnedLeftHeader"
+                      role="presentation"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-column"
+                        role="row"
+                        style="top: 0px; height: 48px; width: 0px;"
+                      />
+                    </div>
+                    
+            
+                    <div
+                      class="ag-header-viewport"
+                      ref="eHeaderViewport"
+                      role="presentation"
+                    >
+                      
+                
+                      <div
+                        class="ag-header-container"
+                        ref="eHeaderContainer"
+                        role="rowgroup"
+                        style="width: 1199px;"
+                      >
+                        <div
+                          aria-rowindex="1"
+                          class="ag-header-row ag-header-row-column"
+                          role="row"
+                          style="top: 0px; height: 48px; width: 1199px;"
+                        >
+                          <div
+                            aria-colindex="1"
+                            class="ag-header-cell ag-focus-managed"
+                            col-id="__detail-button-col__"
+                            role="columnheader"
+                            style="width: 34px; left: 0px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize ag-hidden"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-47-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container"
+                              role="presentation"
+                            >
+                              
+            
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                />
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                
+                
+                                
+                
+                                
+                
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="2"
+                            aria-sort="ascending"
+                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-61"
+                            col-id="name"
+                            role="columnheader"
+                            style="width: 465px; left: 34px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-50-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container ag-header-cell-sorted-asc"
+                              role="presentation"
+                            >
+                              
+            
+                              <span
+                                aria-hidden="true"
+                                class="ag-header-icon ag-header-cell-menu-button"
+                                ref="eMenu"
+                              >
+                                <span
+                                  class="ag-icon ag-icon-menu"
+                                  role="presentation"
+                                  unselectable="on"
+                                />
+                              </span>
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                >
+                                  Name
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-order ag-hidden"
+                                  ref="eSortOrder"
+                                >
+                                  1
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-ascending-icon"
+                                  ref="eSortAsc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-asc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-descending-icon ag-hidden"
+                                  ref="eSortDesc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-desc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-none-icon ag-hidden"
+                                  ref="eSortNone"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-none"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="3"
+                            aria-sort="none"
+                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable"
+                            col-id="description"
+                            role="columnheader"
+                            style="width: 550px; left: 499px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-53-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container ag-header-cell-sorted-none"
+                              role="presentation"
+                            >
+                              
+            
+                              <span
+                                aria-hidden="true"
+                                class="ag-header-icon ag-header-cell-menu-button"
+                                ref="eMenu"
+                              >
+                                <span
+                                  class="ag-icon ag-icon-menu"
+                                  role="presentation"
+                                  unselectable="on"
+                                />
+                              </span>
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                >
+                                  Description
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-order ag-hidden"
+                                  ref="eSortOrder"
+                                />
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-ascending-icon ag-hidden"
+                                  ref="eSortAsc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-asc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-descending-icon ag-hidden"
+                                  ref="eSortDesc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-desc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-none-icon ag-hidden"
+                                  ref="eSortNone"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-none"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="7"
+                            class="ag-header-cell ag-focus-managed"
+                            col-id="metrics-assign--actions"
+                            role="columnheader"
+                            style="width: 150px; left: 1049px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize ag-hidden"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-56-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container"
+                              role="presentation"
+                            >
+                              
+            
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                >
+                                  Actions
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                
+                
+                                
+                
+                                
+                
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-header ag-hidden"
+                      ref="ePinnedRightHeader"
+                      role="presentation"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-column"
+                        role="row"
+                        style="top: 0px; height: 48px; width: 0px;"
+                      />
+                    </div>
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    class="ag-floating-top"
+                    ref="eTop"
+                    role="presentation"
+                    style="min-height: 0px; height: 0px; display: none; overflow-y: hidden;"
+                    unselectable="on"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-floating-top ag-hidden"
+                      ref="eLeftTop"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-top-viewport"
+                      ref="eTopViewport"
+                      role="presentation"
+                      unselectable="on"
+                    >
+                      
+                
+                      <div
+                        class="ag-floating-top-container"
+                        ref="eTopContainer"
+                        role="presentation"
+                        style="width: 1199px;"
+                        unselectable="on"
+                      />
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-floating-top ag-hidden"
+                      ref="eRightTop"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-top-full-width-container ag-hidden"
+                      ref="eTopFullWidthContainer"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    class="ag-body-viewport ag-layout-normal ag-row-no-animation"
+                    ref="eBodyViewport"
+                    role="presentation"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-cols-container ag-hidden"
+                      ref="eLeftContainer"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    >
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="2"
+                        class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                        comp-id="66"
+                        role="row"
+                        row-id="asdf_7d_refund"
+                        row-index="0"
+                        style="height: 42px; transform: translateY(0px);"
+                      />
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="3"
+                        class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute ag-row-last"
+                        comp-id="71"
+                        role="row"
+                        row-id="registration_start"
+                        row-index="1"
+                        style="height: 42px; transform: translateY(42px);"
+                      />
+                    </div>
+                    
+            
+                    <div
+                      class="ag-center-cols-clipper"
+                      ref="eCenterColsClipper"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    >
+                      
+                
+                      <div
+                        class="ag-center-cols-viewport"
+                        ref="eCenterViewport"
+                        role="presentation"
+                        style="height: calc(100% + 0px);"
+                      >
+                        
+                    
+                        <div
+                          class="ag-center-cols-container"
+                          ref="eCenterContainer"
+                          role="rowgroup"
+                          style="width: 1199px; height: 84px;"
+                          unselectable="on"
+                        >
+                          <div
+                            aria-label="Press SPACE to select this row."
+                            aria-rowindex="2"
+                            class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                            comp-id="66"
+                            role="row"
+                            row-id="asdf_7d_refund"
+                            row-index="0"
+                            style="height: 42px; transform: translateY(0px);"
+                          >
+                            <div
+                              aria-colindex="1"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="__detail-button-col__"
+                              comp-id="67"
+                              role="gridcell"
+                              style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <button
+                                  aria-label="Toggle Button"
+                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-75 makeStyles-notRotated-77 MuiIconButton-sizeSmall"
+                                  tabindex="0"
+                                  type="button"
+                                >
+                                  <span
+                                    class="MuiIconButton-label"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="2"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="name"
+                              comp-id="68"
+                              role="gridcell"
+                              style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <div
+                                  class="makeStyles-metricName-78"
+                                  title="asdf_7d_refund"
+                                >
+                                  asdf_7d_refund
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="3"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="description"
+                              comp-id="69"
+                              role="gridcell"
+                              style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              string
+                            </div>
+                            <div
+                              aria-colindex="7"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="metrics-assign--actions"
+                              comp-id="70"
+                              role="gridcell"
+                              style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <div
+                                  class="makeStyles-root-79"
+                                >
+                                  <button
+                                    aria-label="Assign metric"
+                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-83 MuiButton-contained makeStyles-noWrap-80 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+                                    tabindex="0"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="MuiButton-label"
+                                    >
+                                      <span
+                                        class="MuiButton-startIcon MuiButton-iconSizeSmall"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      Assign Metric
+                                    </span>
+                                    <span
+                                      class="MuiTouchRipple-root"
+                                    />
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-label="Press SPACE to select this row."
+                            aria-rowindex="3"
+                            class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute ag-row-last"
+                            comp-id="71"
+                            role="row"
+                            row-id="registration_start"
+                            row-index="1"
+                            style="height: 42px; transform: translateY(42px);"
+                          >
+                            <div
+                              aria-colindex="1"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="__detail-button-col__"
+                              comp-id="72"
+                              role="gridcell"
+                              style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <button
+                                  aria-label="Toggle Button"
+                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-75 makeStyles-notRotated-77 MuiIconButton-sizeSmall"
+                                  tabindex="0"
+                                  type="button"
+                                >
+                                  <span
+                                    class="MuiIconButton-label"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="2"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="name"
+                              comp-id="73"
+                              role="gridcell"
+                              style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <div
+                                  class="makeStyles-metricName-78"
+                                  title="registration_start"
+                                >
+                                  registration_start
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="3"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="description"
+                              comp-id="74"
+                              role="gridcell"
+                              style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              string
+                            </div>
+                            <div
+                              aria-colindex="7"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="metrics-assign--actions"
+                              comp-id="75"
+                              role="gridcell"
+                              style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <div
+                                  class="makeStyles-root-79"
+                                >
+                                  <button
+                                    aria-label="Assign metric"
+                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-84 MuiButton-contained makeStyles-noWrap-80 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+                                    tabindex="0"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="MuiButton-label"
+                                    >
+                                      <span
+                                        class="MuiButton-startIcon MuiButton-iconSizeSmall"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      Assign Metric
+                                    </span>
+                                    <span
+                                      class="MuiTouchRipple-root"
+                                    />
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        
+                
+                      </div>
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-cols-container ag-hidden"
+                      ref="eRightContainer"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    >
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="2"
+                        class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                        comp-id="66"
+                        role="row"
+                        row-id="asdf_7d_refund"
+                        row-index="0"
+                        style="height: 42px; transform: translateY(0px);"
+                      />
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="3"
+                        class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute ag-row-last"
+                        comp-id="71"
+                        role="row"
+                        row-id="registration_start"
+                        row-index="1"
+                        style="height: 42px; transform: translateY(42px);"
+                      />
+                    </div>
+                    
+            
+                    <div
+                      class="ag-full-width-container"
+                      ref="eFullWidthContainer"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    class="ag-floating-bottom"
+                    ref="eBottom"
+                    role="presentation"
+                    style="min-height: 0px; height: 0px; display: none; overflow-y: hidden;"
+                    unselectable="on"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-floating-bottom ag-hidden"
+                      ref="eLeftBottom"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-bottom-viewport"
+                      ref="eBottomViewport"
+                      role="presentation"
+                      unselectable="on"
+                    >
+                      
+                
+                      <div
+                        class="ag-floating-bottom-container"
+                        ref="eBottomContainer"
+                        role="presentation"
+                        style="width: 1199px;"
+                        unselectable="on"
+                      />
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-floating-bottom ag-hidden"
+                      ref="eRightBottom"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-bottom-full-width-container ag-hidden"
+                      ref="eBottomFullWidthContainer"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    aria-hidden="true"
+                    class="ag-body-horizontal-scroll"
+                    ref="eHorizontalScrollBody"
+                    style="height: 0px; max-height: 0px; min-height: 0px;"
+                  >
+                    
+            
+                    <div
+                      class="ag-horizontal-left-spacer"
+                      ref="eHorizontalLeftSpacer"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    />
+                    
+            
+                    <div
+                      class="ag-body-horizontal-scroll-viewport"
+                      ref="eBodyHorizontalScrollViewport"
+                      style="height: 0px; max-height: 0px; min-height: 0px;"
+                    >
+                      
+                
+                      <div
+                        class="ag-body-horizontal-scroll-container"
+                        ref="eBodyHorizontalScrollContainer"
+                        style="width: 1199px; height: 0px; max-height: 0px; min-height: 0px;"
+                      />
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-horizontal-right-spacer"
+                      ref="eHorizontalRightSpacer"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <!--AG-OVERLAY-WRAPPER-->
+                  <div
+                    aria-hidden="true"
+                    class="ag-overlay ag-hidden"
+                    ref="overlayWrapper"
+                  >
+                    
+            
+                    <div
+                      class="ag-overlay-panel"
+                    >
+                      
+                
+                      <div
+                        class="ag-overlay-wrapper ag-layout-normal"
+                        ref="eOverlayWrapper"
+                      />
+                      
+            
+                    </div>
+                    
+        
+                  </div>
+                  
+    
+                </div>
+                
+                    
+                
+                <div
+                  class="ag-tab-guard ag-tab-guard-bottom"
+                  role="presentation"
+                  tabindex="0"
+                />
+              </div>
+              
+                
+                
+              <!--AG-PAGINATION-->
+              <div
+                aria-describedby="ag-42-start-page ag-42-start-page-number ag-42-of-page ag-42-of-page-number ag-42-first-row ag-42-to ag-42-last-row ag-42-of ag-42-row-count"
+                aria-live="polite"
+                class="ag-paging-panel ag-unselectable ag-hidden"
+                id="ag-42"
+              >
+                
+                
+                <span
+                  aria-hidden="true"
+                  class="ag-paging-row-summary-panel"
+                >
+                  
+                    
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    id="ag-42-first-row"
+                    ref="lbFirstRowOnPage"
+                  />
+                  
+                    
+                  <span
+                    id="ag-42-to"
+                  >
+                    to
+                  </span>
+                  
+                    
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    id="ag-42-last-row"
+                    ref="lbLastRowOnPage"
+                  />
+                  
+                    
+                  <span
+                    id="ag-42-of"
+                  >
+                    of
+                  </span>
+                  
+                    
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    id="ag-42-row-count"
+                    ref="lbRecordCount"
+                  />
+                  
+                
+                </span>
+                
+                
+                <span
+                  class="ag-paging-page-summary-panel"
+                  role="presentation"
+                >
+                  
+                    
+                  <div
+                    aria-label="First Page"
+                    class="ag-paging-button"
+                    ref="btFirst"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-first"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                    
+                  <div
+                    aria-label="Previous Page"
+                    class="ag-paging-button"
+                    ref="btPrevious"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-previous"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                    
+                  <span
+                    aria-hidden="true"
+                    class="ag-paging-description"
+                  >
+                    
+                        
+                    <span
+                      id="ag-42-start-page"
+                    >
+                      Page
+                    </span>
+                    
+                        
+                    <span
+                      class="ag-paging-number"
+                      id="ag-42-start-page-number"
+                      ref="lbCurrent"
+                    />
+                    
+                        
+                    <span
+                      id="ag-42-of-page"
+                    >
+                      of
+                    </span>
+                    
+                        
+                    <span
+                      class="ag-paging-number"
+                      id="ag-42-of-page-number"
+                      ref="lbTotal"
+                    />
+                    
+                    
+                  </span>
+                  
+                    
+                  <div
+                    aria-label="Next Page"
+                    class="ag-paging-button"
+                    ref="btNext"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-next"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                    
+                  <div
+                    aria-label="Last Page"
+                    class="ag-paging-button"
+                    ref="btLast"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-last"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                
+                </span>
+                
+            
+              </div>
+              
+                
+            
             </div>
           </div>
         </div>
       </div>
-      <button
-        aria-label="Add metric"
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiButton-label"
-        >
-          Assign
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-35 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-48 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -827,7 +3455,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-36 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-49 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -848,13 +3476,13 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-47 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="attr-window-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-48"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
             id="attr-window-panel"
             role="button"
             tabindex="0"
@@ -918,7 +3546,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
                       is the window of time after exposure to an experiment that we capture metric events for a participant (exposure can be from either assignment or specified exposure events). The refund window is the window of time after a purchase event. Revenue metrics will automatically deduct transactions that have been refunded within the metric’s refund window.
                       <br />
                       <div
-                        class="makeStyles-attributionWindowDiagram-37"
+                        class="makeStyles-attributionWindowDiagram-50"
                       >
                         <svg>
                           attribution_window.svg
@@ -937,7 +3565,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-38 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-51 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -958,13 +3586,13 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-47 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="min-diff-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-48"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
             id="min-diff-panel"
             role="button"
             tabindex="0"
@@ -1028,7 +3656,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
                       are absolute differences from the baseline (not relative). For example, if the baseline conversion rate is 5%, a minimum difference of 0.5 pp is equivalent to a 10% relative change.
                       <br />
                       <div
-                        class="makeStyles-minDiffDiagram-39"
+                        class="makeStyles-minDiffDiagram-52"
                       >
                         <svg>
                           min_diffs.svg
@@ -1044,7 +3672,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-40 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-53 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1074,7 +3702,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-41 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-54 MuiTypography-h4"
     >
       Exposure Events
     </h4>
@@ -1107,11 +3735,11 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-45"
+      class="makeStyles-addMetric-59"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-46"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-60"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1136,7 +3764,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-42 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-55 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1170,7 +3798,7 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-43 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-56 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1203,9 +3831,11 @@ exports[`allows adding, editing and removing a Metric Assignment 2`] = `
 `;
 
 exports[`allows adding, editing and removing a Metric Assignment 3`] = `
-<div>
+<div
+  aria-hidden="true"
+>
   <div
-    class="makeStyles-root-25"
+    class="makeStyles-root-38"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -1261,17 +3891,17 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
             class="MuiTableRow-root"
           >
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-30"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-43"
             >
               <span
-                class="makeStyles-metricName-31 makeStyles-tooltipped-32"
+                class="makeStyles-metricName-44 makeStyles-tooltipped-45"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-root-49 makeStyles-monospaced-29"
+                class="makeStyles-root-85 makeStyles-monospaced-42"
               >
                 primary
               </span>
@@ -1280,7 +3910,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-28"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-41"
               >
                 <div
                   aria-haspopup="listbox"
@@ -1312,11 +3942,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-50 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-86 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-51"
+                    class="PrivateNotchedOutline-legend-87"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -1327,7 +3957,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-34"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-47"
             >
               <span
                 class="MuiSwitch-root"
@@ -1335,7 +3965,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-54 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-55 Mui-checked"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-90 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-91 Mui-checked"
                   variant="outlined"
                 >
                   <span
@@ -1343,7 +3973,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input-57 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-93 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -1366,7 +3996,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-root-58 makeStyles-minDifferenceField-33"
+                class="MuiFormControl-root MuiTextField-root makeStyles-root-94 makeStyles-minDifferenceField-46"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
@@ -1380,10 +4010,10 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                     name="experiment.metricAssignments[0].minDifference"
                     placeholder="1.30"
                     type="number"
-                    value=""
+                    value="0.01"
                   />
                   <div
-                    class="MuiInputAdornment-root makeStyles-adornment-60 MuiInputAdornment-positionEnd"
+                    class="MuiInputAdornment-root makeStyles-adornment-96 MuiInputAdornment-positionEnd"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
@@ -1393,11 +4023,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                   </div>
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-50 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-86 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-51"
+                      class="PrivateNotchedOutline-legend-87"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -1445,122 +4075,1430 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-45"
+      class="makeStyles-tableContainer-58"
     >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-46"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-        />
-      </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-27"
+        class="ag-theme-alpine makeStyles-root-62"
       >
         <div
-          aria-expanded="false"
-          aria-label="Select a metric"
-          class="MuiAutocomplete-root Mui-focused MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-          role="combobox"
+          class="makeStyles-toolbar-63"
         >
           <div
-            class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+            class="makeStyles-rootFullWidth-66"
           >
             <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInput-fullWidth Mui-focused Mui-focused MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+              class="makeStyles-search-67"
             >
-              <input
-                aria-autocomplete="list"
-                aria-invalid="false"
-                autocapitalize="none"
-                autocomplete="off"
-                class="MuiInputBase-input MuiInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd"
-                id="add-metric-select"
-                placeholder="Select a metric"
-                required=""
-                spellcheck="false"
-                type="text"
-                value=""
-              />
               <div
-                class="MuiAutocomplete-endAdornment"
+                class="makeStyles-searchIcon-68"
               >
-                <button
-                  aria-label="Clear"
-                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
-                  tabindex="-1"
-                  title="Clear"
-                  type="button"
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
                 >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
+                  <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
                   />
-                </button>
-                <button
-                  aria-label="Open"
-                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
-                  tabindex="-1"
-                  title="Open"
-                  type="button"
-                >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M7 10l5 5 5-5z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
-                  />
-                </button>
+                </svg>
               </div>
+              <div
+                class="MuiInputBase-root makeStyles-inputRootFullWidth-69"
+              >
+                <input
+                  aria-label="Search"
+                  class="MuiInputBase-input makeStyles-inputInputFullWidth-70"
+                  placeholder="Search…"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                 Reset 
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+        </div>
+        <div
+          class="ag-theme-alpine makeStyles-gridContainer-64"
+        >
+          <div
+            style="height: auto; flex: 1;"
+          >
+            <div
+              class="ag-root-wrapper ag-layout-normal ag-ltr"
+              ref="eRootWrapper"
+            >
+              
+                
+                
+              <div
+                class="ag-root-wrapper-body ag-layout-normal ag-focus-managed"
+                ref="rootWrapperBody"
+              >
+                <div
+                  class="ag-tab-guard ag-tab-guard-top"
+                  role="presentation"
+                  tabindex="0"
+                />
+                
+                    
+                <!--AG-GRID-COMP-->
+                <div
+                  aria-colcount="7"
+                  aria-rowcount="3"
+                  class="ag-root ag-unselectable ag-layout-normal"
+                  ref="gridPanel"
+                  role="grid"
+                  unselectable="on"
+                >
+                  
+        
+                  <!--AG-HEADER-ROOT-->
+                  <div
+                    class="ag-header ag-focus-managed ag-pivot-off"
+                    ref="headerRoot"
+                    role="presentation"
+                    style="height: 49px; min-height: 49px;"
+                    unselectable="on"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-header ag-hidden"
+                      ref="ePinnedLeftHeader"
+                      role="presentation"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-column"
+                        role="row"
+                        style="top: 0px; height: 48px; width: 0px;"
+                      />
+                    </div>
+                    
+            
+                    <div
+                      class="ag-header-viewport"
+                      ref="eHeaderViewport"
+                      role="presentation"
+                    >
+                      
+                
+                      <div
+                        class="ag-header-container"
+                        ref="eHeaderContainer"
+                        role="rowgroup"
+                        style="width: 1199px;"
+                      >
+                        <div
+                          aria-rowindex="1"
+                          class="ag-header-row ag-header-row-column"
+                          role="row"
+                          style="top: 0px; height: 48px; width: 1199px;"
+                        >
+                          <div
+                            aria-colindex="1"
+                            class="ag-header-cell ag-focus-managed"
+                            col-id="__detail-button-col__"
+                            role="columnheader"
+                            style="width: 34px; left: 0px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize ag-hidden"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-47-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container"
+                              role="presentation"
+                            >
+                              
+            
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                />
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                
+                
+                                
+                
+                                
+                
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="2"
+                            aria-sort="ascending"
+                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-61"
+                            col-id="name"
+                            role="columnheader"
+                            style="width: 465px; left: 34px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-50-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container ag-header-cell-sorted-asc"
+                              role="presentation"
+                            >
+                              
+            
+                              <span
+                                aria-hidden="true"
+                                class="ag-header-icon ag-header-cell-menu-button"
+                                ref="eMenu"
+                              >
+                                <span
+                                  class="ag-icon ag-icon-menu"
+                                  role="presentation"
+                                  unselectable="on"
+                                />
+                              </span>
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                >
+                                  Name
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-order ag-hidden"
+                                  ref="eSortOrder"
+                                >
+                                  1
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-ascending-icon"
+                                  ref="eSortAsc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-asc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-descending-icon ag-hidden"
+                                  ref="eSortDesc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-desc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-none-icon ag-hidden"
+                                  ref="eSortNone"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-none"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="3"
+                            aria-sort="none"
+                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable"
+                            col-id="description"
+                            role="columnheader"
+                            style="width: 550px; left: 499px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-53-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container ag-header-cell-sorted-none"
+                              role="presentation"
+                            >
+                              
+            
+                              <span
+                                aria-hidden="true"
+                                class="ag-header-icon ag-header-cell-menu-button"
+                                ref="eMenu"
+                              >
+                                <span
+                                  class="ag-icon ag-icon-menu"
+                                  role="presentation"
+                                  unselectable="on"
+                                />
+                              </span>
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                >
+                                  Description
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-order ag-hidden"
+                                  ref="eSortOrder"
+                                />
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-ascending-icon ag-hidden"
+                                  ref="eSortAsc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-asc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-descending-icon ag-hidden"
+                                  ref="eSortDesc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-desc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-none-icon ag-hidden"
+                                  ref="eSortNone"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-none"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="7"
+                            class="ag-header-cell ag-focus-managed"
+                            col-id="metrics-assign--actions"
+                            role="columnheader"
+                            style="width: 150px; left: 1049px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize ag-hidden"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-56-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container"
+                              role="presentation"
+                            >
+                              
+            
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                >
+                                  Actions
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                
+                
+                                
+                
+                                
+                
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-header ag-hidden"
+                      ref="ePinnedRightHeader"
+                      role="presentation"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-column"
+                        role="row"
+                        style="top: 0px; height: 48px; width: 0px;"
+                      />
+                    </div>
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    class="ag-floating-top"
+                    ref="eTop"
+                    role="presentation"
+                    style="min-height: 0px; height: 0px; display: none; overflow-y: hidden;"
+                    unselectable="on"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-floating-top ag-hidden"
+                      ref="eLeftTop"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-top-viewport"
+                      ref="eTopViewport"
+                      role="presentation"
+                      unselectable="on"
+                    >
+                      
+                
+                      <div
+                        class="ag-floating-top-container"
+                        ref="eTopContainer"
+                        role="presentation"
+                        style="width: 1199px;"
+                        unselectable="on"
+                      />
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-floating-top ag-hidden"
+                      ref="eRightTop"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-top-full-width-container ag-hidden"
+                      ref="eTopFullWidthContainer"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    class="ag-body-viewport ag-layout-normal ag-row-no-animation"
+                    ref="eBodyViewport"
+                    role="presentation"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-cols-container ag-hidden"
+                      ref="eLeftContainer"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    >
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="2"
+                        class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                        comp-id="66"
+                        role="row"
+                        row-id="asdf_7d_refund"
+                        row-index="0"
+                        style="height: 42px; transform: translateY(0px);"
+                      />
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="3"
+                        class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute ag-row-last"
+                        comp-id="71"
+                        role="row"
+                        row-id="registration_start"
+                        row-index="1"
+                        style="height: 42px; transform: translateY(42px);"
+                      />
+                    </div>
+                    
+            
+                    <div
+                      class="ag-center-cols-clipper"
+                      ref="eCenterColsClipper"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    >
+                      
+                
+                      <div
+                        class="ag-center-cols-viewport"
+                        ref="eCenterViewport"
+                        role="presentation"
+                        style="height: calc(100% + 0px);"
+                      >
+                        
+                    
+                        <div
+                          class="ag-center-cols-container"
+                          ref="eCenterContainer"
+                          role="rowgroup"
+                          style="width: 1199px; height: 84px;"
+                          unselectable="on"
+                        >
+                          <div
+                            aria-label="Press SPACE to select this row."
+                            aria-rowindex="2"
+                            class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                            comp-id="66"
+                            role="row"
+                            row-id="asdf_7d_refund"
+                            row-index="0"
+                            style="height: 42px; transform: translateY(0px);"
+                          >
+                            <div
+                              aria-colindex="1"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="__detail-button-col__"
+                              comp-id="67"
+                              role="gridcell"
+                              style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <button
+                                  aria-label="Toggle Button"
+                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-75 makeStyles-notRotated-77 MuiIconButton-sizeSmall"
+                                  tabindex="0"
+                                  type="button"
+                                >
+                                  <span
+                                    class="MuiIconButton-label"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="2"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="name"
+                              comp-id="68"
+                              role="gridcell"
+                              style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <div
+                                  class="makeStyles-metricName-78"
+                                  title="asdf_7d_refund"
+                                >
+                                  asdf_7d_refund
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="3"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="description"
+                              comp-id="69"
+                              role="gridcell"
+                              style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              string
+                            </div>
+                            <div
+                              aria-colindex="7"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="metrics-assign--actions"
+                              comp-id="70"
+                              role="gridcell"
+                              style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <div
+                                  class="makeStyles-root-79"
+                                >
+                                  <button
+                                    aria-label="Assign metric"
+                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-83 MuiButton-contained makeStyles-noWrap-80 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+                                    tabindex="0"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="MuiButton-label"
+                                    >
+                                      <span
+                                        class="MuiButton-startIcon MuiButton-iconSizeSmall"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      Assign Metric
+                                    </span>
+                                    <span
+                                      class="MuiTouchRipple-root"
+                                    />
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-label="Press SPACE to select this row."
+                            aria-rowindex="3"
+                            class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute ag-row-last"
+                            comp-id="71"
+                            role="row"
+                            row-id="registration_start"
+                            row-index="1"
+                            style="height: 42px; transform: translateY(42px);"
+                          >
+                            <div
+                              aria-colindex="1"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="__detail-button-col__"
+                              comp-id="72"
+                              role="gridcell"
+                              style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <button
+                                  aria-label="Toggle Button"
+                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-75 makeStyles-notRotated-77 MuiIconButton-sizeSmall"
+                                  tabindex="0"
+                                  type="button"
+                                >
+                                  <span
+                                    class="MuiIconButton-label"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="2"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="name"
+                              comp-id="73"
+                              role="gridcell"
+                              style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <div
+                                  class="makeStyles-metricName-78"
+                                  title="registration_start"
+                                >
+                                  registration_start
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="3"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="description"
+                              comp-id="74"
+                              role="gridcell"
+                              style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              string
+                            </div>
+                            <div
+                              aria-colindex="7"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="metrics-assign--actions"
+                              comp-id="75"
+                              role="gridcell"
+                              style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <div
+                                  class="makeStyles-root-79"
+                                >
+                                  <button
+                                    aria-label="Assign metric"
+                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-84 MuiButton-contained makeStyles-noWrap-80 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+                                    tabindex="0"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="MuiButton-label"
+                                    >
+                                      <span
+                                        class="MuiButton-startIcon MuiButton-iconSizeSmall"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      Assign Metric
+                                    </span>
+                                    <span
+                                      class="MuiTouchRipple-root"
+                                    />
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        
+                
+                      </div>
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-cols-container ag-hidden"
+                      ref="eRightContainer"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    >
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="2"
+                        class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                        comp-id="66"
+                        role="row"
+                        row-id="asdf_7d_refund"
+                        row-index="0"
+                        style="height: 42px; transform: translateY(0px);"
+                      />
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="3"
+                        class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute ag-row-last"
+                        comp-id="71"
+                        role="row"
+                        row-id="registration_start"
+                        row-index="1"
+                        style="height: 42px; transform: translateY(42px);"
+                      />
+                    </div>
+                    
+            
+                    <div
+                      class="ag-full-width-container"
+                      ref="eFullWidthContainer"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    class="ag-floating-bottom"
+                    ref="eBottom"
+                    role="presentation"
+                    style="min-height: 0px; height: 0px; display: none; overflow-y: hidden;"
+                    unselectable="on"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-floating-bottom ag-hidden"
+                      ref="eLeftBottom"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-bottom-viewport"
+                      ref="eBottomViewport"
+                      role="presentation"
+                      unselectable="on"
+                    >
+                      
+                
+                      <div
+                        class="ag-floating-bottom-container"
+                        ref="eBottomContainer"
+                        role="presentation"
+                        style="width: 1199px;"
+                        unselectable="on"
+                      />
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-floating-bottom ag-hidden"
+                      ref="eRightBottom"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-bottom-full-width-container ag-hidden"
+                      ref="eBottomFullWidthContainer"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    aria-hidden="true"
+                    class="ag-body-horizontal-scroll"
+                    ref="eHorizontalScrollBody"
+                    style="height: 0px; max-height: 0px; min-height: 0px;"
+                  >
+                    
+            
+                    <div
+                      class="ag-horizontal-left-spacer"
+                      ref="eHorizontalLeftSpacer"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    />
+                    
+            
+                    <div
+                      class="ag-body-horizontal-scroll-viewport"
+                      ref="eBodyHorizontalScrollViewport"
+                      style="height: 0px; max-height: 0px; min-height: 0px;"
+                    >
+                      
+                
+                      <div
+                        class="ag-body-horizontal-scroll-container"
+                        ref="eBodyHorizontalScrollContainer"
+                        style="width: 1199px; height: 0px; max-height: 0px; min-height: 0px;"
+                      />
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-horizontal-right-spacer"
+                      ref="eHorizontalRightSpacer"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <!--AG-OVERLAY-WRAPPER-->
+                  <div
+                    aria-hidden="true"
+                    class="ag-overlay ag-hidden"
+                    ref="overlayWrapper"
+                  >
+                    
+            
+                    <div
+                      class="ag-overlay-panel"
+                    >
+                      
+                
+                      <div
+                        class="ag-overlay-wrapper ag-layout-normal"
+                        ref="eOverlayWrapper"
+                      />
+                      
+            
+                    </div>
+                    
+        
+                  </div>
+                  
+    
+                </div>
+                
+                    
+                
+                <div
+                  class="ag-tab-guard ag-tab-guard-bottom"
+                  role="presentation"
+                  tabindex="0"
+                />
+              </div>
+              
+                
+                
+              <!--AG-PAGINATION-->
+              <div
+                aria-describedby="ag-42-start-page ag-42-start-page-number ag-42-of-page ag-42-of-page-number ag-42-first-row ag-42-to ag-42-last-row ag-42-of ag-42-row-count"
+                aria-live="polite"
+                class="ag-paging-panel ag-unselectable ag-hidden"
+                id="ag-42"
+              >
+                
+                
+                <span
+                  aria-hidden="true"
+                  class="ag-paging-row-summary-panel"
+                >
+                  
+                    
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    id="ag-42-first-row"
+                    ref="lbFirstRowOnPage"
+                  />
+                  
+                    
+                  <span
+                    id="ag-42-to"
+                  >
+                    to
+                  </span>
+                  
+                    
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    id="ag-42-last-row"
+                    ref="lbLastRowOnPage"
+                  />
+                  
+                    
+                  <span
+                    id="ag-42-of"
+                  >
+                    of
+                  </span>
+                  
+                    
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    id="ag-42-row-count"
+                    ref="lbRecordCount"
+                  />
+                  
+                
+                </span>
+                
+                
+                <span
+                  class="ag-paging-page-summary-panel"
+                  role="presentation"
+                >
+                  
+                    
+                  <div
+                    aria-label="First Page"
+                    class="ag-paging-button"
+                    ref="btFirst"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-first"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                    
+                  <div
+                    aria-label="Previous Page"
+                    class="ag-paging-button"
+                    ref="btPrevious"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-previous"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                    
+                  <span
+                    aria-hidden="true"
+                    class="ag-paging-description"
+                  >
+                    
+                        
+                    <span
+                      id="ag-42-start-page"
+                    >
+                      Page
+                    </span>
+                    
+                        
+                    <span
+                      class="ag-paging-number"
+                      id="ag-42-start-page-number"
+                      ref="lbCurrent"
+                    />
+                    
+                        
+                    <span
+                      id="ag-42-of-page"
+                    >
+                      of
+                    </span>
+                    
+                        
+                    <span
+                      class="ag-paging-number"
+                      id="ag-42-of-page-number"
+                      ref="lbTotal"
+                    />
+                    
+                    
+                  </span>
+                  
+                    
+                  <div
+                    aria-label="Next Page"
+                    class="ag-paging-button"
+                    ref="btNext"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-next"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                    
+                  <div
+                    aria-label="Last Page"
+                    class="ag-paging-button"
+                    ref="btLast"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-last"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                
+                </span>
+                
+            
+              </div>
+              
+                
+            
             </div>
           </div>
         </div>
       </div>
-      <button
-        aria-label="Add metric"
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiButton-label"
-        >
-          Assign
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-35 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-48 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1598,7 +5536,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-36 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-49 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1619,13 +5557,13 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-47 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="attr-window-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-48"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
             id="attr-window-panel"
             role="button"
             tabindex="0"
@@ -1689,7 +5627,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                       is the window of time after exposure to an experiment that we capture metric events for a participant (exposure can be from either assignment or specified exposure events). The refund window is the window of time after a purchase event. Revenue metrics will automatically deduct transactions that have been refunded within the metric’s refund window.
                       <br />
                       <div
-                        class="makeStyles-attributionWindowDiagram-37"
+                        class="makeStyles-attributionWindowDiagram-50"
                       >
                         <svg>
                           attribution_window.svg
@@ -1708,7 +5646,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-38 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-51 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1729,13 +5667,13 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-47 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="min-diff-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-48"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
             id="min-diff-panel"
             role="button"
             tabindex="0"
@@ -1799,7 +5737,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
                       are absolute differences from the baseline (not relative). For example, if the baseline conversion rate is 5%, a minimum difference of 0.5 pp is equivalent to a 10% relative change.
                       <br />
                       <div
-                        class="makeStyles-minDiffDiagram-39"
+                        class="makeStyles-minDiffDiagram-52"
                       >
                         <svg>
                           min_diffs.svg
@@ -1815,7 +5753,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-40 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-53 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1845,7 +5783,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-41 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-54 MuiTypography-h4"
     >
       Exposure Events
     </h4>
@@ -1878,11 +5816,11 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-45"
+      class="makeStyles-addMetric-59"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-46"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-60"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -1907,7 +5845,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-42 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-55 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1941,7 +5879,7 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-43 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-56 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -1974,11 +5912,9 @@ exports[`allows adding, editing and removing a Metric Assignment 3`] = `
 `;
 
 exports[`allows adding, editing and removing a Metric Assignment 4`] = `
-<div
-  aria-hidden="true"
->
+<div>
   <div
-    class="makeStyles-root-25"
+    class="makeStyles-root-38"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -2034,17 +5970,17 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
             class="MuiTableRow-root"
           >
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-30"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-43"
             >
               <span
-                class="makeStyles-metricName-31 makeStyles-tooltipped-32"
+                class="makeStyles-metricName-44 makeStyles-tooltipped-45"
                 title="string"
               >
                 asdf_7d_refund
               </span>
               <br />
               <span
-                class="makeStyles-root-49 makeStyles-monospaced-29"
+                class="makeStyles-root-85 makeStyles-monospaced-42"
               >
                 primary
               </span>
@@ -2053,7 +5989,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-28"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-41"
               >
                 <div
                   aria-haspopup="listbox"
@@ -2085,11 +6021,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-50 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-86 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-51"
+                    class="PrivateNotchedOutline-legend-87"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -2100,7 +6036,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-34"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-47"
             >
               <span
                 class="MuiSwitch-root"
@@ -2108,7 +6044,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-54 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-55 Mui-checked"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-90 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-91 Mui-checked"
                   variant="outlined"
                 >
                   <span
@@ -2116,7 +6052,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input-57 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-93 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -2139,7 +6075,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-root-58 makeStyles-minDifferenceField-33"
+                class="MuiFormControl-root MuiTextField-root makeStyles-root-94 makeStyles-minDifferenceField-46"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
@@ -2156,7 +6092,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                     value="0.01"
                   />
                   <div
-                    class="MuiInputAdornment-root makeStyles-adornment-60 MuiInputAdornment-positionEnd"
+                    class="MuiInputAdornment-root makeStyles-adornment-96 MuiInputAdornment-positionEnd"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
@@ -2166,11 +6102,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                   </div>
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-50 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-86 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-51"
+                      class="PrivateNotchedOutline-legend-87"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -2218,122 +6154,1430 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-45"
+      class="makeStyles-tableContainer-58"
     >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-46"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-        />
-      </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-27"
+        class="ag-theme-alpine makeStyles-root-62"
       >
         <div
-          aria-expanded="false"
-          aria-label="Select a metric"
-          class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-          role="combobox"
+          class="makeStyles-toolbar-63"
         >
           <div
-            class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+            class="makeStyles-rootFullWidth-66"
           >
             <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+              class="makeStyles-search-67"
             >
-              <input
-                aria-autocomplete="list"
-                aria-invalid="false"
-                autocapitalize="none"
-                autocomplete="off"
-                class="MuiInputBase-input MuiInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd"
-                id="add-metric-select"
-                placeholder="Select a metric"
-                required=""
-                spellcheck="false"
-                type="text"
-                value=""
-              />
               <div
-                class="MuiAutocomplete-endAdornment"
+                class="makeStyles-searchIcon-68"
               >
-                <button
-                  aria-label="Clear"
-                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
-                  tabindex="-1"
-                  title="Clear"
-                  type="button"
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
                 >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
+                  <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
                   />
-                </button>
-                <button
-                  aria-label="Open"
-                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
-                  tabindex="-1"
-                  title="Open"
-                  type="button"
-                >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M7 10l5 5 5-5z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
-                  />
-                </button>
+                </svg>
               </div>
+              <div
+                class="MuiInputBase-root makeStyles-inputRootFullWidth-69"
+              >
+                <input
+                  aria-label="Search"
+                  class="MuiInputBase-input makeStyles-inputInputFullWidth-70"
+                  placeholder="Search…"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                 Reset 
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+        </div>
+        <div
+          class="ag-theme-alpine makeStyles-gridContainer-64"
+        >
+          <div
+            style="height: auto; flex: 1;"
+          >
+            <div
+              class="ag-root-wrapper ag-layout-normal ag-ltr"
+              ref="eRootWrapper"
+            >
+              
+                
+                
+              <div
+                class="ag-root-wrapper-body ag-layout-normal ag-focus-managed"
+                ref="rootWrapperBody"
+              >
+                <div
+                  class="ag-tab-guard ag-tab-guard-top"
+                  role="presentation"
+                  tabindex="0"
+                />
+                
+                    
+                <!--AG-GRID-COMP-->
+                <div
+                  aria-colcount="7"
+                  aria-rowcount="3"
+                  class="ag-root ag-unselectable ag-layout-normal"
+                  ref="gridPanel"
+                  role="grid"
+                  unselectable="on"
+                >
+                  
+        
+                  <!--AG-HEADER-ROOT-->
+                  <div
+                    class="ag-header ag-focus-managed ag-pivot-off"
+                    ref="headerRoot"
+                    role="presentation"
+                    style="height: 49px; min-height: 49px;"
+                    unselectable="on"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-header ag-hidden"
+                      ref="ePinnedLeftHeader"
+                      role="presentation"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-column"
+                        role="row"
+                        style="top: 0px; height: 48px; width: 0px;"
+                      />
+                    </div>
+                    
+            
+                    <div
+                      class="ag-header-viewport"
+                      ref="eHeaderViewport"
+                      role="presentation"
+                    >
+                      
+                
+                      <div
+                        class="ag-header-container"
+                        ref="eHeaderContainer"
+                        role="rowgroup"
+                        style="width: 1199px;"
+                      >
+                        <div
+                          aria-rowindex="1"
+                          class="ag-header-row ag-header-row-column"
+                          role="row"
+                          style="top: 0px; height: 48px; width: 1199px;"
+                        >
+                          <div
+                            aria-colindex="1"
+                            class="ag-header-cell ag-focus-managed"
+                            col-id="__detail-button-col__"
+                            role="columnheader"
+                            style="width: 34px; left: 0px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize ag-hidden"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-47-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container"
+                              role="presentation"
+                            >
+                              
+            
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                />
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                
+                
+                                
+                
+                                
+                
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="2"
+                            aria-sort="ascending"
+                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-61"
+                            col-id="name"
+                            role="columnheader"
+                            style="width: 465px; left: 34px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-50-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container ag-header-cell-sorted-asc"
+                              role="presentation"
+                            >
+                              
+            
+                              <span
+                                aria-hidden="true"
+                                class="ag-header-icon ag-header-cell-menu-button"
+                                ref="eMenu"
+                              >
+                                <span
+                                  class="ag-icon ag-icon-menu"
+                                  role="presentation"
+                                  unselectable="on"
+                                />
+                              </span>
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                >
+                                  Name
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-order ag-hidden"
+                                  ref="eSortOrder"
+                                >
+                                  1
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-ascending-icon"
+                                  ref="eSortAsc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-asc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-descending-icon ag-hidden"
+                                  ref="eSortDesc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-desc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-none-icon ag-hidden"
+                                  ref="eSortNone"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-none"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="3"
+                            aria-sort="none"
+                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable"
+                            col-id="description"
+                            role="columnheader"
+                            style="width: 550px; left: 499px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-53-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container ag-header-cell-sorted-none"
+                              role="presentation"
+                            >
+                              
+            
+                              <span
+                                aria-hidden="true"
+                                class="ag-header-icon ag-header-cell-menu-button"
+                                ref="eMenu"
+                              >
+                                <span
+                                  class="ag-icon ag-icon-menu"
+                                  role="presentation"
+                                  unselectable="on"
+                                />
+                              </span>
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                >
+                                  Description
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-order ag-hidden"
+                                  ref="eSortOrder"
+                                />
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-ascending-icon ag-hidden"
+                                  ref="eSortAsc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-asc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-descending-icon ag-hidden"
+                                  ref="eSortDesc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-desc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-none-icon ag-hidden"
+                                  ref="eSortNone"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-none"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="7"
+                            class="ag-header-cell ag-focus-managed"
+                            col-id="metrics-assign--actions"
+                            role="columnheader"
+                            style="width: 150px; left: 1049px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize ag-hidden"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-56-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container"
+                              role="presentation"
+                            >
+                              
+            
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                >
+                                  Actions
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                
+                
+                                
+                
+                                
+                
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-header ag-hidden"
+                      ref="ePinnedRightHeader"
+                      role="presentation"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-column"
+                        role="row"
+                        style="top: 0px; height: 48px; width: 0px;"
+                      />
+                    </div>
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    class="ag-floating-top"
+                    ref="eTop"
+                    role="presentation"
+                    style="min-height: 0px; height: 0px; display: none; overflow-y: hidden;"
+                    unselectable="on"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-floating-top ag-hidden"
+                      ref="eLeftTop"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-top-viewport"
+                      ref="eTopViewport"
+                      role="presentation"
+                      unselectable="on"
+                    >
+                      
+                
+                      <div
+                        class="ag-floating-top-container"
+                        ref="eTopContainer"
+                        role="presentation"
+                        style="width: 1199px;"
+                        unselectable="on"
+                      />
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-floating-top ag-hidden"
+                      ref="eRightTop"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-top-full-width-container ag-hidden"
+                      ref="eTopFullWidthContainer"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    class="ag-body-viewport ag-layout-normal ag-row-no-animation"
+                    ref="eBodyViewport"
+                    role="presentation"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-cols-container ag-hidden"
+                      ref="eLeftContainer"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    >
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="2"
+                        class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                        comp-id="66"
+                        role="row"
+                        row-id="asdf_7d_refund"
+                        row-index="0"
+                        style="height: 42px; transform: translateY(0px);"
+                      />
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="3"
+                        class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute ag-row-last"
+                        comp-id="71"
+                        role="row"
+                        row-id="registration_start"
+                        row-index="1"
+                        style="height: 42px; transform: translateY(42px);"
+                      />
+                    </div>
+                    
+            
+                    <div
+                      class="ag-center-cols-clipper"
+                      ref="eCenterColsClipper"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    >
+                      
+                
+                      <div
+                        class="ag-center-cols-viewport"
+                        ref="eCenterViewport"
+                        role="presentation"
+                        style="height: calc(100% + 0px);"
+                      >
+                        
+                    
+                        <div
+                          class="ag-center-cols-container"
+                          ref="eCenterContainer"
+                          role="rowgroup"
+                          style="width: 1199px; height: 84px;"
+                          unselectable="on"
+                        >
+                          <div
+                            aria-label="Press SPACE to select this row."
+                            aria-rowindex="2"
+                            class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                            comp-id="66"
+                            role="row"
+                            row-id="asdf_7d_refund"
+                            row-index="0"
+                            style="height: 42px; transform: translateY(0px);"
+                          >
+                            <div
+                              aria-colindex="1"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="__detail-button-col__"
+                              comp-id="67"
+                              role="gridcell"
+                              style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <button
+                                  aria-label="Toggle Button"
+                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-75 makeStyles-notRotated-77 MuiIconButton-sizeSmall"
+                                  tabindex="0"
+                                  type="button"
+                                >
+                                  <span
+                                    class="MuiIconButton-label"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="2"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="name"
+                              comp-id="68"
+                              role="gridcell"
+                              style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <div
+                                  class="makeStyles-metricName-78"
+                                  title="asdf_7d_refund"
+                                >
+                                  asdf_7d_refund
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="3"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="description"
+                              comp-id="69"
+                              role="gridcell"
+                              style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              string
+                            </div>
+                            <div
+                              aria-colindex="7"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="metrics-assign--actions"
+                              comp-id="70"
+                              role="gridcell"
+                              style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <div
+                                  class="makeStyles-root-79"
+                                >
+                                  <button
+                                    aria-label="Assign metric"
+                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-83 MuiButton-contained makeStyles-noWrap-80 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+                                    tabindex="0"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="MuiButton-label"
+                                    >
+                                      <span
+                                        class="MuiButton-startIcon MuiButton-iconSizeSmall"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      Assign Metric
+                                    </span>
+                                    <span
+                                      class="MuiTouchRipple-root"
+                                    />
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-label="Press SPACE to select this row."
+                            aria-rowindex="3"
+                            class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute ag-row-last"
+                            comp-id="71"
+                            role="row"
+                            row-id="registration_start"
+                            row-index="1"
+                            style="height: 42px; transform: translateY(42px);"
+                          >
+                            <div
+                              aria-colindex="1"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="__detail-button-col__"
+                              comp-id="72"
+                              role="gridcell"
+                              style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <button
+                                  aria-label="Toggle Button"
+                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-75 makeStyles-notRotated-77 MuiIconButton-sizeSmall"
+                                  tabindex="0"
+                                  type="button"
+                                >
+                                  <span
+                                    class="MuiIconButton-label"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="2"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="name"
+                              comp-id="73"
+                              role="gridcell"
+                              style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <div
+                                  class="makeStyles-metricName-78"
+                                  title="registration_start"
+                                >
+                                  registration_start
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="3"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="description"
+                              comp-id="74"
+                              role="gridcell"
+                              style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              string
+                            </div>
+                            <div
+                              aria-colindex="7"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="metrics-assign--actions"
+                              comp-id="75"
+                              role="gridcell"
+                              style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <div
+                                  class="makeStyles-root-79"
+                                >
+                                  <button
+                                    aria-label="Assign metric"
+                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-84 MuiButton-contained makeStyles-noWrap-80 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+                                    tabindex="0"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="MuiButton-label"
+                                    >
+                                      <span
+                                        class="MuiButton-startIcon MuiButton-iconSizeSmall"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      Assign Metric
+                                    </span>
+                                    <span
+                                      class="MuiTouchRipple-root"
+                                    />
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        
+                
+                      </div>
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-cols-container ag-hidden"
+                      ref="eRightContainer"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    >
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="2"
+                        class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                        comp-id="66"
+                        role="row"
+                        row-id="asdf_7d_refund"
+                        row-index="0"
+                        style="height: 42px; transform: translateY(0px);"
+                      />
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="3"
+                        class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute ag-row-last"
+                        comp-id="71"
+                        role="row"
+                        row-id="registration_start"
+                        row-index="1"
+                        style="height: 42px; transform: translateY(42px);"
+                      />
+                    </div>
+                    
+            
+                    <div
+                      class="ag-full-width-container"
+                      ref="eFullWidthContainer"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    class="ag-floating-bottom"
+                    ref="eBottom"
+                    role="presentation"
+                    style="min-height: 0px; height: 0px; display: none; overflow-y: hidden;"
+                    unselectable="on"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-floating-bottom ag-hidden"
+                      ref="eLeftBottom"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-bottom-viewport"
+                      ref="eBottomViewport"
+                      role="presentation"
+                      unselectable="on"
+                    >
+                      
+                
+                      <div
+                        class="ag-floating-bottom-container"
+                        ref="eBottomContainer"
+                        role="presentation"
+                        style="width: 1199px;"
+                        unselectable="on"
+                      />
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-floating-bottom ag-hidden"
+                      ref="eRightBottom"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-bottom-full-width-container ag-hidden"
+                      ref="eBottomFullWidthContainer"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    aria-hidden="true"
+                    class="ag-body-horizontal-scroll"
+                    ref="eHorizontalScrollBody"
+                    style="height: 0px; max-height: 0px; min-height: 0px;"
+                  >
+                    
+            
+                    <div
+                      class="ag-horizontal-left-spacer"
+                      ref="eHorizontalLeftSpacer"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    />
+                    
+            
+                    <div
+                      class="ag-body-horizontal-scroll-viewport"
+                      ref="eBodyHorizontalScrollViewport"
+                      style="height: 0px; max-height: 0px; min-height: 0px;"
+                    >
+                      
+                
+                      <div
+                        class="ag-body-horizontal-scroll-container"
+                        ref="eBodyHorizontalScrollContainer"
+                        style="width: 1199px; height: 0px; max-height: 0px; min-height: 0px;"
+                      />
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-horizontal-right-spacer"
+                      ref="eHorizontalRightSpacer"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <!--AG-OVERLAY-WRAPPER-->
+                  <div
+                    aria-hidden="true"
+                    class="ag-overlay ag-hidden"
+                    ref="overlayWrapper"
+                  >
+                    
+            
+                    <div
+                      class="ag-overlay-panel"
+                    >
+                      
+                
+                      <div
+                        class="ag-overlay-wrapper ag-layout-normal"
+                        ref="eOverlayWrapper"
+                      />
+                      
+            
+                    </div>
+                    
+        
+                  </div>
+                  
+    
+                </div>
+                
+                    
+                
+                <div
+                  class="ag-tab-guard ag-tab-guard-bottom"
+                  role="presentation"
+                  tabindex="0"
+                />
+              </div>
+              
+                
+                
+              <!--AG-PAGINATION-->
+              <div
+                aria-describedby="ag-42-start-page ag-42-start-page-number ag-42-of-page ag-42-of-page-number ag-42-first-row ag-42-to ag-42-last-row ag-42-of ag-42-row-count"
+                aria-live="polite"
+                class="ag-paging-panel ag-unselectable ag-hidden"
+                id="ag-42"
+              >
+                
+                
+                <span
+                  aria-hidden="true"
+                  class="ag-paging-row-summary-panel"
+                >
+                  
+                    
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    id="ag-42-first-row"
+                    ref="lbFirstRowOnPage"
+                  />
+                  
+                    
+                  <span
+                    id="ag-42-to"
+                  >
+                    to
+                  </span>
+                  
+                    
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    id="ag-42-last-row"
+                    ref="lbLastRowOnPage"
+                  />
+                  
+                    
+                  <span
+                    id="ag-42-of"
+                  >
+                    of
+                  </span>
+                  
+                    
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    id="ag-42-row-count"
+                    ref="lbRecordCount"
+                  />
+                  
+                
+                </span>
+                
+                
+                <span
+                  class="ag-paging-page-summary-panel"
+                  role="presentation"
+                >
+                  
+                    
+                  <div
+                    aria-label="First Page"
+                    class="ag-paging-button"
+                    ref="btFirst"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-first"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                    
+                  <div
+                    aria-label="Previous Page"
+                    class="ag-paging-button"
+                    ref="btPrevious"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-previous"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                    
+                  <span
+                    aria-hidden="true"
+                    class="ag-paging-description"
+                  >
+                    
+                        
+                    <span
+                      id="ag-42-start-page"
+                    >
+                      Page
+                    </span>
+                    
+                        
+                    <span
+                      class="ag-paging-number"
+                      id="ag-42-start-page-number"
+                      ref="lbCurrent"
+                    />
+                    
+                        
+                    <span
+                      id="ag-42-of-page"
+                    >
+                      of
+                    </span>
+                    
+                        
+                    <span
+                      class="ag-paging-number"
+                      id="ag-42-of-page-number"
+                      ref="lbTotal"
+                    />
+                    
+                    
+                  </span>
+                  
+                    
+                  <div
+                    aria-label="Next Page"
+                    class="ag-paging-button"
+                    ref="btNext"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-next"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                    
+                  <div
+                    aria-label="Last Page"
+                    class="ag-paging-button"
+                    ref="btLast"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-last"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                
+                </span>
+                
+            
+              </div>
+              
+                
+            
             </div>
           </div>
         </div>
       </div>
-      <button
-        aria-label="Add metric"
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiButton-label"
-        >
-          Assign
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-35 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-48 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -2371,7 +7615,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-36 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-49 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -2392,13 +7636,13 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-47 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="attr-window-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-48"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
             id="attr-window-panel"
             role="button"
             tabindex="0"
@@ -2462,7 +7706,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                       is the window of time after exposure to an experiment that we capture metric events for a participant (exposure can be from either assignment or specified exposure events). The refund window is the window of time after a purchase event. Revenue metrics will automatically deduct transactions that have been refunded within the metric’s refund window.
                       <br />
                       <div
-                        class="makeStyles-attributionWindowDiagram-37"
+                        class="makeStyles-attributionWindowDiagram-50"
                       >
                         <svg>
                           attribution_window.svg
@@ -2481,7 +7725,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-38 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-51 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -2502,13 +7746,13 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-47 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="min-diff-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-48"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
             id="min-diff-panel"
             role="button"
             tabindex="0"
@@ -2572,7 +7816,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
                       are absolute differences from the baseline (not relative). For example, if the baseline conversion rate is 5%, a minimum difference of 0.5 pp is equivalent to a 10% relative change.
                       <br />
                       <div
-                        class="makeStyles-minDiffDiagram-39"
+                        class="makeStyles-minDiffDiagram-52"
                       >
                         <svg>
                           min_diffs.svg
@@ -2588,7 +7832,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-40 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-53 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -2618,7 +7862,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-41 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-54 MuiTypography-h4"
     >
       Exposure Events
     </h4>
@@ -2651,11 +7895,11 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-45"
+      class="makeStyles-addMetric-59"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-46"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-60"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -2680,7 +7924,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-42 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-55 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -2714,7 +7958,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-43 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-56 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -2749,778 +7993,7 @@ exports[`allows adding, editing and removing a Metric Assignment 4`] = `
 exports[`allows adding, editing and removing a Metric Assignment 5`] = `
 <div>
   <div
-    class="makeStyles-root-25"
-  >
-    <h4
-      class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
-    >
-      Assign Metrics
-    </h4>
-    <div
-      class="MuiTableContainer-root"
-    >
-      <table
-        class="MuiTable-root"
-      >
-        <thead
-          class="MuiTableHead-root"
-        >
-          <tr
-            class="MuiTableRow-root MuiTableRow-head"
-          >
-            <th
-              class="MuiTableCell-root MuiTableCell-head"
-              scope="col"
-            >
-              Metric
-            </th>
-            <th
-              class="MuiTableCell-root MuiTableCell-head"
-              scope="col"
-            >
-              Attribution Window
-            </th>
-            <th
-              class="MuiTableCell-root MuiTableCell-head"
-              scope="col"
-            >
-              Change Expected?
-            </th>
-            <th
-              class="MuiTableCell-root MuiTableCell-head"
-              scope="col"
-            >
-              Minimum Practical Difference
-            </th>
-            <th
-              class="MuiTableCell-root MuiTableCell-head"
-              scope="col"
-            />
-          </tr>
-        </thead>
-        <tbody
-          class="MuiTableBody-root"
-        >
-          <tr
-            class="MuiTableRow-root"
-          >
-            <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-30"
-            >
-              <span
-                class="makeStyles-metricName-31 makeStyles-tooltipped-32"
-                title="string"
-              >
-                asdf_7d_refund
-              </span>
-              <br />
-              <span
-                class="makeStyles-root-49 makeStyles-monospaced-29"
-              >
-                primary
-              </span>
-            </td>
-            <td
-              class="MuiTableCell-root MuiTableCell-body"
-            >
-              <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-28"
-              >
-                <div
-                  aria-haspopup="listbox"
-                  aria-label="Attribution Window"
-                  aria-labelledby="experiment.metricAssignments[0].attributionWindowSeconds mui-component-select-experiment.metricAssignments[0].attributionWindowSeconds"
-                  class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
-                  id="mui-component-select-experiment.metricAssignments[0].attributionWindowSeconds"
-                  role="button"
-                  tabindex="0"
-                >
-                  -
-                </div>
-                <input
-                  aria-hidden="true"
-                  class="MuiSelect-nativeInput"
-                  name="experiment.metricAssignments[0].attributionWindowSeconds"
-                  tabindex="-1"
-                  value=""
-                />
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M7 10l5 5 5-5z"
-                  />
-                </svg>
-                <fieldset
-                  aria-hidden="true"
-                  class="PrivateNotchedOutline-root-50 MuiOutlinedInput-notchedOutline"
-                  style="padding-left: 8px;"
-                >
-                  <legend
-                    class="PrivateNotchedOutline-legend-51"
-                    style="width: 0.01px;"
-                  >
-                    <span>
-                      ​
-                    </span>
-                  </legend>
-                </fieldset>
-              </div>
-            </td>
-            <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-34"
-            >
-              <span
-                class="MuiSwitch-root"
-              >
-                <span
-                  aria-disabled="false"
-                  aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-54 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-55 Mui-checked"
-                  variant="outlined"
-                >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <input
-                      checked=""
-                      class="PrivateSwitchBase-input-57 MuiSwitch-input"
-                      id="experiment.metricAssignments[0].changeExpected"
-                      name="experiment.metricAssignments[0].changeExpected"
-                      type="checkbox"
-                      value="true"
-                    />
-                    <span
-                      class="MuiSwitch-thumb"
-                    />
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
-                  />
-                </span>
-                <span
-                  class="MuiSwitch-track"
-                />
-              </span>
-            </td>
-            <td
-              class="MuiTableCell-root MuiTableCell-body"
-            >
-              <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-root-58 makeStyles-minDifferenceField-33"
-              >
-                <div
-                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
-                >
-                  <input
-                    aria-invalid="false"
-                    aria-label="Minimum Difference"
-                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
-                    id="experiment.metricAssignments[0].minDifference"
-                    min="0"
-                    name="experiment.metricAssignments[0].minDifference"
-                    placeholder="1.30"
-                    type="number"
-                    value="0.01"
-                  />
-                  <div
-                    class="MuiInputAdornment-root makeStyles-adornment-60 MuiInputAdornment-positionEnd"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
-                    >
-                      USD
-                    </p>
-                  </div>
-                  <fieldset
-                    aria-hidden="true"
-                    class="PrivateNotchedOutline-root-50 MuiOutlinedInput-notchedOutline"
-                    style="padding-left: 8px;"
-                  >
-                    <legend
-                      class="PrivateNotchedOutline-legend-51"
-                      style="width: 0.01px;"
-                    >
-                      <span>
-                        ​
-                      </span>
-                    </legend>
-                  </fieldset>
-                </div>
-              </div>
-            </td>
-            <td
-              class="MuiTableCell-root MuiTableCell-body"
-            >
-              <div>
-                <button
-                  aria-controls="menu"
-                  aria-haspopup="true"
-                  aria-label="more"
-                  class="MuiButtonBase-root MuiIconButton-root"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    <div
-      class="makeStyles-addMetric-45"
-    >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-46"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-        />
-      </svg>
-      <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-27"
-      >
-        <div
-          aria-expanded="false"
-          aria-label="Select a metric"
-          class="MuiAutocomplete-root Mui-focused MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-          role="combobox"
-        >
-          <div
-            class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
-          >
-            <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInput-fullWidth Mui-focused Mui-focused MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
-            >
-              <input
-                aria-autocomplete="list"
-                aria-invalid="false"
-                autocapitalize="none"
-                autocomplete="off"
-                class="MuiInputBase-input MuiInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd"
-                id="add-metric-select"
-                placeholder="Select a metric"
-                required=""
-                spellcheck="false"
-                type="text"
-                value=""
-              />
-              <div
-                class="MuiAutocomplete-endAdornment"
-              >
-                <button
-                  aria-label="Clear"
-                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
-                  tabindex="-1"
-                  title="Clear"
-                  type="button"
-                >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
-                  />
-                </button>
-                <button
-                  aria-label="Open"
-                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
-                  tabindex="-1"
-                  title="Open"
-                  type="button"
-                >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M7 10l5 5 5-5z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <button
-        aria-label="Add metric"
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiButton-label"
-        >
-          Assign
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
-    </div>
-    <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-35 MuiPaper-elevation0"
-      role="alert"
-    >
-      <div
-        class="MuiAlert-icon"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
-          />
-        </svg>
-      </div>
-      <div
-        class="MuiAlert-message"
-      >
-        <a
-          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
-          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-primary-metric"
-          target="_blank"
-        >
-          How do I choose a Primary Metric?
-        </a>
-         
-        <a
-          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
-          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-does-change-expected-mean-for-a-metric"
-          target="_blank"
-        >
-          What is Change Expected?
-        </a>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-36 MuiPaper-elevation0"
-      role="alert"
-    >
-      <div
-        class="MuiAlert-icon"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
-          />
-        </svg>
-      </div>
-      <div
-        class="MuiAlert-message"
-      >
-        <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-47 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
-        >
-          <div
-            aria-controls="attr-window-panel-content"
-            aria-disabled="false"
-            aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-48"
-            id="attr-window-panel"
-            role="button"
-            tabindex="0"
-          >
-            <div
-              class="MuiAccordionSummary-content"
-            >
-              What is an Attribution Window?
-            </div>
-            <div
-              aria-disabled="false"
-              aria-hidden="true"
-              class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
-            >
-              <span
-                class="MuiIconButton-label"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
-                  />
-                </svg>
-              </span>
-              <span
-                class="MuiTouchRipple-root"
-              />
-            </div>
-          </div>
-          <div
-            class="MuiCollapse-container MuiCollapse-hidden"
-            style="min-height: 0px;"
-          >
-            <div
-              class="MuiCollapse-wrapper"
-            >
-              <div
-                class="MuiCollapse-wrapperInner"
-              >
-                <div
-                  aria-labelledby="attr-window-panel"
-                  id="attr-window-panel-content"
-                  role="region"
-                >
-                  <div
-                    class="MuiAccordionDetails-root"
-                  >
-                    <div>
-                      <a
-                        class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
-                        href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-attribution-window-for-a-metric"
-                        target="_blank"
-                      >
-                        An Attribution Window
-                      </a>
-                       
-                      is the window of time after exposure to an experiment that we capture metric events for a participant (exposure can be from either assignment or specified exposure events). The refund window is the window of time after a purchase event. Revenue metrics will automatically deduct transactions that have been refunded within the metric’s refund window.
-                      <br />
-                      <div
-                        class="makeStyles-attributionWindowDiagram-37"
-                      >
-                        <svg>
-                          attribution_window.svg
-                        </svg>
-                        <svg>
-                          refund_window.svg
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-38 MuiPaper-elevation0"
-      role="alert"
-    >
-      <div
-        class="MuiAlert-icon"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
-          />
-        </svg>
-      </div>
-      <div
-        class="MuiAlert-message"
-      >
-        <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-47 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
-        >
-          <div
-            aria-controls="min-diff-panel-content"
-            aria-disabled="false"
-            aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-48"
-            id="min-diff-panel"
-            role="button"
-            tabindex="0"
-          >
-            <div
-              class="MuiAccordionSummary-content"
-            >
-              How do I choose a Minimum Difference?
-            </div>
-            <div
-              aria-disabled="false"
-              aria-hidden="true"
-              class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiIconButton-edgeEnd"
-            >
-              <span
-                class="MuiIconButton-label"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
-                  />
-                </svg>
-              </span>
-              <span
-                class="MuiTouchRipple-root"
-              />
-            </div>
-          </div>
-          <div
-            class="MuiCollapse-container MuiCollapse-hidden"
-            style="min-height: 0px;"
-          >
-            <div
-              class="MuiCollapse-wrapper"
-            >
-              <div
-                class="MuiCollapse-wrapperInner"
-              >
-                <div
-                  aria-labelledby="min-diff-panel"
-                  id="min-diff-panel-content"
-                  role="region"
-                >
-                  <div
-                    class="MuiAccordionDetails-root"
-                  >
-                    <div>
-                      <a
-                        class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
-                        href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#how-do-i-choose-a-minimum-difference-practically-equivalent-value-for-my-metrics"
-                        target="_blank"
-                      >
-                        Minimum Practical Difference values
-                      </a>
-                       
-                      are absolute differences from the baseline (not relative). For example, if the baseline conversion rate is 5%, a minimum difference of 0.5 pp is equivalent to a 10% relative change.
-                      <br />
-                      <div
-                        class="makeStyles-minDiffDiagram-39"
-                      >
-                        <svg>
-                          min_diffs.svg
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-40 MuiPaper-elevation0"
-      role="alert"
-    >
-      <div
-        class="MuiAlert-icon"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
-          />
-        </svg>
-      </div>
-      <div
-        class="MuiAlert-message"
-      >
-        <a
-          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
-          href="https://betterexperiments.wordpress.com/?start=metric-request"
-          target="_blank"
-        >
-          Can't find a metric? Request one!
-        </a>
-      </div>
-    </div>
-    <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-41 MuiTypography-h4"
-    >
-      Exposure Events
-    </h4>
-    <div
-      class="MuiTableContainer-root"
-    >
-      <table
-        class="MuiTable-root"
-      >
-        <tbody
-          class="MuiTableBody-root"
-        >
-          <tr
-            class="MuiTableRow-root"
-          >
-            <td
-              class="MuiTableCell-root MuiTableCell-body"
-              colspan="1"
-            >
-              <p
-                class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter"
-              >
-                You don't have any exposure events.
-                <br />
-                We strongly suggest considering adding one to improve the accuracy of your metrics.
-              </p>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    <div
-      class="makeStyles-addMetric-45"
-    >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-46"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-        />
-      </svg>
-      <button
-        aria-label="Add exposure event"
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiButton-label"
-        >
-          Add Event
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
-    </div>
-    <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-42 MuiPaper-elevation0"
-      role="alert"
-    >
-      <div
-        class="MuiAlert-icon"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
-          />
-        </svg>
-      </div>
-      <div
-        class="MuiAlert-message"
-      >
-        <a
-          class="MuiTypography-root MuiLink-root MuiLink-underlineAlways MuiTypography-colorPrimary"
-          href="https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#what-is-an-exposure-event-and-when-do-i-need-it"
-          target="_blank"
-        >
-          What is an Exposure Event? And when do I need it?
-        </a>
-        <br />
-        <span>
-          Only validated events can be used as exposure events.
-        </span>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-43 MuiPaper-elevation0"
-      role="alert"
-    >
-      <div
-        class="MuiAlert-icon"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
-          />
-        </svg>
-      </div>
-      <div
-        class="MuiAlert-message"
-      >
-        If you have multiple exposure events, then participants will be considered exposed if they trigger
-         
-        <strong>
-          any
-        </strong>
-         of the exposure events.
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`allows adding, editing and removing a Metric Assignment 6`] = `
-<div>
-  <div
-    class="makeStyles-root-25"
+    class="makeStyles-root-38"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -3590,122 +8063,1430 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-45"
+      class="makeStyles-tableContainer-58"
     >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-46"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-        />
-      </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-27"
+        class="ag-theme-alpine makeStyles-root-62"
       >
         <div
-          aria-expanded="false"
-          aria-label="Select a metric"
-          class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-          role="combobox"
+          class="makeStyles-toolbar-63"
         >
           <div
-            class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+            class="makeStyles-rootFullWidth-66"
           >
             <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+              class="makeStyles-search-67"
             >
-              <input
-                aria-autocomplete="list"
-                aria-invalid="false"
-                autocapitalize="none"
-                autocomplete="off"
-                class="MuiInputBase-input MuiInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd"
-                id="add-metric-select"
-                placeholder="Select a metric"
-                required=""
-                spellcheck="false"
-                type="text"
-                value=""
-              />
               <div
-                class="MuiAutocomplete-endAdornment"
+                class="makeStyles-searchIcon-68"
               >
-                <button
-                  aria-label="Clear"
-                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
-                  tabindex="-1"
-                  title="Clear"
-                  type="button"
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
                 >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
+                  <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
                   />
-                </button>
-                <button
-                  aria-label="Open"
-                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
-                  tabindex="-1"
-                  title="Open"
-                  type="button"
-                >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M7 10l5 5 5-5z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
-                  />
-                </button>
+                </svg>
               </div>
+              <div
+                class="MuiInputBase-root makeStyles-inputRootFullWidth-69"
+              >
+                <input
+                  aria-label="Search"
+                  class="MuiInputBase-input makeStyles-inputInputFullWidth-70"
+                  placeholder="Search…"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                 Reset 
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+        </div>
+        <div
+          class="ag-theme-alpine makeStyles-gridContainer-64"
+        >
+          <div
+            style="height: auto; flex: 1;"
+          >
+            <div
+              class="ag-root-wrapper ag-layout-normal ag-ltr"
+              ref="eRootWrapper"
+            >
+              
+                
+                
+              <div
+                class="ag-root-wrapper-body ag-layout-normal ag-focus-managed"
+                ref="rootWrapperBody"
+              >
+                <div
+                  class="ag-tab-guard ag-tab-guard-top"
+                  role="presentation"
+                  tabindex="0"
+                />
+                
+                    
+                <!--AG-GRID-COMP-->
+                <div
+                  aria-colcount="7"
+                  aria-rowcount="3"
+                  class="ag-root ag-unselectable ag-layout-normal"
+                  ref="gridPanel"
+                  role="grid"
+                  unselectable="on"
+                >
+                  
+        
+                  <!--AG-HEADER-ROOT-->
+                  <div
+                    class="ag-header ag-focus-managed ag-pivot-off"
+                    ref="headerRoot"
+                    role="presentation"
+                    style="height: 49px; min-height: 49px;"
+                    unselectable="on"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-header ag-hidden"
+                      ref="ePinnedLeftHeader"
+                      role="presentation"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-column"
+                        role="row"
+                        style="top: 0px; height: 48px; width: 0px;"
+                      />
+                    </div>
+                    
+            
+                    <div
+                      class="ag-header-viewport"
+                      ref="eHeaderViewport"
+                      role="presentation"
+                    >
+                      
+                
+                      <div
+                        class="ag-header-container"
+                        ref="eHeaderContainer"
+                        role="rowgroup"
+                        style="width: 1199px;"
+                      >
+                        <div
+                          aria-rowindex="1"
+                          class="ag-header-row ag-header-row-column"
+                          role="row"
+                          style="top: 0px; height: 48px; width: 1199px;"
+                        >
+                          <div
+                            aria-colindex="1"
+                            class="ag-header-cell ag-focus-managed"
+                            col-id="__detail-button-col__"
+                            role="columnheader"
+                            style="width: 34px; left: 0px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize ag-hidden"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-47-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container"
+                              role="presentation"
+                            >
+                              
+            
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                />
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                
+                
+                                
+                
+                                
+                
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="2"
+                            aria-sort="ascending"
+                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-61"
+                            col-id="name"
+                            role="columnheader"
+                            style="width: 465px; left: 34px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-50-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container ag-header-cell-sorted-asc"
+                              role="presentation"
+                            >
+                              
+            
+                              <span
+                                aria-hidden="true"
+                                class="ag-header-icon ag-header-cell-menu-button"
+                                ref="eMenu"
+                              >
+                                <span
+                                  class="ag-icon ag-icon-menu"
+                                  role="presentation"
+                                  unselectable="on"
+                                />
+                              </span>
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                >
+                                  Name
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-order ag-hidden"
+                                  ref="eSortOrder"
+                                >
+                                  1
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-ascending-icon"
+                                  ref="eSortAsc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-asc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-descending-icon ag-hidden"
+                                  ref="eSortDesc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-desc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-none-icon ag-hidden"
+                                  ref="eSortNone"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-none"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="3"
+                            aria-sort="none"
+                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable"
+                            col-id="description"
+                            role="columnheader"
+                            style="width: 550px; left: 499px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-53-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container ag-header-cell-sorted-none"
+                              role="presentation"
+                            >
+                              
+            
+                              <span
+                                aria-hidden="true"
+                                class="ag-header-icon ag-header-cell-menu-button"
+                                ref="eMenu"
+                              >
+                                <span
+                                  class="ag-icon ag-icon-menu"
+                                  role="presentation"
+                                  unselectable="on"
+                                />
+                              </span>
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                >
+                                  Description
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-order ag-hidden"
+                                  ref="eSortOrder"
+                                />
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-ascending-icon ag-hidden"
+                                  ref="eSortAsc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-asc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-descending-icon ag-hidden"
+                                  ref="eSortDesc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-desc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-none-icon ag-hidden"
+                                  ref="eSortNone"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-none"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="7"
+                            class="ag-header-cell ag-focus-managed"
+                            col-id="metrics-assign--actions"
+                            role="columnheader"
+                            style="width: 150px; left: 1049px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize ag-hidden"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-56-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container"
+                              role="presentation"
+                            >
+                              
+            
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                >
+                                  Actions
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                
+                
+                                
+                
+                                
+                
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-header ag-hidden"
+                      ref="ePinnedRightHeader"
+                      role="presentation"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-column"
+                        role="row"
+                        style="top: 0px; height: 48px; width: 0px;"
+                      />
+                    </div>
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    class="ag-floating-top"
+                    ref="eTop"
+                    role="presentation"
+                    style="min-height: 0px; height: 0px; display: none; overflow-y: hidden;"
+                    unselectable="on"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-floating-top ag-hidden"
+                      ref="eLeftTop"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-top-viewport"
+                      ref="eTopViewport"
+                      role="presentation"
+                      unselectable="on"
+                    >
+                      
+                
+                      <div
+                        class="ag-floating-top-container"
+                        ref="eTopContainer"
+                        role="presentation"
+                        style="width: 1199px;"
+                        unselectable="on"
+                      />
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-floating-top ag-hidden"
+                      ref="eRightTop"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-top-full-width-container ag-hidden"
+                      ref="eTopFullWidthContainer"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    class="ag-body-viewport ag-layout-normal ag-row-no-animation"
+                    ref="eBodyViewport"
+                    role="presentation"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-cols-container ag-hidden"
+                      ref="eLeftContainer"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    >
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="2"
+                        class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                        comp-id="66"
+                        role="row"
+                        row-id="asdf_7d_refund"
+                        row-index="0"
+                        style="height: 42px; transform: translateY(0px);"
+                      />
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="3"
+                        class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute ag-row-last"
+                        comp-id="71"
+                        role="row"
+                        row-id="registration_start"
+                        row-index="1"
+                        style="height: 42px; transform: translateY(42px);"
+                      />
+                    </div>
+                    
+            
+                    <div
+                      class="ag-center-cols-clipper"
+                      ref="eCenterColsClipper"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    >
+                      
+                
+                      <div
+                        class="ag-center-cols-viewport"
+                        ref="eCenterViewport"
+                        role="presentation"
+                        style="height: calc(100% + 0px);"
+                      >
+                        
+                    
+                        <div
+                          class="ag-center-cols-container"
+                          ref="eCenterContainer"
+                          role="rowgroup"
+                          style="width: 1199px; height: 84px;"
+                          unselectable="on"
+                        >
+                          <div
+                            aria-label="Press SPACE to select this row."
+                            aria-rowindex="2"
+                            class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                            comp-id="66"
+                            role="row"
+                            row-id="asdf_7d_refund"
+                            row-index="0"
+                            style="height: 42px; transform: translateY(0px);"
+                          >
+                            <div
+                              aria-colindex="1"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="__detail-button-col__"
+                              comp-id="67"
+                              role="gridcell"
+                              style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <button
+                                  aria-label="Toggle Button"
+                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-75 makeStyles-notRotated-77 MuiIconButton-sizeSmall"
+                                  tabindex="0"
+                                  type="button"
+                                >
+                                  <span
+                                    class="MuiIconButton-label"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="2"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="name"
+                              comp-id="68"
+                              role="gridcell"
+                              style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <div
+                                  class="makeStyles-metricName-78"
+                                  title="asdf_7d_refund"
+                                >
+                                  asdf_7d_refund
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="3"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="description"
+                              comp-id="69"
+                              role="gridcell"
+                              style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              string
+                            </div>
+                            <div
+                              aria-colindex="7"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="metrics-assign--actions"
+                              comp-id="70"
+                              role="gridcell"
+                              style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <div
+                                  class="makeStyles-root-79"
+                                >
+                                  <button
+                                    aria-label="Assign metric"
+                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-83 MuiButton-contained makeStyles-noWrap-80 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+                                    tabindex="0"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="MuiButton-label"
+                                    >
+                                      <span
+                                        class="MuiButton-startIcon MuiButton-iconSizeSmall"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      Assign Metric
+                                    </span>
+                                    <span
+                                      class="MuiTouchRipple-root"
+                                    />
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-label="Press SPACE to select this row."
+                            aria-rowindex="3"
+                            class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute ag-row-last"
+                            comp-id="71"
+                            role="row"
+                            row-id="registration_start"
+                            row-index="1"
+                            style="height: 42px; transform: translateY(42px);"
+                          >
+                            <div
+                              aria-colindex="1"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="__detail-button-col__"
+                              comp-id="72"
+                              role="gridcell"
+                              style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <button
+                                  aria-label="Toggle Button"
+                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-75 makeStyles-notRotated-77 MuiIconButton-sizeSmall"
+                                  tabindex="0"
+                                  type="button"
+                                >
+                                  <span
+                                    class="MuiIconButton-label"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="2"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="name"
+                              comp-id="73"
+                              role="gridcell"
+                              style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <div
+                                  class="makeStyles-metricName-78"
+                                  title="registration_start"
+                                >
+                                  registration_start
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="3"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="description"
+                              comp-id="74"
+                              role="gridcell"
+                              style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              string
+                            </div>
+                            <div
+                              aria-colindex="7"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="metrics-assign--actions"
+                              comp-id="75"
+                              role="gridcell"
+                              style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <div
+                                  class="makeStyles-root-79"
+                                >
+                                  <button
+                                    aria-label="Assign metric"
+                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-84 MuiButton-contained makeStyles-noWrap-80 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+                                    tabindex="0"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="MuiButton-label"
+                                    >
+                                      <span
+                                        class="MuiButton-startIcon MuiButton-iconSizeSmall"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      Assign Metric
+                                    </span>
+                                    <span
+                                      class="MuiTouchRipple-root"
+                                    />
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        
+                
+                      </div>
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-cols-container ag-hidden"
+                      ref="eRightContainer"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    >
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="2"
+                        class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                        comp-id="66"
+                        role="row"
+                        row-id="asdf_7d_refund"
+                        row-index="0"
+                        style="height: 42px; transform: translateY(0px);"
+                      />
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="3"
+                        class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute ag-row-last"
+                        comp-id="71"
+                        role="row"
+                        row-id="registration_start"
+                        row-index="1"
+                        style="height: 42px; transform: translateY(42px);"
+                      />
+                    </div>
+                    
+            
+                    <div
+                      class="ag-full-width-container"
+                      ref="eFullWidthContainer"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    class="ag-floating-bottom"
+                    ref="eBottom"
+                    role="presentation"
+                    style="min-height: 0px; height: 0px; display: none; overflow-y: hidden;"
+                    unselectable="on"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-floating-bottom ag-hidden"
+                      ref="eLeftBottom"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-bottom-viewport"
+                      ref="eBottomViewport"
+                      role="presentation"
+                      unselectable="on"
+                    >
+                      
+                
+                      <div
+                        class="ag-floating-bottom-container"
+                        ref="eBottomContainer"
+                        role="presentation"
+                        style="width: 1199px;"
+                        unselectable="on"
+                      />
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-floating-bottom ag-hidden"
+                      ref="eRightBottom"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-bottom-full-width-container ag-hidden"
+                      ref="eBottomFullWidthContainer"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    aria-hidden="true"
+                    class="ag-body-horizontal-scroll"
+                    ref="eHorizontalScrollBody"
+                    style="height: 0px; max-height: 0px; min-height: 0px;"
+                  >
+                    
+            
+                    <div
+                      class="ag-horizontal-left-spacer"
+                      ref="eHorizontalLeftSpacer"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    />
+                    
+            
+                    <div
+                      class="ag-body-horizontal-scroll-viewport"
+                      ref="eBodyHorizontalScrollViewport"
+                      style="height: 0px; max-height: 0px; min-height: 0px;"
+                    >
+                      
+                
+                      <div
+                        class="ag-body-horizontal-scroll-container"
+                        ref="eBodyHorizontalScrollContainer"
+                        style="width: 1199px; height: 0px; max-height: 0px; min-height: 0px;"
+                      />
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-horizontal-right-spacer"
+                      ref="eHorizontalRightSpacer"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <!--AG-OVERLAY-WRAPPER-->
+                  <div
+                    aria-hidden="true"
+                    class="ag-overlay ag-hidden"
+                    ref="overlayWrapper"
+                  >
+                    
+            
+                    <div
+                      class="ag-overlay-panel"
+                    >
+                      
+                
+                      <div
+                        class="ag-overlay-wrapper ag-layout-normal"
+                        ref="eOverlayWrapper"
+                      />
+                      
+            
+                    </div>
+                    
+        
+                  </div>
+                  
+    
+                </div>
+                
+                    
+                
+                <div
+                  class="ag-tab-guard ag-tab-guard-bottom"
+                  role="presentation"
+                  tabindex="0"
+                />
+              </div>
+              
+                
+                
+              <!--AG-PAGINATION-->
+              <div
+                aria-describedby="ag-42-start-page ag-42-start-page-number ag-42-of-page ag-42-of-page-number ag-42-first-row ag-42-to ag-42-last-row ag-42-of ag-42-row-count"
+                aria-live="polite"
+                class="ag-paging-panel ag-unselectable ag-hidden"
+                id="ag-42"
+              >
+                
+                
+                <span
+                  aria-hidden="true"
+                  class="ag-paging-row-summary-panel"
+                >
+                  
+                    
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    id="ag-42-first-row"
+                    ref="lbFirstRowOnPage"
+                  />
+                  
+                    
+                  <span
+                    id="ag-42-to"
+                  >
+                    to
+                  </span>
+                  
+                    
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    id="ag-42-last-row"
+                    ref="lbLastRowOnPage"
+                  />
+                  
+                    
+                  <span
+                    id="ag-42-of"
+                  >
+                    of
+                  </span>
+                  
+                    
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    id="ag-42-row-count"
+                    ref="lbRecordCount"
+                  />
+                  
+                
+                </span>
+                
+                
+                <span
+                  class="ag-paging-page-summary-panel"
+                  role="presentation"
+                >
+                  
+                    
+                  <div
+                    aria-label="First Page"
+                    class="ag-paging-button"
+                    ref="btFirst"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-first"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                    
+                  <div
+                    aria-label="Previous Page"
+                    class="ag-paging-button"
+                    ref="btPrevious"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-previous"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                    
+                  <span
+                    aria-hidden="true"
+                    class="ag-paging-description"
+                  >
+                    
+                        
+                    <span
+                      id="ag-42-start-page"
+                    >
+                      Page
+                    </span>
+                    
+                        
+                    <span
+                      class="ag-paging-number"
+                      id="ag-42-start-page-number"
+                      ref="lbCurrent"
+                    />
+                    
+                        
+                    <span
+                      id="ag-42-of-page"
+                    >
+                      of
+                    </span>
+                    
+                        
+                    <span
+                      class="ag-paging-number"
+                      id="ag-42-of-page-number"
+                      ref="lbTotal"
+                    />
+                    
+                    
+                  </span>
+                  
+                    
+                  <div
+                    aria-label="Next Page"
+                    class="ag-paging-button"
+                    ref="btNext"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-next"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                    
+                  <div
+                    aria-label="Last Page"
+                    class="ag-paging-button"
+                    ref="btLast"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-last"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                
+                </span>
+                
+            
+              </div>
+              
+                
+            
             </div>
           </div>
         </div>
       </div>
-      <button
-        aria-label="Add metric"
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiButton-label"
-        >
-          Assign
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-35 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-48 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -3743,7 +9524,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-36 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-49 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -3764,13 +9545,13 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-47 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="attr-window-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-48"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
             id="attr-window-panel"
             role="button"
             tabindex="0"
@@ -3834,7 +9615,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
                       is the window of time after exposure to an experiment that we capture metric events for a participant (exposure can be from either assignment or specified exposure events). The refund window is the window of time after a purchase event. Revenue metrics will automatically deduct transactions that have been refunded within the metric’s refund window.
                       <br />
                       <div
-                        class="makeStyles-attributionWindowDiagram-37"
+                        class="makeStyles-attributionWindowDiagram-50"
                       >
                         <svg>
                           attribution_window.svg
@@ -3853,7 +9634,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-38 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-51 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -3874,13 +9655,13 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-47 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="min-diff-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-48"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
             id="min-diff-panel"
             role="button"
             tabindex="0"
@@ -3944,7 +9725,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
                       are absolute differences from the baseline (not relative). For example, if the baseline conversion rate is 5%, a minimum difference of 0.5 pp is equivalent to a 10% relative change.
                       <br />
                       <div
-                        class="makeStyles-minDiffDiagram-39"
+                        class="makeStyles-minDiffDiagram-52"
                       >
                         <svg>
                           min_diffs.svg
@@ -3960,7 +9741,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-40 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-53 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -3990,7 +9771,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-41 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-54 MuiTypography-h4"
     >
       Exposure Events
     </h4>
@@ -4023,11 +9804,11 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-45"
+      class="makeStyles-addMetric-59"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-46"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-60"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -4052,7 +9833,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-42 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-55 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -4086,7 +9867,7 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-43 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-56 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -4118,10 +9899,10 @@ exports[`allows adding, editing and removing a Metric Assignment 6`] = `
 </div>
 `;
 
-exports[`allows adding, editing and removing a Metric Assignment 7`] = `
+exports[`allows adding, editing and removing a Metric Assignment 6`] = `
 <div>
   <div
-    class="makeStyles-root-25"
+    class="makeStyles-root-38"
   >
     <h4
       class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom"
@@ -4177,17 +9958,17 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
             class="MuiTableRow-root"
           >
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-30"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-metricNameCell-43"
             >
               <span
-                class="makeStyles-metricName-31 makeStyles-tooltipped-32"
+                class="makeStyles-metricName-44 makeStyles-tooltipped-45"
                 title="string"
               >
                 registration_start
               </span>
               <br />
               <span
-                class="makeStyles-root-61 makeStyles-monospaced-29"
+                class="makeStyles-root-97 makeStyles-monospaced-42"
               >
                 primary
               </span>
@@ -4196,7 +9977,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-28"
+                class="MuiInputBase-root MuiOutlinedInput-root makeStyles-attributionWindowSelect-41"
               >
                 <div
                   aria-haspopup="listbox"
@@ -4228,11 +10009,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="PrivateNotchedOutline-root-62 MuiOutlinedInput-notchedOutline"
+                  class="PrivateNotchedOutline-root-98 MuiOutlinedInput-notchedOutline"
                   style="padding-left: 8px;"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legend-63"
+                    class="PrivateNotchedOutline-legend-99"
                     style="width: 0.01px;"
                   >
                     <span>
@@ -4243,7 +10024,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-34"
+              class="MuiTableCell-root MuiTableCell-body makeStyles-changeExpected-47"
             >
               <span
                 class="MuiSwitch-root"
@@ -4251,7 +10032,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                 <span
                   aria-disabled="false"
                   aria-label="Change Expected"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-66 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-67 Mui-checked"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-102 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-103 Mui-checked"
                   variant="outlined"
                 >
                   <span
@@ -4259,7 +10040,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input-69 MuiSwitch-input"
+                      class="PrivateSwitchBase-input-105 MuiSwitch-input"
                       id="experiment.metricAssignments[0].changeExpected"
                       name="experiment.metricAssignments[0].changeExpected"
                       type="checkbox"
@@ -4282,7 +10063,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
               class="MuiTableCell-root MuiTableCell-body"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-root-70 makeStyles-minDifferenceField-33"
+                class="MuiFormControl-root MuiTextField-root makeStyles-root-106 makeStyles-minDifferenceField-46"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
@@ -4300,10 +10081,10 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                     value="0"
                   />
                   <div
-                    class="MuiInputAdornment-root makeStyles-adornment-72 MuiInputAdornment-positionEnd"
+                    class="MuiInputAdornment-root makeStyles-adornment-108 MuiInputAdornment-positionEnd"
                   >
                     <p
-                      class="MuiTypography-root makeStyles-tooltipped-71 MuiTypography-body1 MuiTypography-colorTextSecondary"
+                      class="MuiTypography-root makeStyles-tooltipped-107 MuiTypography-body1 MuiTypography-colorTextSecondary"
                       title="Percentage Points"
                     >
                       pp
@@ -4311,11 +10092,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                   </div>
                   <fieldset
                     aria-hidden="true"
-                    class="PrivateNotchedOutline-root-62 MuiOutlinedInput-notchedOutline"
+                    class="PrivateNotchedOutline-root-98 MuiOutlinedInput-notchedOutline"
                     style="padding-left: 8px;"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legend-63"
+                      class="PrivateNotchedOutline-legend-99"
                       style="width: 0.01px;"
                     >
                       <span>
@@ -4363,122 +10144,1430 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-45"
+      class="makeStyles-tableContainer-58"
     >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-46"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-        />
-      </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-27"
+        class="ag-theme-alpine makeStyles-root-62"
       >
         <div
-          aria-expanded="false"
-          aria-label="Select a metric"
-          class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-          role="combobox"
+          class="makeStyles-toolbar-63"
         >
           <div
-            class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+            class="makeStyles-rootFullWidth-66"
           >
             <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+              class="makeStyles-search-67"
             >
-              <input
-                aria-autocomplete="list"
-                aria-invalid="false"
-                autocapitalize="none"
-                autocomplete="off"
-                class="MuiInputBase-input MuiInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd"
-                id="add-metric-select"
-                placeholder="Select a metric"
-                required=""
-                spellcheck="false"
-                type="text"
-                value=""
-              />
               <div
-                class="MuiAutocomplete-endAdornment"
+                class="makeStyles-searchIcon-68"
               >
-                <button
-                  aria-label="Clear"
-                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
-                  tabindex="-1"
-                  title="Clear"
-                  type="button"
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
                 >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
+                  <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
                   />
-                </button>
-                <button
-                  aria-label="Open"
-                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
-                  tabindex="-1"
-                  title="Open"
-                  type="button"
-                >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M7 10l5 5 5-5z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
-                  />
-                </button>
+                </svg>
               </div>
+              <div
+                class="MuiInputBase-root makeStyles-inputRootFullWidth-69"
+              >
+                <input
+                  aria-label="Search"
+                  class="MuiInputBase-input makeStyles-inputInputFullWidth-70"
+                  placeholder="Search…"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                 Reset 
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+        </div>
+        <div
+          class="ag-theme-alpine makeStyles-gridContainer-64"
+        >
+          <div
+            style="height: auto; flex: 1;"
+          >
+            <div
+              class="ag-root-wrapper ag-layout-normal ag-ltr"
+              ref="eRootWrapper"
+            >
+              
+                
+                
+              <div
+                class="ag-root-wrapper-body ag-layout-normal ag-focus-managed"
+                ref="rootWrapperBody"
+              >
+                <div
+                  class="ag-tab-guard ag-tab-guard-top"
+                  role="presentation"
+                  tabindex="0"
+                />
+                
+                    
+                <!--AG-GRID-COMP-->
+                <div
+                  aria-colcount="7"
+                  aria-rowcount="3"
+                  class="ag-root ag-unselectable ag-layout-normal"
+                  ref="gridPanel"
+                  role="grid"
+                  unselectable="on"
+                >
+                  
+        
+                  <!--AG-HEADER-ROOT-->
+                  <div
+                    class="ag-header ag-focus-managed ag-pivot-off"
+                    ref="headerRoot"
+                    role="presentation"
+                    style="height: 49px; min-height: 49px;"
+                    unselectable="on"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-header ag-hidden"
+                      ref="ePinnedLeftHeader"
+                      role="presentation"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-column"
+                        role="row"
+                        style="top: 0px; height: 48px; width: 0px;"
+                      />
+                    </div>
+                    
+            
+                    <div
+                      class="ag-header-viewport"
+                      ref="eHeaderViewport"
+                      role="presentation"
+                    >
+                      
+                
+                      <div
+                        class="ag-header-container"
+                        ref="eHeaderContainer"
+                        role="rowgroup"
+                        style="width: 1199px;"
+                      >
+                        <div
+                          aria-rowindex="1"
+                          class="ag-header-row ag-header-row-column"
+                          role="row"
+                          style="top: 0px; height: 48px; width: 1199px;"
+                        >
+                          <div
+                            aria-colindex="1"
+                            class="ag-header-cell ag-focus-managed"
+                            col-id="__detail-button-col__"
+                            role="columnheader"
+                            style="width: 34px; left: 0px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize ag-hidden"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-47-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container"
+                              role="presentation"
+                            >
+                              
+            
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                />
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                
+                
+                                
+                
+                                
+                
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="2"
+                            aria-sort="ascending"
+                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-61"
+                            col-id="name"
+                            role="columnheader"
+                            style="width: 465px; left: 34px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-50-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container ag-header-cell-sorted-asc"
+                              role="presentation"
+                            >
+                              
+            
+                              <span
+                                aria-hidden="true"
+                                class="ag-header-icon ag-header-cell-menu-button"
+                                ref="eMenu"
+                              >
+                                <span
+                                  class="ag-icon ag-icon-menu"
+                                  role="presentation"
+                                  unselectable="on"
+                                />
+                              </span>
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                >
+                                  Name
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-order ag-hidden"
+                                  ref="eSortOrder"
+                                >
+                                  1
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-ascending-icon"
+                                  ref="eSortAsc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-asc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-descending-icon ag-hidden"
+                                  ref="eSortDesc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-desc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-none-icon ag-hidden"
+                                  ref="eSortNone"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-none"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="3"
+                            aria-sort="none"
+                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable"
+                            col-id="description"
+                            role="columnheader"
+                            style="width: 550px; left: 499px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-53-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container ag-header-cell-sorted-none"
+                              role="presentation"
+                            >
+                              
+            
+                              <span
+                                aria-hidden="true"
+                                class="ag-header-icon ag-header-cell-menu-button"
+                                ref="eMenu"
+                              >
+                                <span
+                                  class="ag-icon ag-icon-menu"
+                                  role="presentation"
+                                  unselectable="on"
+                                />
+                              </span>
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                >
+                                  Description
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-order ag-hidden"
+                                  ref="eSortOrder"
+                                />
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-ascending-icon ag-hidden"
+                                  ref="eSortAsc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-asc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-descending-icon ag-hidden"
+                                  ref="eSortDesc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-desc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-none-icon ag-hidden"
+                                  ref="eSortNone"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-none"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="7"
+                            class="ag-header-cell ag-focus-managed"
+                            col-id="metrics-assign--actions"
+                            role="columnheader"
+                            style="width: 150px; left: 1049px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize ag-hidden"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-56-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container"
+                              role="presentation"
+                            >
+                              
+            
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                >
+                                  Actions
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                
+                
+                                
+                
+                                
+                
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-header ag-hidden"
+                      ref="ePinnedRightHeader"
+                      role="presentation"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-column"
+                        role="row"
+                        style="top: 0px; height: 48px; width: 0px;"
+                      />
+                    </div>
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    class="ag-floating-top"
+                    ref="eTop"
+                    role="presentation"
+                    style="min-height: 0px; height: 0px; display: none; overflow-y: hidden;"
+                    unselectable="on"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-floating-top ag-hidden"
+                      ref="eLeftTop"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-top-viewport"
+                      ref="eTopViewport"
+                      role="presentation"
+                      unselectable="on"
+                    >
+                      
+                
+                      <div
+                        class="ag-floating-top-container"
+                        ref="eTopContainer"
+                        role="presentation"
+                        style="width: 1199px;"
+                        unselectable="on"
+                      />
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-floating-top ag-hidden"
+                      ref="eRightTop"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-top-full-width-container ag-hidden"
+                      ref="eTopFullWidthContainer"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    class="ag-body-viewport ag-layout-normal ag-row-no-animation"
+                    ref="eBodyViewport"
+                    role="presentation"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-cols-container ag-hidden"
+                      ref="eLeftContainer"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    >
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="2"
+                        class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                        comp-id="66"
+                        role="row"
+                        row-id="asdf_7d_refund"
+                        row-index="0"
+                        style="height: 42px; transform: translateY(0px);"
+                      />
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="3"
+                        class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute ag-row-last"
+                        comp-id="71"
+                        role="row"
+                        row-id="registration_start"
+                        row-index="1"
+                        style="height: 42px; transform: translateY(42px);"
+                      />
+                    </div>
+                    
+            
+                    <div
+                      class="ag-center-cols-clipper"
+                      ref="eCenterColsClipper"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    >
+                      
+                
+                      <div
+                        class="ag-center-cols-viewport"
+                        ref="eCenterViewport"
+                        role="presentation"
+                        style="height: calc(100% + 0px);"
+                      >
+                        
+                    
+                        <div
+                          class="ag-center-cols-container"
+                          ref="eCenterContainer"
+                          role="rowgroup"
+                          style="width: 1199px; height: 84px;"
+                          unselectable="on"
+                        >
+                          <div
+                            aria-label="Press SPACE to select this row."
+                            aria-rowindex="2"
+                            class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                            comp-id="66"
+                            role="row"
+                            row-id="asdf_7d_refund"
+                            row-index="0"
+                            style="height: 42px; transform: translateY(0px);"
+                          >
+                            <div
+                              aria-colindex="1"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="__detail-button-col__"
+                              comp-id="67"
+                              role="gridcell"
+                              style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <button
+                                  aria-label="Toggle Button"
+                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-75 makeStyles-notRotated-77 MuiIconButton-sizeSmall"
+                                  tabindex="0"
+                                  type="button"
+                                >
+                                  <span
+                                    class="MuiIconButton-label"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="2"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="name"
+                              comp-id="68"
+                              role="gridcell"
+                              style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <div
+                                  class="makeStyles-metricName-78"
+                                  title="asdf_7d_refund"
+                                >
+                                  asdf_7d_refund
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="3"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="description"
+                              comp-id="69"
+                              role="gridcell"
+                              style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              string
+                            </div>
+                            <div
+                              aria-colindex="7"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="metrics-assign--actions"
+                              comp-id="70"
+                              role="gridcell"
+                              style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <div
+                                  class="makeStyles-root-79"
+                                >
+                                  <button
+                                    aria-label="Assign metric"
+                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-83 MuiButton-contained makeStyles-noWrap-80 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+                                    tabindex="0"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="MuiButton-label"
+                                    >
+                                      <span
+                                        class="MuiButton-startIcon MuiButton-iconSizeSmall"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      Assign Metric
+                                    </span>
+                                    <span
+                                      class="MuiTouchRipple-root"
+                                    />
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-label="Press SPACE to select this row."
+                            aria-rowindex="3"
+                            class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute ag-row-last"
+                            comp-id="71"
+                            role="row"
+                            row-id="registration_start"
+                            row-index="1"
+                            style="height: 42px; transform: translateY(42px);"
+                          >
+                            <div
+                              aria-colindex="1"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="__detail-button-col__"
+                              comp-id="72"
+                              role="gridcell"
+                              style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <button
+                                  aria-label="Toggle Button"
+                                  class="MuiButtonBase-root MuiIconButton-root makeStyles-root-75 makeStyles-notRotated-77 MuiIconButton-sizeSmall"
+                                  tabindex="0"
+                                  type="button"
+                                >
+                                  <span
+                                    class="MuiIconButton-label"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="2"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="name"
+                              comp-id="73"
+                              role="gridcell"
+                              style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <div
+                                  class="makeStyles-metricName-78"
+                                  title="registration_start"
+                                >
+                                  registration_start
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="3"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="description"
+                              comp-id="74"
+                              role="gridcell"
+                              style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              string
+                            </div>
+                            <div
+                              aria-colindex="7"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="metrics-assign--actions"
+                              comp-id="75"
+                              role="gridcell"
+                              style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              <div
+                                class="ag-react-container"
+                              >
+                                <div
+                                  class="makeStyles-root-79"
+                                >
+                                  <button
+                                    aria-label="Assign metric"
+                                    class="MuiButtonBase-root MuiButton-root WithStyles(ForwardRef(Button))-root-84 MuiButton-contained makeStyles-noWrap-80 MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+                                    tabindex="0"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="MuiButton-label"
+                                    >
+                                      <span
+                                        class="MuiButton-startIcon MuiButton-iconSizeSmall"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      Assign Metric
+                                    </span>
+                                    <span
+                                      class="MuiTouchRipple-root"
+                                    />
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        
+                
+                      </div>
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-cols-container ag-hidden"
+                      ref="eRightContainer"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    >
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="2"
+                        class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                        comp-id="66"
+                        role="row"
+                        row-id="asdf_7d_refund"
+                        row-index="0"
+                        style="height: 42px; transform: translateY(0px);"
+                      />
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="3"
+                        class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute ag-row-last"
+                        comp-id="71"
+                        role="row"
+                        row-id="registration_start"
+                        row-index="1"
+                        style="height: 42px; transform: translateY(42px);"
+                      />
+                    </div>
+                    
+            
+                    <div
+                      class="ag-full-width-container"
+                      ref="eFullWidthContainer"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    class="ag-floating-bottom"
+                    ref="eBottom"
+                    role="presentation"
+                    style="min-height: 0px; height: 0px; display: none; overflow-y: hidden;"
+                    unselectable="on"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-floating-bottom ag-hidden"
+                      ref="eLeftBottom"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-bottom-viewport"
+                      ref="eBottomViewport"
+                      role="presentation"
+                      unselectable="on"
+                    >
+                      
+                
+                      <div
+                        class="ag-floating-bottom-container"
+                        ref="eBottomContainer"
+                        role="presentation"
+                        style="width: 1199px;"
+                        unselectable="on"
+                      />
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-floating-bottom ag-hidden"
+                      ref="eRightBottom"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-bottom-full-width-container ag-hidden"
+                      ref="eBottomFullWidthContainer"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    aria-hidden="true"
+                    class="ag-body-horizontal-scroll"
+                    ref="eHorizontalScrollBody"
+                    style="height: 0px; max-height: 0px; min-height: 0px;"
+                  >
+                    
+            
+                    <div
+                      class="ag-horizontal-left-spacer"
+                      ref="eHorizontalLeftSpacer"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    />
+                    
+            
+                    <div
+                      class="ag-body-horizontal-scroll-viewport"
+                      ref="eBodyHorizontalScrollViewport"
+                      style="height: 0px; max-height: 0px; min-height: 0px;"
+                    >
+                      
+                
+                      <div
+                        class="ag-body-horizontal-scroll-container"
+                        ref="eBodyHorizontalScrollContainer"
+                        style="width: 1199px; height: 0px; max-height: 0px; min-height: 0px;"
+                      />
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-horizontal-right-spacer"
+                      ref="eHorizontalRightSpacer"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <!--AG-OVERLAY-WRAPPER-->
+                  <div
+                    aria-hidden="true"
+                    class="ag-overlay ag-hidden"
+                    ref="overlayWrapper"
+                  >
+                    
+            
+                    <div
+                      class="ag-overlay-panel"
+                    >
+                      
+                
+                      <div
+                        class="ag-overlay-wrapper ag-layout-normal"
+                        ref="eOverlayWrapper"
+                      />
+                      
+            
+                    </div>
+                    
+        
+                  </div>
+                  
+    
+                </div>
+                
+                    
+                
+                <div
+                  class="ag-tab-guard ag-tab-guard-bottom"
+                  role="presentation"
+                  tabindex="0"
+                />
+              </div>
+              
+                
+                
+              <!--AG-PAGINATION-->
+              <div
+                aria-describedby="ag-42-start-page ag-42-start-page-number ag-42-of-page ag-42-of-page-number ag-42-first-row ag-42-to ag-42-last-row ag-42-of ag-42-row-count"
+                aria-live="polite"
+                class="ag-paging-panel ag-unselectable ag-hidden"
+                id="ag-42"
+              >
+                
+                
+                <span
+                  aria-hidden="true"
+                  class="ag-paging-row-summary-panel"
+                >
+                  
+                    
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    id="ag-42-first-row"
+                    ref="lbFirstRowOnPage"
+                  />
+                  
+                    
+                  <span
+                    id="ag-42-to"
+                  >
+                    to
+                  </span>
+                  
+                    
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    id="ag-42-last-row"
+                    ref="lbLastRowOnPage"
+                  />
+                  
+                    
+                  <span
+                    id="ag-42-of"
+                  >
+                    of
+                  </span>
+                  
+                    
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    id="ag-42-row-count"
+                    ref="lbRecordCount"
+                  />
+                  
+                
+                </span>
+                
+                
+                <span
+                  class="ag-paging-page-summary-panel"
+                  role="presentation"
+                >
+                  
+                    
+                  <div
+                    aria-label="First Page"
+                    class="ag-paging-button"
+                    ref="btFirst"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-first"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                    
+                  <div
+                    aria-label="Previous Page"
+                    class="ag-paging-button"
+                    ref="btPrevious"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-previous"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                    
+                  <span
+                    aria-hidden="true"
+                    class="ag-paging-description"
+                  >
+                    
+                        
+                    <span
+                      id="ag-42-start-page"
+                    >
+                      Page
+                    </span>
+                    
+                        
+                    <span
+                      class="ag-paging-number"
+                      id="ag-42-start-page-number"
+                      ref="lbCurrent"
+                    />
+                    
+                        
+                    <span
+                      id="ag-42-of-page"
+                    >
+                      of
+                    </span>
+                    
+                        
+                    <span
+                      class="ag-paging-number"
+                      id="ag-42-of-page-number"
+                      ref="lbTotal"
+                    />
+                    
+                    
+                  </span>
+                  
+                    
+                  <div
+                    aria-label="Next Page"
+                    class="ag-paging-button"
+                    ref="btNext"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-next"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                    
+                  <div
+                    aria-label="Last Page"
+                    class="ag-paging-button"
+                    ref="btLast"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-last"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                
+                </span>
+                
+            
+              </div>
+              
+                
+            
             </div>
           </div>
         </div>
       </div>
-      <button
-        aria-label="Add metric"
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiButton-label"
-        >
-          Assign
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-35 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-48 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -4516,7 +11605,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-36 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-attributionWindowInfo-49 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -4537,13 +11626,13 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-47 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="attr-window-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-48"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
             id="attr-window-panel"
             role="button"
             tabindex="0"
@@ -4607,7 +11696,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                       is the window of time after exposure to an experiment that we capture metric events for a participant (exposure can be from either assignment or specified exposure events). The refund window is the window of time after a purchase event. Revenue metrics will automatically deduct transactions that have been refunded within the metric’s refund window.
                       <br />
                       <div
-                        class="makeStyles-attributionWindowDiagram-37"
+                        class="makeStyles-attributionWindowDiagram-50"
                       >
                         <svg>
                           attribution_window.svg
@@ -4626,7 +11715,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-38 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-minDiffInfo-51 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -4647,13 +11736,13 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-47 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-73 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="min-diff-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-48"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-74"
             id="min-diff-panel"
             role="button"
             tabindex="0"
@@ -4717,7 +11806,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
                       are absolute differences from the baseline (not relative). For example, if the baseline conversion rate is 5%, a minimum difference of 0.5 pp is equivalent to a 10% relative change.
                       <br />
                       <div
-                        class="makeStyles-minDiffDiagram-39"
+                        class="makeStyles-minDiffDiagram-52"
                       >
                         <svg>
                           min_diffs.svg
@@ -4733,7 +11822,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-40 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-requestMetricInfo-53 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -4763,7 +11852,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </div>
     </div>
     <h4
-      class="MuiTypography-root makeStyles-exposureEventsTitle-41 MuiTypography-h4"
+      class="MuiTypography-root makeStyles-exposureEventsTitle-54 MuiTypography-h4"
     >
       Exposure Events
     </h4>
@@ -4796,11 +11885,11 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-45"
+      class="makeStyles-addMetric-59"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-46"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-60"
         focusable="false"
         viewBox="0 0 24 24"
       >
@@ -4825,7 +11914,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-42 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-exposureEventsInfo-55 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -4859,7 +11948,7 @@ exports[`allows adding, editing and removing a Metric Assignment 7`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-43 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-multipleExposureEventsInfo-56 MuiPaper-elevation0"
       role="alert"
     >
       <div
@@ -4964,119 +12053,1269 @@ exports[`renders as expected 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-21"
+      class="makeStyles-tableContainer-21"
     >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-22"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-        />
-      </svg>
       <div
-        class="MuiFormControl-root makeStyles-addMetricSelect-3"
+        class="ag-theme-alpine makeStyles-root-25"
       >
         <div
-          aria-expanded="false"
-          aria-label="Select a metric"
-          class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-          role="combobox"
+          class="makeStyles-toolbar-26"
         >
           <div
-            class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+            class="makeStyles-rootFullWidth-29"
           >
             <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+              class="makeStyles-search-30"
             >
-              <input
-                aria-autocomplete="list"
-                aria-invalid="false"
-                autocapitalize="none"
-                autocomplete="off"
-                class="MuiInputBase-input MuiInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd"
-                id="add-metric-select"
-                placeholder="Select a metric"
-                required=""
-                spellcheck="false"
-                type="text"
-                value=""
-              />
               <div
-                class="MuiAutocomplete-endAdornment"
+                class="makeStyles-searchIcon-31"
               >
-                <button
-                  aria-label="Clear"
-                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
-                  tabindex="-1"
-                  title="Clear"
-                  type="button"
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
                 >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
+                  <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
                   />
-                </button>
-                <button
-                  aria-label="Open"
-                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
-                  tabindex="-1"
-                  title="Open"
-                  type="button"
-                >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M7 10l5 5 5-5z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
-                  />
-                </button>
+                </svg>
               </div>
+              <div
+                class="MuiInputBase-root makeStyles-inputRootFullWidth-32"
+              >
+                <input
+                  aria-label="Search"
+                  class="MuiInputBase-input makeStyles-inputInputFullWidth-33"
+                  placeholder="Search…"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                 Reset 
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+        </div>
+        <div
+          class="ag-theme-alpine makeStyles-gridContainer-27"
+        >
+          <div
+            style="height: auto; flex: 1;"
+          >
+            <div
+              class="ag-root-wrapper ag-layout-normal ag-ltr"
+              ref="eRootWrapper"
+            >
+              
+                
+                
+              <div
+                class="ag-root-wrapper-body ag-layout-normal ag-focus-managed"
+                ref="rootWrapperBody"
+              >
+                <div
+                  class="ag-tab-guard ag-tab-guard-top"
+                  role="presentation"
+                  tabindex="0"
+                />
+                
+                    
+                <!--AG-GRID-COMP-->
+                <div
+                  aria-colcount="7"
+                  aria-rowcount="3"
+                  class="ag-root ag-unselectable ag-layout-normal"
+                  ref="gridPanel"
+                  role="grid"
+                  unselectable="on"
+                >
+                  
+        
+                  <!--AG-HEADER-ROOT-->
+                  <div
+                    class="ag-header ag-focus-managed ag-pivot-off"
+                    ref="headerRoot"
+                    role="presentation"
+                    style="height: 49px; min-height: 49px;"
+                    unselectable="on"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-header ag-hidden"
+                      ref="ePinnedLeftHeader"
+                      role="presentation"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-column"
+                        role="row"
+                        style="top: 0px; height: 48px; width: 0px;"
+                      />
+                    </div>
+                    
+            
+                    <div
+                      class="ag-header-viewport"
+                      ref="eHeaderViewport"
+                      role="presentation"
+                    >
+                      
+                
+                      <div
+                        class="ag-header-container"
+                        ref="eHeaderContainer"
+                        role="rowgroup"
+                        style="width: 1199px;"
+                      >
+                        <div
+                          aria-rowindex="1"
+                          class="ag-header-row ag-header-row-column"
+                          role="row"
+                          style="top: 0px; height: 48px; width: 1199px;"
+                        >
+                          <div
+                            aria-colindex="1"
+                            class="ag-header-cell ag-focus-managed"
+                            col-id="__detail-button-col__"
+                            role="columnheader"
+                            style="width: 34px; left: 0px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize ag-hidden"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-9-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container"
+                              role="presentation"
+                            >
+                              
+            
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                />
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                
+                
+                                
+                
+                                
+                
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="2"
+                            aria-sort="none"
+                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable makeStyles-noLeftPadding-24"
+                            col-id="name"
+                            role="columnheader"
+                            style="width: 465px; left: 34px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-12-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container ag-header-cell-sorted-none"
+                              role="presentation"
+                            >
+                              
+            
+                              <span
+                                aria-hidden="true"
+                                class="ag-header-icon ag-header-cell-menu-button"
+                                ref="eMenu"
+                              >
+                                <span
+                                  class="ag-icon ag-icon-menu"
+                                  role="presentation"
+                                  unselectable="on"
+                                />
+                              </span>
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                >
+                                  Name
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-order ag-hidden"
+                                  ref="eSortOrder"
+                                />
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-ascending-icon ag-hidden"
+                                  ref="eSortAsc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-asc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-descending-icon ag-hidden"
+                                  ref="eSortDesc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-desc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-none-icon ag-hidden"
+                                  ref="eSortNone"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-none"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="3"
+                            aria-sort="none"
+                            class="ag-header-cell ag-focus-managed ag-header-cell-sortable"
+                            col-id="description"
+                            role="columnheader"
+                            style="width: 550px; left: 499px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-15-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container ag-header-cell-sorted-none"
+                              role="presentation"
+                            >
+                              
+            
+                              <span
+                                aria-hidden="true"
+                                class="ag-header-icon ag-header-cell-menu-button"
+                                ref="eMenu"
+                              >
+                                <span
+                                  class="ag-icon ag-icon-menu"
+                                  role="presentation"
+                                  unselectable="on"
+                                />
+                              </span>
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                >
+                                  Description
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-order ag-hidden"
+                                  ref="eSortOrder"
+                                />
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-ascending-icon ag-hidden"
+                                  ref="eSortAsc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-asc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-descending-icon ag-hidden"
+                                  ref="eSortDesc"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-desc"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-sort-none-icon ag-hidden"
+                                  ref="eSortNone"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-none"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="7"
+                            class="ag-header-cell ag-focus-managed"
+                            col-id="metrics-assign--actions"
+                            role="columnheader"
+                            style="width: 150px; left: 1049px;"
+                            tabindex="-1"
+                            unselectable="on"
+                          >
+                            
+            
+                            <div
+                              class="ag-header-cell-resize ag-hidden"
+                              ref="eResize"
+                              role="presentation"
+                            />
+                            
+            
+                            <!--AG-CHECKBOX-->
+                            <div
+                              class="ag-header-select-all ag-labeled ag-label-align-right ag-checkbox ag-input-field ag-hidden"
+                              ref="cbSelectAll"
+                              role="presentation"
+                            >
+                              
+                
+                              <div
+                                class="ag-input-field-label ag-label ag-hidden ag-checkbox-label"
+                                ref="eLabel"
+                                role="presentation"
+                              />
+                              
+                
+                              <div
+                                class="ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper"
+                                ref="eWrapper"
+                                role="presentation"
+                              >
+                                
+                    
+                                <input
+                                  aria-label="Press Space to toggle all rows selection (unchecked)"
+                                  class="ag-input-field-input ag-checkbox-input"
+                                  id="ag-18-input"
+                                  ref="eInput"
+                                  tabindex="-1"
+                                  type="checkbox"
+                                />
+                                
+                
+                              </div>
+                              
+            
+                            </div>
+                            
+        
+                            <div
+                              class="ag-cell-label-container"
+                              role="presentation"
+                            >
+                              
+            
+                              
+            
+                              <div
+                                class="ag-header-cell-label"
+                                ref="eLabel"
+                                role="presentation"
+                                unselectable="on"
+                              >
+                                
+                
+                                <span
+                                  class="ag-header-cell-text"
+                                  ref="eText"
+                                  unselectable="on"
+                                >
+                                  Actions
+                                </span>
+                                
+                
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden"
+                                  ref="eFilter"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-filter"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                
+                
+                                
+                
+                                
+                
+                                
+                
+                                
+            
+                              </div>
+                              
+        
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-header ag-hidden"
+                      ref="ePinnedRightHeader"
+                      role="presentation"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-column"
+                        role="row"
+                        style="top: 0px; height: 48px; width: 0px;"
+                      />
+                    </div>
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    class="ag-floating-top"
+                    ref="eTop"
+                    role="presentation"
+                    style="min-height: 0px; height: 0px; display: none; overflow-y: hidden;"
+                    unselectable="on"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-floating-top ag-hidden"
+                      ref="eLeftTop"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-top-viewport"
+                      ref="eTopViewport"
+                      role="presentation"
+                      unselectable="on"
+                    >
+                      
+                
+                      <div
+                        class="ag-floating-top-container"
+                        ref="eTopContainer"
+                        role="presentation"
+                        style="width: 1199px;"
+                        unselectable="on"
+                      />
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-floating-top ag-hidden"
+                      ref="eRightTop"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-top-full-width-container ag-hidden"
+                      ref="eTopFullWidthContainer"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    class="ag-body-viewport ag-layout-normal ag-row-no-animation"
+                    ref="eBodyViewport"
+                    role="presentation"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-cols-container ag-hidden"
+                      ref="eLeftContainer"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    >
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="2"
+                        class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                        comp-id="28"
+                        role="row"
+                        row-id="asdf_7d_refund"
+                        row-index="0"
+                        style="height: 42px; transform: translateY(0px); "
+                      />
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="3"
+                        class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute ag-row-last"
+                        comp-id="33"
+                        role="row"
+                        row-id="registration_start"
+                        row-index="1"
+                        style="height: 42px; transform: translateY(42px); "
+                      />
+                    </div>
+                    
+            
+                    <div
+                      class="ag-center-cols-clipper"
+                      ref="eCenterColsClipper"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    >
+                      
+                
+                      <div
+                        class="ag-center-cols-viewport"
+                        ref="eCenterViewport"
+                        role="presentation"
+                        style="height: calc(100% + 0px);"
+                      >
+                        
+                    
+                        <div
+                          class="ag-center-cols-container"
+                          ref="eCenterContainer"
+                          role="rowgroup"
+                          style="width: 1199px; height: 84px;"
+                          unselectable="on"
+                        >
+                          <div
+                            aria-label="Press SPACE to select this row."
+                            aria-rowindex="2"
+                            class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                            comp-id="28"
+                            role="row"
+                            row-id="asdf_7d_refund"
+                            row-index="0"
+                            style="height: 42px; transform: translateY(0px); "
+                          >
+                            <div
+                              aria-colindex="1"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="__detail-button-col__"
+                              comp-id="29"
+                              role="gridcell"
+                              style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            />
+                            <div
+                              aria-colindex="2"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="name"
+                              comp-id="30"
+                              role="gridcell"
+                              style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            />
+                            <div
+                              aria-colindex="3"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="description"
+                              comp-id="31"
+                              role="gridcell"
+                              style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              string
+                            </div>
+                            <div
+                              aria-colindex="7"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="metrics-assign--actions"
+                              comp-id="32"
+                              role="gridcell"
+                              style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                              tabindex="-1"
+                              unselectable="on"
+                            />
+                          </div>
+                          <div
+                            aria-label="Press SPACE to select this row."
+                            aria-rowindex="3"
+                            class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute ag-row-last"
+                            comp-id="33"
+                            role="row"
+                            row-id="registration_start"
+                            row-index="1"
+                            style="height: 42px; transform: translateY(42px); "
+                          >
+                            <div
+                              aria-colindex="1"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="__detail-button-col__"
+                              comp-id="34"
+                              role="gridcell"
+                              style="width: 34px; left: 0px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            />
+                            <div
+                              aria-colindex="2"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="name"
+                              comp-id="35"
+                              role="gridcell"
+                              style="width: 465px; left: 34px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-weight: 700; padding-left: 0; "
+                              tabindex="-1"
+                              unselectable="on"
+                            />
+                            <div
+                              aria-colindex="3"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="description"
+                              comp-id="36"
+                              role="gridcell"
+                              style="width: 550px; left: 499px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; font-size: 12px; word-break: normal; "
+                              tabindex="-1"
+                              unselectable="on"
+                            >
+                              string
+                            </div>
+                            <div
+                              aria-colindex="7"
+                              class="ag-cell ag-cell-not-inline-editing ag-cell-auto-height ag-cell-value ag-cell-wrap-text"
+                              col-id="metrics-assign--actions"
+                              comp-id="37"
+                              role="gridcell"
+                              style="width: 150px; left: 1049px; display: flex; align-items: center; line-height: 15px; padding-top: 8px; padding-bottom: 8px; font-family: 'Roboto Mono', monospace; justify-content: center; padding: 10px 4px; "
+                              tabindex="-1"
+                              unselectable="on"
+                            />
+                          </div>
+                        </div>
+                        
+                
+                      </div>
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-cols-container ag-hidden"
+                      ref="eRightContainer"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    >
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="2"
+                        class="ag-row ag-row-no-focus ag-row-even ag-row-level-0 ag-row-position-absolute ag-row-first"
+                        comp-id="28"
+                        role="row"
+                        row-id="asdf_7d_refund"
+                        row-index="0"
+                        style="height: 42px; transform: translateY(0px); "
+                      />
+                      <div
+                        aria-label="Press SPACE to select this row."
+                        aria-rowindex="3"
+                        class="ag-row ag-row-no-focus ag-row-odd ag-row-level-0 ag-row-position-absolute ag-row-last"
+                        comp-id="33"
+                        role="row"
+                        row-id="registration_start"
+                        row-index="1"
+                        style="height: 42px; transform: translateY(42px); "
+                      />
+                    </div>
+                    
+            
+                    <div
+                      class="ag-full-width-container"
+                      ref="eFullWidthContainer"
+                      role="presentation"
+                      style="height: 84px;"
+                      unselectable="on"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    class="ag-floating-bottom"
+                    ref="eBottom"
+                    role="presentation"
+                    style="min-height: 0px; height: 0px; display: none; overflow-y: hidden;"
+                    unselectable="on"
+                  >
+                    
+            
+                    <div
+                      class="ag-pinned-left-floating-bottom ag-hidden"
+                      ref="eLeftBottom"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-bottom-viewport"
+                      ref="eBottomViewport"
+                      role="presentation"
+                      unselectable="on"
+                    >
+                      
+                
+                      <div
+                        class="ag-floating-bottom-container"
+                        ref="eBottomContainer"
+                        role="presentation"
+                        style="width: 1199px;"
+                        unselectable="on"
+                      />
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-pinned-right-floating-bottom ag-hidden"
+                      ref="eRightBottom"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+            
+                    <div
+                      class="ag-floating-bottom-full-width-container ag-hidden"
+                      ref="eBottomFullWidthContainer"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <div
+                    aria-hidden="true"
+                    class="ag-body-horizontal-scroll"
+                    ref="eHorizontalScrollBody"
+                    style="height: 0px; max-height: 0px; min-height: 0px;"
+                  >
+                    
+            
+                    <div
+                      class="ag-horizontal-left-spacer"
+                      ref="eHorizontalLeftSpacer"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    />
+                    
+            
+                    <div
+                      class="ag-body-horizontal-scroll-viewport"
+                      ref="eBodyHorizontalScrollViewport"
+                      style="height: 0px; max-height: 0px; min-height: 0px;"
+                    >
+                      
+                
+                      <div
+                        class="ag-body-horizontal-scroll-container"
+                        ref="eBodyHorizontalScrollContainer"
+                        style="width: 1199px; height: 0px; max-height: 0px; min-height: 0px;"
+                      />
+                      
+            
+                    </div>
+                    
+            
+                    <div
+                      class="ag-horizontal-right-spacer"
+                      ref="eHorizontalRightSpacer"
+                      style="width: 0px; max-width: 0px; min-width: 0px;"
+                    />
+                    
+        
+                  </div>
+                  
+        
+                  <!--AG-OVERLAY-WRAPPER-->
+                  <div
+                    aria-hidden="true"
+                    class="ag-overlay ag-hidden"
+                    ref="overlayWrapper"
+                  >
+                    
+            
+                    <div
+                      class="ag-overlay-panel"
+                    >
+                      
+                
+                      <div
+                        class="ag-overlay-wrapper ag-layout-normal"
+                        ref="eOverlayWrapper"
+                      />
+                      
+            
+                    </div>
+                    
+        
+                  </div>
+                  
+    
+                </div>
+                
+                    
+                
+                <div
+                  class="ag-tab-guard ag-tab-guard-bottom"
+                  role="presentation"
+                  tabindex="0"
+                />
+              </div>
+              
+                
+                
+              <!--AG-PAGINATION-->
+              <div
+                aria-describedby="ag-4-start-page ag-4-start-page-number ag-4-of-page ag-4-of-page-number ag-4-first-row ag-4-to ag-4-last-row ag-4-of ag-4-row-count"
+                aria-live="polite"
+                class="ag-paging-panel ag-unselectable ag-hidden"
+                id="ag-4"
+              >
+                
+                
+                <span
+                  aria-hidden="true"
+                  class="ag-paging-row-summary-panel"
+                >
+                  
+                    
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    id="ag-4-first-row"
+                    ref="lbFirstRowOnPage"
+                  />
+                  
+                    
+                  <span
+                    id="ag-4-to"
+                  >
+                    to
+                  </span>
+                  
+                    
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    id="ag-4-last-row"
+                    ref="lbLastRowOnPage"
+                  />
+                  
+                    
+                  <span
+                    id="ag-4-of"
+                  >
+                    of
+                  </span>
+                  
+                    
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    id="ag-4-row-count"
+                    ref="lbRecordCount"
+                  />
+                  
+                
+                </span>
+                
+                
+                <span
+                  class="ag-paging-page-summary-panel"
+                  role="presentation"
+                >
+                  
+                    
+                  <div
+                    aria-label="First Page"
+                    class="ag-paging-button"
+                    ref="btFirst"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-first"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                    
+                  <div
+                    aria-label="Previous Page"
+                    class="ag-paging-button"
+                    ref="btPrevious"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-previous"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                    
+                  <span
+                    aria-hidden="true"
+                    class="ag-paging-description"
+                  >
+                    
+                        
+                    <span
+                      id="ag-4-start-page"
+                    >
+                      Page
+                    </span>
+                    
+                        
+                    <span
+                      class="ag-paging-number"
+                      id="ag-4-start-page-number"
+                      ref="lbCurrent"
+                    />
+                    
+                        
+                    <span
+                      id="ag-4-of-page"
+                    >
+                      of
+                    </span>
+                    
+                        
+                    <span
+                      class="ag-paging-number"
+                      id="ag-4-of-page-number"
+                      ref="lbTotal"
+                    />
+                    
+                    
+                  </span>
+                  
+                    
+                  <div
+                    aria-label="Next Page"
+                    class="ag-paging-button"
+                    ref="btNext"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-next"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                    
+                  <div
+                    aria-label="Last Page"
+                    class="ag-paging-button"
+                    ref="btLast"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-last"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  
+                
+                </span>
+                
+            
+              </div>
+              
+                
+            
             </div>
           </div>
         </div>
       </div>
-      <button
-        aria-label="Add metric"
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiButton-label"
-        >
-          Assign
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
     </div>
     <div
       class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo makeStyles-metricsInfo-11 MuiPaper-elevation0"
@@ -5138,13 +13377,13 @@ exports[`renders as expected 1`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-23 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-36 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="attr-window-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-24"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-37"
             id="attr-window-panel"
             role="button"
             tabindex="0"
@@ -5248,13 +13487,13 @@ exports[`renders as expected 1`] = `
         class="MuiAlert-message"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-23 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root MuiAccordion-root MuiAlert-standardInfo makeStyles-accordionRoot-36 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
             aria-controls="min-diff-panel-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-24"
+            class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-accordionSummary-37"
             id="min-diff-panel"
             role="button"
             tabindex="0"
@@ -5397,11 +13636,11 @@ exports[`renders as expected 1`] = `
       </table>
     </div>
     <div
-      class="makeStyles-addMetric-21"
+      class="makeStyles-addMetric-22"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-22"
+        class="MuiSvgIcon-root makeStyles-addMetricAddSymbol-23"
         focusable="false"
         viewBox="0 0 24 24"
       >

--- a/src/components/general/AgGridWithDetails.tsx
+++ b/src/components/general/AgGridWithDetails.tsx
@@ -60,8 +60,8 @@ const detailButtonColumnDef = {
     paddingRight: 0,
   },
   cellRenderer: 'detailButtonRenderer',
-  width: 54,
-  minWidth: 54,
+  width: 34,
+  minWidth: 34,
 }
 
 /**

--- a/src/components/general/ChevronToggleButton.tsx
+++ b/src/components/general/ChevronToggleButton.tsx
@@ -28,7 +28,12 @@ const ChevronToggleButton = ({
   const toggleClass = isOpen ? classes.rotated : classes.notRotated
 
   return (
-    <IconButton className={clsx(classes.root, toggleClass, className)} aria-label={'Toggle Button'} onClick={onClick}>
+    <IconButton
+      size='small'
+      className={clsx(classes.root, toggleClass, className)}
+      aria-label={'Toggle Button'}
+      onClick={onClick}
+    >
       <ChevronRightRoundedIcon />
     </IconButton>
   )

--- a/src/components/general/GridControls.tsx
+++ b/src/components/general/GridControls.tsx
@@ -23,6 +23,11 @@ const useStyles = makeStyles((theme: Theme) =>
       marginLeft: 0,
       width: '100%',
     },
+    searchBorder: {
+      borderWidth: 1,
+      borderStyle: 'solid',
+      borderColor: theme.palette.divider,
+    },
     searchIcon: {
       padding: theme.spacing(0, 2),
       height: '100%',
@@ -79,7 +84,7 @@ const GridControls = ({
 
   return (
     <div className={clsx(fullWidth ? classes.rootFullWidth : classes.root, className)}>
-      <div className={classes.search}>
+      <div className={clsx(classes.search, fullWidth && classes.searchBorder)}>
         <div className={classes.searchIcon}>
           <SearchIcon />
         </div>

--- a/src/components/general/__snapshots__/AgGridWithDetails.test.tsx.snap
+++ b/src/components/general/__snapshots__/AgGridWithDetails.test.tsx.snap
@@ -70,20 +70,20 @@ exports[`renders correctly with various optional props 1`] = `
                 class="ag-header-container"
                 ref="eHeaderContainer"
                 role="rowgroup"
-                style="width: 154px;"
+                style="width: 134px;"
               >
                 <div
                   aria-rowindex="1"
                   class="ag-header-row ag-header-row-column"
                   role="row"
-                  style="top: 0px; height: 25px; width: 154px;"
+                  style="top: 0px; height: 25px; width: 134px;"
                 >
                   <div
                     aria-colindex="1"
                     class="ag-header-cell ag-focus-managed"
                     col-id="__detail-button-col__"
                     role="columnheader"
-                    style="width: 54px; left: 0px;"
+                    style="width: 34px; left: 0px;"
                     tabindex="-1"
                     unselectable="on"
                   >
@@ -188,7 +188,7 @@ exports[`renders correctly with various optional props 1`] = `
                     class="ag-header-cell ag-focus-managed"
                     col-id="test"
                     role="columnheader"
-                    style="width: 100px; left: 54px;"
+                    style="width: 100px; left: 34px;"
                     tabindex="-1"
                     unselectable="on"
                   >
@@ -344,7 +344,7 @@ exports[`renders correctly with various optional props 1`] = `
                 class="ag-floating-top-container"
                 ref="eTopContainer"
                 role="presentation"
-                style="width: 154px;"
+                style="width: 134px;"
                 unselectable="on"
               />
               
@@ -419,7 +419,7 @@ exports[`renders correctly with various optional props 1`] = `
                   class="ag-center-cols-container"
                   ref="eCenterContainer"
                   role="rowgroup"
-                  style="width: 154px; height: 25px;"
+                  style="width: 134px; height: 25px;"
                   unselectable="on"
                 >
                   <div
@@ -438,7 +438,7 @@ exports[`renders correctly with various optional props 1`] = `
                       col-id="__detail-button-col__"
                       comp-id="15"
                       role="gridcell"
-                      style="width: 54px; left: 0px; display: flex; align-items: center; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
+                      style="width: 34px; left: 0px; display: flex; align-items: center; color: rgba(0, 0, 0, 0.5); padding-left: 0; padding-right: 0; "
                       tabindex="-1"
                       unselectable="on"
                     />
@@ -448,7 +448,7 @@ exports[`renders correctly with various optional props 1`] = `
                       col-id="test"
                       comp-id="16"
                       role="gridcell"
-                      style="width: 100px; left: 54px;  "
+                      style="width: 100px; left: 34px;  "
                       tabindex="-1"
                       unselectable="on"
                     >
@@ -532,7 +532,7 @@ exports[`renders correctly with various optional props 1`] = `
                 class="ag-floating-bottom-container"
                 ref="eBottomContainer"
                 role="presentation"
-                style="width: 154px;"
+                style="width: 134px;"
                 unselectable="on"
               />
               
@@ -584,7 +584,7 @@ exports[`renders correctly with various optional props 1`] = `
               <div
                 class="ag-body-horizontal-scroll-container"
                 ref="eBodyHorizontalScrollContainer"
-                style="width: 154px; height: 0px; max-height: 0px; min-height: 0px;"
+                style="width: 134px; height: 0px; max-height: 0px; min-height: 0px;"
               />
               
             

--- a/src/components/general/__snapshots__/GridContainer.test.tsx.snap
+++ b/src/components/general/__snapshots__/GridContainer.test.tsx.snap
@@ -132,20 +132,20 @@ exports[`should render a grid with data, allow searching and resetting 1`] = `
                     class="ag-header-container"
                     ref="eHeaderContainer"
                     role="rowgroup"
-                    style="width: 154px;"
+                    style="width: 134px;"
                   >
                     <div
                       aria-rowindex="1"
                       class="ag-header-row ag-header-row-column"
                       role="row"
-                      style="top: 0px; height: 48px; width: 154px;"
+                      style="top: 0px; height: 48px; width: 134px;"
                     >
                       <div
                         aria-colindex="1"
                         class="ag-header-cell ag-focus-managed"
                         col-id="__detail-button-col__"
                         role="columnheader"
-                        style="width: 54px; left: 0px;"
+                        style="width: 34px; left: 0px;"
                         tabindex="-1"
                         unselectable="on"
                       >
@@ -250,7 +250,7 @@ exports[`should render a grid with data, allow searching and resetting 1`] = `
                         class="ag-header-cell ag-focus-managed"
                         col-id="test"
                         role="columnheader"
-                        style="width: 100px; left: 54px;"
+                        style="width: 100px; left: 34px;"
                         tabindex="-1"
                         unselectable="on"
                       >
@@ -406,7 +406,7 @@ exports[`should render a grid with data, allow searching and resetting 1`] = `
                     class="ag-floating-top-container"
                     ref="eTopContainer"
                     role="presentation"
-                    style="width: 154px;"
+                    style="width: 134px;"
                     unselectable="on"
                   />
                   
@@ -470,7 +470,7 @@ exports[`should render a grid with data, allow searching and resetting 1`] = `
                       class="ag-center-cols-container"
                       ref="eCenterContainer"
                       role="rowgroup"
-                      style="width: 154px; height: 1px;"
+                      style="width: 134px; height: 1px;"
                       unselectable="on"
                     />
                     
@@ -531,7 +531,7 @@ exports[`should render a grid with data, allow searching and resetting 1`] = `
                     class="ag-floating-bottom-container"
                     ref="eBottomContainer"
                     role="presentation"
-                    style="width: 154px;"
+                    style="width: 134px;"
                     unselectable="on"
                   />
                   
@@ -583,7 +583,7 @@ exports[`should render a grid with data, allow searching and resetting 1`] = `
                   <div
                     class="ag-body-horizontal-scroll-container"
                     ref="eBodyHorizontalScrollContainer"
-                    style="width: 154px; height: 0px; max-height: 0px; min-height: 0px;"
+                    style="width: 134px; height: 0px; max-height: 0px; min-height: 0px;"
                   />
                   
             
@@ -887,20 +887,20 @@ exports[`should render an empty grid 1`] = `
                     class="ag-header-container"
                     ref="eHeaderContainer"
                     role="rowgroup"
-                    style="width: 54px;"
+                    style="width: 34px;"
                   >
                     <div
                       aria-rowindex="1"
                       class="ag-header-row ag-header-row-column"
                       role="row"
-                      style="top: 0px; height: 48px; width: 54px;"
+                      style="top: 0px; height: 48px; width: 34px;"
                     >
                       <div
                         aria-colindex="1"
                         class="ag-header-cell ag-focus-managed"
                         col-id="__detail-button-col__"
                         role="columnheader"
-                        style="width: 54px; left: 0px;"
+                        style="width: 34px; left: 0px;"
                         tabindex="-1"
                         unselectable="on"
                       >
@@ -1054,7 +1054,7 @@ exports[`should render an empty grid 1`] = `
                     class="ag-floating-top-container"
                     ref="eTopContainer"
                     role="presentation"
-                    style="width: 54px;"
+                    style="width: 34px;"
                     unselectable="on"
                   />
                   
@@ -1118,7 +1118,7 @@ exports[`should render an empty grid 1`] = `
                       class="ag-center-cols-container"
                       ref="eCenterContainer"
                       role="rowgroup"
-                      style="width: 54px; height: 1px;"
+                      style="width: 34px; height: 1px;"
                       unselectable="on"
                     />
                     
@@ -1179,7 +1179,7 @@ exports[`should render an empty grid 1`] = `
                     class="ag-floating-bottom-container"
                     ref="eBottomContainer"
                     role="presentation"
-                    style="width: 54px;"
+                    style="width: 34px;"
                     unselectable="on"
                   />
                   
@@ -1231,7 +1231,7 @@ exports[`should render an empty grid 1`] = `
                   <div
                     class="ag-body-horizontal-scroll-container"
                     ref="eBodyHorizontalScrollContainer"
-                    style="width: 54px; height: 0px; max-height: 0px; min-height: 0px;"
+                    style="width: 34px; height: 0px; max-height: 0px; min-height: 0px;"
                   />
                   
             

--- a/src/components/general/__snapshots__/GridContainer.test.tsx.snap
+++ b/src/components/general/__snapshots__/GridContainer.test.tsx.snap
@@ -3,24 +3,24 @@
 exports[`should render a grid with data, allow searching and resetting 1`] = `
 <div>
   <div
-    class="ag-theme-alpine makeStyles-root-19"
+    class="ag-theme-alpine makeStyles-root-20"
   >
     <div
-      class="makeStyles-toolbar-20"
+      class="makeStyles-toolbar-21"
     >
       <h2
-        class="MuiTypography-root makeStyles-root-22 MuiTypography-h2"
+        class="MuiTypography-root makeStyles-root-23 MuiTypography-h2"
       >
         Test Grid
       </h2>
       <div
-        class="makeStyles-root-23"
+        class="makeStyles-root-24"
       >
         <div
-          class="makeStyles-search-25"
+          class="makeStyles-search-26"
         >
           <div
-            class="makeStyles-searchIcon-26"
+            class="makeStyles-searchIcon-28"
           >
             <svg
               aria-hidden="true"
@@ -34,11 +34,11 @@ exports[`should render a grid with data, allow searching and resetting 1`] = `
             </svg>
           </div>
           <div
-            class="MuiInputBase-root makeStyles-inputRoot-29 Mui-focused"
+            class="MuiInputBase-root makeStyles-inputRoot-31 Mui-focused"
           >
             <input
               aria-label="Search"
-              class="MuiInputBase-input makeStyles-inputInput-30"
+              class="MuiInputBase-input makeStyles-inputInput-32"
               placeholder="Search…"
               type="text"
               value="explat_test"
@@ -62,7 +62,7 @@ exports[`should render a grid with data, allow searching and resetting 1`] = `
       </div>
     </div>
     <div
-      class="ag-theme-alpine makeStyles-gridContainer-21"
+      class="ag-theme-alpine makeStyles-gridContainer-22"
     >
       <div
         style="height: auto; flex: 1;"

--- a/src/components/metrics/MetricsTableAgGrid.test.tsx
+++ b/src/components/metrics/MetricsTableAgGrid.test.tsx
@@ -108,3 +108,20 @@ test('with some metrics can search parameters', async () => {
     expect(metric).not.toBeInTheDocument()
   })
 })
+
+test('with some metrics and onAssignMetric can click on the assign metric button', async () => {
+  const user = userEvent.setup()
+  const onAssignMetric = jest.fn()
+  const { container } = render(
+    <MetricsTableAgGrid metrics={Fixtures.createMetrics(2)} onAssignMetric={onAssignMetric} />,
+  )
+
+  const containerElmt = container.querySelector('.ag-center-cols-container') as HTMLDivElement
+  await waitFor(() => getByText(containerElmt, /metric_1/), { container })
+
+  const buttons = screen.getAllByRole('button', { name: /Assign metric/i })
+
+  await user.click(buttons[0])
+
+  expect(onAssignMetric.mock.calls.length).toBe(1)
+})

--- a/src/components/metrics/MetricsTableAgGrid.tsx
+++ b/src/components/metrics/MetricsTableAgGrid.tsx
@@ -8,7 +8,13 @@ import React from 'react'
 import { Metric } from 'src/lib/schemas'
 
 import GridContainer from '../general/GridContainer'
-import { Data, MetricDetailRenderer, MetricEditButtonRenderer, MetricNameRenderer } from './MetricsTableAgGrid.utils'
+import {
+  AssignMetricButtonRenderer,
+  Data,
+  MetricDetailRenderer,
+  MetricEditButtonRenderer,
+  MetricNameRenderer,
+} from './MetricsTableAgGrid.utils'
 
 const ACTION_COLUMN_SUFFIX = '--actions'
 
@@ -19,10 +25,12 @@ const MetricsTableAgGrid = ({
   title,
   metrics,
   onEditMetric,
+  onAssignMetric,
 }: {
   title?: string
   metrics: Metric[]
   onEditMetric?: (metricId: number) => void
+  onAssignMetric?: (data: Metric) => void
 }): JSX.Element => {
   const theme = useTheme()
 
@@ -70,6 +78,7 @@ const MetricsTableAgGrid = ({
     {
       headerName: 'Parameter Type',
       field: 'parameterType',
+      hide: !!onAssignMetric,
       width: 200,
     },
     {
@@ -91,7 +100,7 @@ const MetricsTableAgGrid = ({
       ? [
           {
             headerName: 'Actions',
-            field: `metrics${ACTION_COLUMN_SUFFIX}`,
+            field: `metrics-edit${ACTION_COLUMN_SUFFIX}`,
             sortable: false,
             filter: false,
             resizable: false,
@@ -107,6 +116,26 @@ const MetricsTableAgGrid = ({
             ),
             width: 100,
             minWidth: 54,
+          },
+        ]
+      : []),
+    ...(onAssignMetric
+      ? [
+          {
+            headerName: 'Actions',
+            field: `metrics-assign${ACTION_COLUMN_SUFFIX}`,
+            sortable: false,
+            filter: false,
+            resizable: false,
+            cellStyle: {
+              justifyContent: 'center',
+              padding: '10px 4px',
+            },
+            cellRendererFramework: ({ data }: { data: Metric }) => (
+              <AssignMetricButtonRenderer data={data} onAssignMetric={onAssignMetric} />
+            ),
+            width: 150,
+            minWidth: 150,
           },
         ]
       : []),

--- a/src/components/metrics/MetricsTableAgGrid.tsx
+++ b/src/components/metrics/MetricsTableAgGrid.tsx
@@ -1,7 +1,7 @@
 import 'ag-grid-community/dist/styles/ag-grid.css'
 import 'ag-grid-community/dist/styles/ag-theme-alpine.css'
 
-import { useTheme } from '@material-ui/core'
+import { makeStyles, useTheme } from '@material-ui/core'
 import { GetQuickFilterTextParams } from 'ag-grid-community'
 import React from 'react'
 
@@ -14,7 +14,14 @@ import {
   MetricDetailRenderer,
   MetricEditButtonRenderer,
   MetricNameRenderer,
+  WizardMetricDetailRenderer,
 } from './MetricsTableAgGrid.utils'
+
+const useStyles = makeStyles({
+  noLeftPadding: {
+    paddingLeft: '0 !important',
+  },
+})
 
 const ACTION_COLUMN_SUFFIX = '--actions'
 
@@ -33,6 +40,7 @@ const MetricsTableAgGrid = ({
   onAssignMetric?: (data: Metric) => void
 }): JSX.Element => {
   const theme = useTheme()
+  const classes = useStyles()
 
   const paramsGetQuickFilterText = (params: GetQuickFilterTextParams) => {
     return JSON.stringify(params.value, null, 4)
@@ -57,13 +65,15 @@ const MetricsTableAgGrid = ({
   const columnDefs = [
     {
       headerName: 'Name',
+      headerClass: classes.noLeftPadding,
       field: 'name',
       cellStyle: {
         fontFamily: theme.custom.fonts.monospace,
         fontWeight: theme.custom.fontWeights.monospaceBold,
+        paddingLeft: 0,
       },
       cellRendererFramework: ({ value: name }: { value: string }) => <MetricNameRenderer name={name} />,
-      width: 430,
+      width: 465,
     },
     {
       headerName: 'Description',
@@ -73,7 +83,7 @@ const MetricsTableAgGrid = ({
         lineHeight: '15px',
         wordBreak: 'normal',
       },
-      width: 590,
+      width: 550,
     },
     {
       headerName: 'Parameter Type',
@@ -153,7 +163,7 @@ const MetricsTableAgGrid = ({
       defaultColDef={defaultColDef}
       columnDefs={columnDefs}
       getRowNodeId={getRowNodeId}
-      detailRowRenderer={MetricDetailRenderer}
+      detailRowRenderer={onAssignMetric ? WizardMetricDetailRenderer : MetricDetailRenderer}
       actionColumnIdSuffix={ACTION_COLUMN_SUFFIX}
       defaultSortColumnId='name'
     />

--- a/src/components/metrics/MetricsTableAgGrid.tsx
+++ b/src/components/metrics/MetricsTableAgGrid.tsx
@@ -16,9 +16,11 @@ const ACTION_COLUMN_SUFFIX = '--actions'
  * Renders a table of metrics information with a detail row component.
  */
 const MetricsTableAgGrid = ({
+  title,
   metrics,
   onEditMetric,
 }: {
+  title?: string
   metrics: Metric[]
   onEditMetric?: (metricId: number) => void
 }): JSX.Element => {
@@ -116,7 +118,7 @@ const MetricsTableAgGrid = ({
 
   return (
     <GridContainer
-      title='Metrics'
+      title={title}
       search
       rowData={metrics as Data[]}
       defaultColDef={defaultColDef}

--- a/src/components/metrics/MetricsTableAgGrid.utils.tsx
+++ b/src/components/metrics/MetricsTableAgGrid.utils.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   createStyles,
   IconButton,
   makeStyles,
@@ -9,9 +10,9 @@ import {
   TableRow,
   Theme,
   Tooltip,
+  withStyles,
 } from '@material-ui/core'
-import { Edit as EditIcon } from '@material-ui/icons'
-import debugFactory from 'debug'
+import { Add as AddIcon, Edit as EditIcon } from '@material-ui/icons'
 import React from 'react'
 
 import { Metric } from 'src/lib/schemas'
@@ -19,9 +20,7 @@ import { formatBoolean } from 'src/utils/formatters'
 
 export type Data = Partial<Metric & Record<string, unknown>>
 
-const debug = debugFactory('abacus:components/MetricTableRenderers.tsx')
-
-const useStyles = makeStyles((theme: Theme) =>
+const useMetricDetailStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       padding: theme.spacing(2, 8),
@@ -46,20 +45,45 @@ const useStyles = makeStyles((theme: Theme) =>
       borderStyle: 'solid',
       background: '#fff',
     },
-    metricName: {
-      minWidth: 0,
-      flex: 1,
-      justifyContent: 'flex-start',
-      whiteSpace: 'nowrap',
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-    },
   }),
 )
 
+const useMetricNameStyles = makeStyles({
+  metricName: {
+    minWidth: 0,
+    flex: 1,
+    justifyContent: 'flex-start',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+})
+
+const useAssignMetricButtonStyles = makeStyles({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    '& .MuiButton-containedSizeSmall': {
+      padding: '5px 15px',
+      fontSize: '14px',
+      lineHeight: 1.75,
+    },
+    '& .MuiButton-label': {
+      fontSize: '0.875rem',
+      marginRight: 4,
+    },
+    '& .MuiButton-startIcon': {
+      marginLeft: 0,
+      marginRight: 2,
+    },
+  },
+  noWrap: {
+    whiteSpace: 'nowrap',
+  },
+})
+
 export const MetricDetailRenderer = ({ data }: { data: Data }): JSX.Element => {
-  debug('MetricDetailRenderer#render')
-  const classes = useStyles()
+  const classes = useMetricDetailStyles()
 
   return (
     <TableContainer className={classes.root}>
@@ -84,8 +108,7 @@ export const MetricDetailRenderer = ({ data }: { data: Data }): JSX.Element => {
 }
 
 export const MetricNameRenderer = ({ name }: { name: string }): JSX.Element => {
-  debug('MetricNameRenderer#render')
-  const classes = useStyles()
+  const classes = useMetricNameStyles()
 
   return (
     <Tooltip title={name}>
@@ -101,8 +124,6 @@ export const MetricEditButtonRenderer = ({
   data: Metric
   onEditMetric: (metricId: number) => void
 }): JSX.Element => {
-  debug('MetricEditButtonRenderer#render')
-
   return (
     <IconButton
       onClick={() => {
@@ -112,5 +133,42 @@ export const MetricEditButtonRenderer = ({
     >
       <EditIcon />
     </IconButton>
+  )
+}
+
+export const AssignMetricButtonRenderer = ({
+  data,
+  onAssignMetric,
+}: {
+  data: Metric
+  onAssignMetric: (data: Metric) => void
+}): JSX.Element => {
+  const classes = useAssignMetricButtonStyles()
+
+  const ColorButton = withStyles((theme: Theme) => ({
+    root: {
+      color: theme.palette.primary.contrastText,
+      backgroundColor: theme.palette.primary.light,
+      '&:hover': {
+        backgroundColor: theme.palette.primary.main,
+      },
+    },
+  }))(Button)
+
+  return (
+    <div className={classes.root}>
+      <ColorButton
+        variant='contained'
+        color='primary'
+        disableElevation
+        size='small'
+        onClick={() => onAssignMetric(data)}
+        startIcon={<AddIcon />}
+        className={classes.noWrap}
+        aria-label='Assign metric'
+      >
+        Assign Metric
+      </ColorButton>
+    </div>
   )
 }

--- a/src/components/metrics/MetricsTableAgGrid.utils.tsx
+++ b/src/components/metrics/MetricsTableAgGrid.utils.tsx
@@ -107,6 +107,39 @@ export const MetricDetailRenderer = ({ data }: { data: Data }): JSX.Element => {
   )
 }
 
+export const WizardMetricDetailRenderer = ({ data }: { data: Data }): JSX.Element => {
+  const classes = useMetricDetailStyles()
+
+  return (
+    <TableContainer className={classes.root}>
+      <Table>
+        <TableBody>
+          <TableRow>
+            <TableCell className={classes.headerCell}>Name:</TableCell>
+            <TableCell className={classes.dataCell}>{data.name}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell className={classes.headerCell}>Parameter Type:</TableCell>
+            <TableCell className={classes.dataCell}>{data.parameterType}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell className={classes.headerCell}>Higher is Better:</TableCell>
+            <TableCell className={classes.dataCell}>{formatBoolean(data.higherIsBetter as boolean)}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell className={classes.headerCell}>Parameters:</TableCell>
+            <TableCell className={classes.dataCell}>
+              <div className={classes.pre}>
+                {JSON.stringify(data.parameterType === 'conversion' ? data.eventParams : data.revenueParams, null, 4)}
+              </div>
+            </TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </TableContainer>
+  )
+}
+
 export const MetricNameRenderer = ({ name }: { name: string }): JSX.Element => {
   const classes = useMetricNameStyles()
 

--- a/src/pages/Metrics.tsx
+++ b/src/pages/Metrics.tsx
@@ -111,7 +111,11 @@ const MetricsIndexPage = (): JSX.Element => {
       {isLoading && <LinearProgress />}
       {metrics && (
         <>
-          <MetricsTableAgGrid metrics={metrics || []} onEditMetric={debugMode ? onEditMetric : undefined} />
+          <MetricsTableAgGrid
+            title='Metrics'
+            metrics={metrics || []}
+            onEditMetric={debugMode ? onEditMetric : undefined}
+          />
           {debugMode && (
             <div className={classes.actions}>
               <Button variant='contained' color='secondary' onClick={onAddMetric}>


### PR DESCRIPTION
## Changes in this PR

**Metrics Assignment Table Stacked PR: 3/3**: based on #626. 

- Adds the metrics table to the experiment wizard metrics assignment page.
- Add a title prop so that the title is optional, and the search bar can be full width.
- Adds a light grey border around the search bar when it is full width
- Can use the "Assign Metric" button to assign metrics now.
- Decreases the row toggle button size.
- Adds additional metric info to the detail row to make the metrics table more compact.
- Update tests and snapshots.

Relevant to #604

## Screenshot

<img width="950" alt="Screen Shot 2022-01-07 at 3 39 24 PM" src="https://user-images.githubusercontent.com/1518252/148613656-8f2809bd-667b-40eb-9cb1-fa4b3856aaf6.png">

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
- Manual testing with mock data (locally or on Vercel)

## Known issues

In this PR, any open detail rows will disappear after clicking an "Assign Metric" button. This is fixed in a subsequent PR.