### PR TITLE
Retain search history: Save last sort options

### DIFF
--- a/src/components/experiments/multi-view/ExperimentsTableAgGrid.test.tsx
+++ b/src/components/experiments/multi-view/ExperimentsTableAgGrid.test.tsx
@@ -56,7 +56,7 @@ it('should allow searching, sorting, and resetting by changing url params', asyn
   await screen.findByText(/First/)
 
   // Wait for default sorting options
-  let expectedParamsObj = defaultSortParams as UrlParams
+  let expectedParamsObj: UrlParams = defaultSortParams
   await waitFor(() => {
     expect(history.length).toBe(2)
   })
@@ -79,7 +79,7 @@ it('should allow searching, sorting, and resetting by changing url params', asyn
     search: searchString,
   }
   const nameColumn = screen.getByText(/Name/)
-  userEvent.click(nameColumn)
+  await userEvent.click(nameColumn)
   await waitFor(() => {
     container.querySelectorAll('.ag-header-cell-label').forEach((value, _key, _parent) => {
       const headerText = value.querySelector('.ag-header-cell-text')?.innerHTML
@@ -133,15 +133,15 @@ it('getting rid of all sorting should result in special url params', async () =>
     null: 'true',
   }
   const nameColumn = screen.getByText(/Name/)
-  userEvent.click(nameColumn)
+  await userEvent.click(nameColumn)
   await waitFor(() => {
     expect(history.length).toBe(3)
   })
-  userEvent.click(nameColumn)
+  await userEvent.click(nameColumn)
   await waitFor(() => {
     expect(history.length).toBe(4)
   })
-  userEvent.click(nameColumn)
+  await userEvent.click(nameColumn)
   await waitFor(() => {
     expect(history.length).toBe(5)
   })

--- a/src/components/experiments/multi-view/ExperimentsTableAgGrid.test.tsx
+++ b/src/components/experiments/multi-view/ExperimentsTableAgGrid.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import addToDate from 'date-fns/add'
 import { createMemoryHistory } from 'history'
@@ -9,7 +9,7 @@ import { ExperimentBare, Platform, Status } from 'src/lib/schemas'
 import { changeFieldByRole, render } from 'src/test-helpers/test-utils'
 
 import ExperimentsTableAgGrid from './ExperimentsTableAgGrid'
-import { getParamsStringFromObj } from './ExperimentsTableAgGrid.utils'
+import { defaultSortParams, getParamsStringFromObj, UrlParams } from './ExperimentsTableAgGrid.utils'
 
 it('should render an empty table', () => {
   const { container } = render(<ExperimentsTableAgGrid experiments={[]} />)
@@ -34,7 +34,73 @@ it('should render a table with experiments', async () => {
   expect(container).toMatchSnapshot()
 })
 
-it('should allow searching and resetting by changing url params', async () => {
+it('should allow searching, sorting, and resetting by changing url params', async () => {
+  const history = createMemoryHistory()
+  const experiments: ExperimentBare[] = [
+    {
+      experimentId: 1,
+      name: 'First',
+      endDatetime: addToDate(new Date(), { days: 14 }),
+      ownerLogin: 'Owner',
+      platform: Platform.Wpcom,
+      startDatetime: new Date(),
+      status: Status.Staging,
+    },
+  ]
+  const { container } = render(
+    <Router history={history}>
+      <ExperimentsTableAgGrid experiments={experiments} />
+    </Router>,
+  )
+
+  await screen.findByText(/First/)
+
+  // Wait for default sorting options
+  let expectedParamsObj = defaultSortParams as UrlParams
+  await waitFor(() => {
+    expect(history.length).toBe(2)
+  })
+  expect(history.location.search).toBe(`?${getParamsStringFromObj(expectedParamsObj)}`)
+
+  // Test search bar
+  const searchString = 'explat_test'
+  expectedParamsObj = {
+    ...expectedParamsObj,
+    search: searchString,
+  }
+  await changeFieldByRole('textbox', /Search/, searchString)
+  expect(history.length).toBe(3)
+  expect(history.location.search).toBe(`?${getParamsStringFromObj(expectedParamsObj)}`)
+
+  // Test sorting
+  expectedParamsObj = {
+    nameS: 'asc',
+    nameSi: '0',
+    search: searchString,
+  }
+  const nameColumn = screen.getByText(/Name/)
+  userEvent.click(nameColumn)
+  await waitFor(() => {
+    container.querySelectorAll('.ag-header-cell-label').forEach((value, _key, _parent) => {
+      const headerText = value.querySelector('.ag-header-cell-text')?.innerHTML
+      if (headerText === 'Name') {
+        expect(value.querySelector('.ag-icon-asc')).toBeInTheDocument()
+      }
+    })
+  })
+  expect(history.length).toBe(4)
+  expect(history.location.search).toBe(`?${getParamsStringFromObj(expectedParamsObj)}`)
+
+  // Test reset
+  expectedParamsObj = defaultSortParams
+  const resetButton = screen.getByRole('button', { name: /Reset/ })
+  userEvent.click(resetButton)
+  await screen.findByText(/wpcom/)
+  expect(history.length).toBe(5)
+  expect(history.location.search).toBe(`?${getParamsStringFromObj(expectedParamsObj)}`)
+})
+
+it('getting rid of all sorting should result in special url params', async () => {
   const history = createMemoryHistory()
   const experiments: ExperimentBare[] = [
     {
@@ -55,19 +121,29 @@ it('should allow searching and resetting by changing url params', async () => {
 
   await screen.findByText(/First/)
 
-  // Test search bar
-  const searchString = 'explat_test'
-  const expectedParamsObj = {
-    search: searchString,
-  }
-  await changeFieldByRole('textbox', /Search/, searchString)
-  expect(history.length).toBe(2)
+  // Wait for default sorting options
+  let expectedParamsObj = defaultSortParams as UrlParams
+  await waitFor(() => {
+    expect(history.length).toBe(2)
+  })
   expect(history.location.search).toBe(`?${getParamsStringFromObj(expectedParamsObj)}`)
 
-  // Test reset
-  const resetButton = screen.getByRole('button', { name: /Reset/ })
-  userEvent.click(resetButton)
-  await screen.findByText(/wpcom/)
-  expect(history.length).toBe(3)
-  expect(history.location.search).toBe('')
+  // Test sorting
+  expectedParamsObj = {
+    null: 'true',
+  }
+  const nameColumn = screen.getByText(/Name/)
+  userEvent.click(nameColumn)
+  await waitFor(() => {
+    expect(history.length).toBe(3)
+  })
+  userEvent.click(nameColumn)
+  await waitFor(() => {
+    expect(history.length).toBe(4)
+  })
+  userEvent.click(nameColumn)
+  await waitFor(() => {
+    expect(history.length).toBe(5)
+  })
+  expect(history.location.search).toBe(`?${getParamsStringFromObj(expectedParamsObj)}`)
 })

--- a/src/components/experiments/multi-view/ExperimentsTableAgGrid.utils.tsx
+++ b/src/components/experiments/multi-view/ExperimentsTableAgGrid.utils.tsx
@@ -1,5 +1,14 @@
+import { ColumnApi, ColumnState } from 'ag-grid-community'
+
 export interface UrlParams {
   [key: string]: string
+}
+
+export const defaultSortParams = {
+  statusS: 'asc',
+  statusSi: '0',
+  startDatetimeS: 'desc',
+  startDatetimeSi: '1',
 }
 
 export const getParamsStringFromObj = (paramsObj: UrlParams): string => {
@@ -11,9 +20,74 @@ export const getParamsStringFromObj = (paramsObj: UrlParams): string => {
   const noNullVals = Object.entries(paramsObj).filter(([_key, value]) => value !== null && value !== undefined)
   const filteredParams = Object.fromEntries(noNullVals)
 
+  // special param if the search/filter is empty (to distinguish from default URL)
+  if (Object.keys(filteredParams).length === 0) {
+    return 'null=true'
+  }
+
   return new URLSearchParams(filteredParams).toString()
 }
 
 export const getParamsObjFromSearchString = (search: string): UrlParams => {
   return Object.fromEntries(new URLSearchParams(search).entries()) as UrlParams
+}
+
+export const getSortParamsFromGrid = (colState: ColumnState[]): UrlParams => {
+  return colState
+    .filter((value: ColumnState) => value.sort !== null)
+    .map((value: ColumnState) => {
+      // istanbul ignore next; trivial and shouldn't occur
+      if (!value.colId) {
+        return {}
+      }
+
+      return {
+        [`${value.colId}S`]: value.sort,
+        [`${value.colId}Si`]: String(value.sortIndex),
+      } as UrlParams
+    })
+    .reduce((prevValue: UrlParams, currentValue: UrlParams) => {
+      return {
+        ...prevValue,
+        ...currentValue,
+      } as UrlParams
+    }, {})
+}
+
+export const getSortParamsFromUrlParams = (params: UrlParams): UrlParams => {
+  const sortParams = {} as UrlParams
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (key.endsWith('S') || key.endsWith('Si')) {
+      sortParams[key] = value
+    }
+  })
+
+  return sortParams
+}
+
+export const setGridSort = (params: UrlParams, gridColumnApi: ColumnApi): void => {
+  const columnState = gridColumnApi.getColumnState()
+
+  const state = columnState
+    .map((column: ColumnState) => {
+      const colId = column.colId as string
+      return params[`${colId}Si`]
+        ? [
+            {
+              colId: colId,
+              sort: params[`${colId}S`],
+              sortIndex: parseInt(params[`${colId}Si`]),
+            },
+          ]
+        : []
+    })
+    .reduce((prevValue, currentValue) => {
+      return [...prevValue, ...currentValue]
+    }, [])
+
+  gridColumnApi.applyColumnState({
+    state: state,
+    defaultState: { sort: null },
+  })
 }


### PR DESCRIPTION
**Stacked PR 3/4 for retaining search history:** based on #635. Next #637 

Saves sorting options on the experiments AG grid to the URL params.

Related to #545 

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
- Manual testing with mock data (locally or on Vercel)
