### PR TITLE
Retain search history: Save last filter options

### DIFF
--- a/src/components/experiments/multi-view/ExperimentsTableAgGrid.test.tsx
+++ b/src/components/experiments/multi-view/ExperimentsTableAgGrid.test.tsx
@@ -101,15 +101,17 @@ it('should allow searching, filtering, sorting, and resetting by changing url pa
     search: searchString,
   }
   const cellLabels = container.querySelectorAll('.ag-cell-label-container')
+  let filterMenu: Element | null = null
   cellLabels.forEach((value, _key, _parent) => {
     const headerText = value.querySelector('.ag-header-cell-text')?.innerHTML
     if (headerText === 'Name') {
-      const filterMenu = value.querySelector('.ag-icon-menu') as HTMLElement
-      userEvent.click(filterMenu)
+      filterMenu = value.querySelector('.ag-icon-menu') as Element
     }
   })
+  expect(filterMenu).not.toBeNull()
+  await userEvent.click((filterMenu as unknown) as Element)
   const inputField = container.querySelector('input[aria-label="Filter Value"]') as HTMLElement
-  userEvent.type(inputField, filterText)
+  await userEvent.type(inputField, filterText)
   await waitFor(() => {
     container.querySelectorAll('.ag-header-cell-label').forEach((value, _key, _parent) => {
       const headerText = value.querySelector('.ag-header-cell-text')?.innerHTML
@@ -138,12 +140,12 @@ it('should allow searching, filtering, sorting, and resetting by changing url pa
   cellLabels.forEach((value, _key, _parent) => {
     const headerText = value.querySelector('.ag-header-cell-text')?.innerHTML
     if (headerText === 'Name') {
-      const filterMenu = value.querySelector('.ag-icon-menu') as HTMLElement
-      userEvent.click(filterMenu)
+      filterMenu = value.querySelector('.ag-icon-menu') as HTMLElement
     }
   })
+  await userEvent.click((filterMenu as unknown) as Element)
   const inputFields = container.querySelectorAll('input[aria-label="Filter Value"]')
-  userEvent.type(inputFields[1], filterText2)
+  await userEvent.type(inputFields[1], filterText2)
   await waitFor(() => {
     expect(history.length).toBe(6)
   })
@@ -166,12 +168,12 @@ it('should allow searching, filtering, sorting, and resetting by changing url pa
   cellLabels.forEach((value, _key, _parent) => {
     const headerText = value.querySelector('.ag-header-cell-text')?.innerHTML
     if (headerText === 'Start') {
-      const filterMenu = value.querySelector('.ag-icon-menu') as HTMLElement
-      userEvent.click(filterMenu)
+      filterMenu = value.querySelector('.ag-icon-menu') as HTMLElement
     }
   })
+  await userEvent.click((filterMenu as unknown) as Element)
   const dateInputField = container.querySelector('input[placeholder="yyyy-mm-dd"]') as HTMLElement
-  userEvent.type(dateInputField, filterDate)
+  await userEvent.type(dateInputField, filterDate)
   await waitFor(() => {
     container.querySelectorAll('.ag-header-cell-label').forEach((value, _key, _parent) => {
       const headerText = value.querySelector('.ag-header-cell-text')?.innerHTML
@@ -205,12 +207,12 @@ it('should allow searching, filtering, sorting, and resetting by changing url pa
   cellLabels.forEach((value, _key, _parent) => {
     const headerText = value.querySelector('.ag-header-cell-text')?.innerHTML
     if (headerText === 'Start') {
-      const filterMenu = value.querySelector('.ag-icon-menu') as HTMLElement
-      userEvent.click(filterMenu)
+      filterMenu = value.querySelector('.ag-icon-menu') as HTMLElement
     }
   })
+  await userEvent.click((filterMenu as unknown) as Element)
   const dateInputFields = container.querySelectorAll('input[placeholder="yyyy-mm-dd"]')
-  userEvent.type(dateInputFields[2], filterDate2)
+  await userEvent.type(dateInputFields[2], filterDate2)
   await waitFor(() => {
     container.querySelectorAll('.ag-header-cell-label').forEach((value, _key, _parent) => {
       const headerText = value.querySelector('.ag-header-cell-text')?.innerHTML

--- a/src/components/experiments/multi-view/ExperimentsTableAgGrid.utils.tsx
+++ b/src/components/experiments/multi-view/ExperimentsTableAgGrid.utils.tsx
@@ -1,4 +1,34 @@
-import { ColumnApi, ColumnState } from 'ag-grid-community'
+import { ColumnApi, ColumnState, GridApi } from 'ag-grid-community'
+import _ from 'lodash'
+
+type FilterType = 'text' | 'date'
+type FilterOption =
+  | 'equals'
+  | 'notEqual'
+  | 'contains'
+  | 'notContains'
+  | 'startsWith'
+  | 'endsWith'
+  | 'lessThan'
+  | 'greaterThan'
+  | 'inRange'
+
+interface SingleFilterObj {
+  filterType: FilterType
+  type: FilterOption
+  filter?: string
+  dateFrom?: string
+  dateTo?: string
+}
+
+interface ConditionalFilterObj {
+  filterType: FilterType
+  operator: 'AND' | 'OR'
+  condition1: SingleFilterObj
+  condition2: SingleFilterObj
+}
+
+type FilterObj = SingleFilterObj | ConditionalFilterObj
 
 export interface UrlParams {
   [key: string]: string
@@ -30,6 +60,58 @@ export const getParamsStringFromObj = (paramsObj: UrlParams): string => {
 
 export const getParamsObjFromSearchString = (search: string): UrlParams => {
   return Object.fromEntries(new URLSearchParams(search).entries()) as UrlParams
+}
+
+export const getFilterParamsFromGrid = (api: GridApi, colState: ColumnState[]): UrlParams => {
+  return colState
+    .map((column: ColumnState) => column.colId as string)
+    .map((colId: string) => {
+      const filterInstance = api.getFilterInstance(colId)
+      return { model: filterInstance?.getModel() as FilterObj, colId: colId }
+    })
+    .filter(({ model }) => model !== null)
+    .map(({ model, colId }) => {
+      if ('operator' in model) {
+        if ('dateFrom' in model.condition1) {
+          return {
+            [`${colId}Op`]: model.operator,
+            [`${colId}C1df`]: model.condition1.dateFrom,
+            [`${colId}C1dt`]: model.condition1.dateTo,
+            [`${colId}C1t`]: model.condition1.type,
+            [`${colId}C2df`]: model.condition2.dateFrom,
+            [`${colId}C2dt`]: model.condition2.dateTo,
+            [`${colId}C2t`]: model.condition2.type,
+          } as UrlParams
+        } else {
+          return {
+            [`${colId}Op`]: model.operator,
+            [`${colId}C1f`]: model.condition1.filter,
+            [`${colId}C1t`]: model.condition1.type,
+            [`${colId}C2f`]: model.condition2.filter,
+            [`${colId}C2t`]: model.condition2.type,
+          } as UrlParams
+        }
+      } else {
+        if ('dateFrom' in model) {
+          return {
+            [`${colId}Df`]: model.dateFrom,
+            [`${colId}Dt`]: model.dateTo,
+            [`${colId}T`]: model.type,
+          } as UrlParams
+        } else {
+          return {
+            [`${colId}F`]: model.filter,
+            [`${colId}T`]: model.type,
+          } as UrlParams
+        }
+      }
+    })
+    .reduce((prevValue, currentValue) => {
+      return {
+        ...prevValue,
+        ...currentValue,
+      } as UrlParams
+    }, {})
 }
 
 export const getSortParamsFromGrid = (colState: ColumnState[]): UrlParams => {
@@ -66,6 +148,18 @@ export const getSortParamsFromUrlParams = (params: UrlParams): UrlParams => {
   return sortParams
 }
 
+export const getFilterParamsFromUrlParams = (params: UrlParams): UrlParams => {
+  const filterParams = {} as UrlParams
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (!(key.endsWith('S') || key.endsWith('Si') || key === 'search' || key === 'null')) {
+      filterParams[key] = value
+    }
+  })
+
+  return filterParams
+}
+
 export const setGridSort = (params: UrlParams, gridColumnApi: ColumnApi): void => {
   const columnState = gridColumnApi.getColumnState()
 
@@ -89,5 +183,62 @@ export const setGridSort = (params: UrlParams, gridColumnApi: ColumnApi): void =
   gridColumnApi.applyColumnState({
     state: state,
     defaultState: { sort: null },
+  })
+}
+
+export const setGridFilter = (params: UrlParams, gridApi: GridApi, gridColumnApi: ColumnApi): void => {
+  // istanbul ignore next; trivial and shouldn't occur
+  if (Object.keys(params).length === 0) {
+    gridApi.setFilterModel(null)
+    return
+  }
+
+  const columnState = gridColumnApi.getColumnState()
+  columnState.forEach((column: ColumnState) => {
+    const colId = column.colId as string
+    const filterInstance = gridApi.getFilterInstance(colId)
+
+    let filterType = ''
+    let singleFilter = {}
+    let condition1 = {}
+    let condition2 = {}
+    if (colId.endsWith('Datetime')) {
+      filterType = 'date'
+      singleFilter = { dateFrom: params[`${colId}Df`], dateTo: params[`${colId}Dt`] }
+      condition1 = { dateFrom: params[`${colId}C1df`], dateTo: params[`${colId}C1dt`] }
+      condition2 = { dateFrom: params[`${colId}C2df`], dateTo: params[`${colId}C2dt`] }
+    } else {
+      filterType = 'text'
+      singleFilter = { filter: params[`${colId}F`] }
+      condition1 = { filter: params[`${colId}C1f`] }
+      condition2 = { filter: params[`${colId}C2f`] }
+    }
+
+    let model = null
+    if (params[`${colId}F`] || params[`${colId}Df`]) {
+      model = {
+        ...singleFilter,
+        filterType: filterType,
+        type: params[`${colId}T`],
+      }
+    } else if (params[`${colId}Op`]) {
+      model = {
+        operator: params[`${colId}Op`],
+        filterType: filterType,
+        condition1: {
+          ...condition1,
+          filterType: filterType,
+          type: params[`${colId}C1t`],
+        },
+        condition2: {
+          ...condition2,
+          filterType: filterType,
+          type: params[`${colId}C2t`],
+        },
+      }
+    }
+
+    filterInstance?.setModel(model)
+    gridApi.onFilterChanged()
   })
 }


### PR DESCRIPTION
**Stacked PR 4/4 for retaining search history:** based on #636 

Saves the experiments AG grid filter options as URL params.

Closes #545 

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
- Manual testing with mock data (locally or on Vercel)
