### PR TITLE
Retain search history: Add @testing-library/user-event for testing ExperimentsTableAgGrid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8739,6 +8739,26 @@
         "@types/testing-library__react-hooks": "^3.0.0"
       }
     },
+    "@testing-library/user-event": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
+      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
+          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "@turf/area": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@turf/area/-/area-6.0.1.tgz",
@@ -9338,7 +9358,6 @@
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9536,8 +9555,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -9627,8 +9645,7 @@
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -18211,15 +18228,11 @@
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
       "dev": true,
-      "requires": {
-        "icu4c-data": "^0.67.2"
-      },
       "dependencies": {
         "icu4c-data": {
           "version": "0.67.2",
           "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.67.2.tgz",
-          "integrity": "sha512-OIRiop+k1IVf4TBLEOj910duoO9NKwtJLwp++qWT6KT5gRziHNt+5gwhcGuTqRy++RTK2gLoAIbk8KYCNxW++g==",
-          "dev": true
+          "integrity": "sha512-OIRiop+k1IVf4TBLEOj910duoO9NKwtJLwp++qWT6KT5gRziHNt+5gwhcGuTqRy++RTK2gLoAIbk8KYCNxW++g=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8740,9 +8740,9 @@
       }
     },
     "@testing-library/user-event": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
-      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "version": "14.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.0.0-beta.7.tgz",
+      "integrity": "sha512-VYpTXUIPWpma1AbtuZnzLdoGr1yz1CMJU+A9rVMIez40V5ycvWiAbgDYh+rAdWItj5nXCC5G73bDNppYgC+8QQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@testing-library/jest-dom": "^5.11.1",
     "@testing-library/react": "^11.0.4",
     "@testing-library/react-hooks": "^3.3.0",
-    "@testing-library/user-event": "^13.5.0",
+    "@testing-library/user-event": "^14.0.0-beta.7",
     "@types/css-mediaquery": "^0.1.0",
     "@types/debug": "^4.1.5",
     "@types/expect-puppeteer": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@testing-library/jest-dom": "^5.11.1",
     "@testing-library/react": "^11.0.4",
     "@testing-library/react-hooks": "^3.3.0",
+    "@testing-library/user-event": "^13.5.0",
     "@types/css-mediaquery": "^0.1.0",
     "@types/debug": "^4.1.5",
     "@types/expect-puppeteer": "^4.4.1",


### PR DESCRIPTION
**Stacked PR 1/2 for retaining search history**: next #635 

This PR adds [the `@testing-library/user-event` module](https://testing-library.com/docs/ecosystem-user-event/) which allows for more advanced simulation of browser interactions than `fireEvent`. This was necessary (or at least made more convenient) the writing of tests for the new `ExperimentsTableAgGrid` code that allows for retaining search history.

Related to #545  

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Doesn't affect any other parts of the codebase
