### PR TITLE
WIP: Add duration instead of start/end date

### DIFF
--- a/src/components/experiments/wizard/BasicInfo.tsx
+++ b/src/components/experiments/wizard/BasicInfo.tsx
@@ -1,17 +1,20 @@
-import { InputAdornment, TextField as MuiTextField, Typography } from '@material-ui/core'
+import {
+  FormControl,
+  FormLabel,
+  InputAdornment,
+  Link,
+  MenuItem,
+  TextField as MuiTextField,
+  Typography,
+} from '@material-ui/core'
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
-import { Alert, AutocompleteRenderInputParams } from '@material-ui/lab'
-import * as dateFns from 'date-fns'
-import { Field, useField } from 'formik'
-import { TextField } from 'formik-material-ui'
+import { AutocompleteRenderInputParams } from '@material-ui/lab'
+import { Field } from 'formik'
+import { Select, TextField } from 'formik-material-ui'
 import React from 'react'
 
 import AbacusAutocomplete, { autocompleteInputProps } from 'src/components/general/Autocomplete'
-import {
-  MAX_DISTANCE_BETWEEN_NOW_AND_START_DATE_IN_MONTHS,
-  MAX_DISTANCE_BETWEEN_START_AND_END_DATE_IN_MONTHS,
-} from 'src/lib/schemas'
-import { formatIsoDate } from 'src/utils/time'
+import CollapsibleAlert from 'src/components/general/CollapsibleAlert'
 
 import { ExperimentFormCompletionBag } from './ExperimentForm'
 
@@ -38,13 +41,6 @@ const useStyles = makeStyles((theme: Theme) =>
         margin: theme.spacing(2, 2),
       },
     },
-    datePicker: {
-      flex: 1,
-      '& input:invalid': {
-        // Fix the native date-picker placeholder text colour
-        color: theme.palette.text.hint,
-      },
-    },
   }),
 )
 
@@ -54,15 +50,6 @@ const BasicInfo = ({
   completionBag: ExperimentFormCompletionBag
 }): JSX.Element => {
   const classes = useStyles()
-
-  const [startDateField] = useField('experiment.startDatetime')
-  const minStartDate = new Date()
-  const maxStartDate = dateFns.addMonths(new Date(), MAX_DISTANCE_BETWEEN_NOW_AND_START_DATE_IN_MONTHS)
-  const minEndDate = startDateField.value && new Date(startDateField.value)
-  const maxEndDate =
-    startDateField.value &&
-    dateFns.addMonths(new Date(startDateField.value), MAX_DISTANCE_BETWEEN_START_AND_END_DATE_IN_MONTHS)
-  const formatDateForInput = (date: Date) => (date ? formatIsoDate(date) : undefined)
 
   return (
     <div className={classes.root}>
@@ -107,45 +94,41 @@ const BasicInfo = ({
       </div>
 
       <div className={classes.row}>
-        <Field
-          component={TextField}
-          className={classes.datePicker}
-          name='experiment.startDatetime'
-          id='experiment.startDatetime'
-          label='Start date (UTC)'
-          type='date'
-          variant='outlined'
-          required
-          InputLabelProps={{
-            shrink: true,
-          }}
-          inputProps={{
-            min: formatDateForInput(minStartDate),
-            max: formatDateForInput(maxStartDate),
-          }}
-        />
-        <span className={classes.through}> through </span>
-        <Field
-          component={TextField}
-          className={classes.datePicker}
-          name='experiment.endDatetime'
-          id='experiment.endDatetime'
-          label='End date (UTC)'
-          type='date'
-          variant='outlined'
-          required
-          InputLabelProps={{
-            shrink: true,
-          }}
-          inputProps={{
-            min: formatDateForInput(minEndDate),
-            max: formatDateForInput(maxEndDate),
-          }}
-        />
+        <FormControl component='fieldset'>
+          <FormLabel required>Duration (in weeks)</FormLabel>
+          <Field component={Select} name='experiment.duration'>
+            <MenuItem value={0} disabled>
+              Set the experiment duration
+            </MenuItem>
+            <MenuItem value={1}>1 week</MenuItem>
+            {Array.from({ length: 5 }, (v, k) => k + 2).map((durationInWeeks) => (
+              <MenuItem key={durationInWeeks} value={durationInWeeks}>
+                {durationInWeeks} weeks
+              </MenuItem>
+            ))}
+          </Field>
+        </FormControl>
       </div>
-      <Alert severity='info'>
-        The experiment will <strong>start and end automatically</strong> around 00:10 UTC on these dates.
-      </Alert>
+
+      <CollapsibleAlert
+        id='duration-warning-panel'
+        severity='info'
+        summary='How do I calculate the duration for the experiment?'
+      >
+        <Link
+          underline='always'
+          href='https://www.optimizely.com/sample-size-calculator/?conversion=3&effect=20&significance=95'
+          target='_blank'
+        >
+          Use this calculator
+        </Link>{' '}
+        to determine the required experiment sample size and divide it by the actual weekly volume of the exposure event
+        as calculated in{' '}
+        <Link underline='always' href='https://mc.a8c.com/tracks/' target='_blank'>
+          Tracks
+        </Link>
+        <br />
+      </CollapsibleAlert>
 
       <div className={classes.row}>
         <Field

--- a/src/components/experiments/wizard/ExperimentForm.tsx
+++ b/src/components/experiments/wizard/ExperimentForm.tsx
@@ -46,13 +46,7 @@ const stages: Stage[] = [
   {
     id: StageId.BasicInfo,
     title: 'Basic Info',
-    validatableFields: [
-      'experiment.name',
-      'experiment.description',
-      'experiment.startDatetime',
-      'experiment.endDatetime',
-      'experiment.ownerLogin',
-    ],
+    validatableFields: ['experiment.name', 'experiment.description', 'experiment.duration', 'experiment.ownerLogin'],
   },
   {
     id: StageId.Audience,

--- a/src/lib/form-data.ts
+++ b/src/lib/form-data.ts
@@ -1,5 +1,3 @@
-import { formatIsoDate } from 'src/utils/time'
-
 import {
   Event,
   ExperimentFull,
@@ -73,15 +71,14 @@ function exposureEventToFormData(exposureEvent: Event): ExposureEventFormData {
 export function experimentToFormData(
   experiment: Partial<ExperimentFull>,
 ): {
-  startDatetime: string
   variations: VariationFormData[]
   segmentAssignments: SegmentAssignmentFormData[]
   name: string
   description: string
+  duration: number
   metricAssignments: MetricAssignmentFormData[]
   exposureEvents: ExposureEventFormData[]
   existingUsersAllowed: 'true' | 'false'
-  endDatetime: string
   platform: string
   p2Url: string
   ownerLogin: string
@@ -91,8 +88,7 @@ export function experimentToFormData(
     p2Url: experiment.p2Url ?? '',
     name: experiment.name ?? '',
     description: experiment.description ?? '',
-    startDatetime: experiment.startDatetime ? formatIsoDate(experiment.startDatetime) : '',
-    endDatetime: experiment.endDatetime ? formatIsoDate(experiment.endDatetime) : '',
+    duration: experiment.duration ?? 0,
     ownerLogin: experiment.ownerLogin ?? '',
     existingUsersAllowed:
       experiment.existingUsersAllowed === undefined

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -362,6 +362,7 @@ export const experimentBareSchema = yup
   .object({
     experimentId: idSchema.defined(),
     name: nameSchema.defined(),
+    duration: yup.number().defined(),
     startDatetime: dateSchema.defined(),
     endDatetime: dateSchema
       .defined()

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -362,7 +362,7 @@ export const experimentBareSchema = yup
   .object({
     experimentId: idSchema.defined(),
     name: nameSchema.defined(),
-    duration: yup.number().defined(),
+    duration: yup.number().notRequired(),
     startDatetime: dateSchema.defined(),
     endDatetime: dateSchema
       .defined()
@@ -415,6 +415,7 @@ const yupUndefined = yup.mixed().oneOf([]).notRequired()
 export const experimentFullNewSchema = experimentFullSchema.shape({
   experimentId: idSchema.nullable(),
   status: yupUndefined,
+  duration: yup.number().required(),
   assignmentCacheStatus: yupUndefined,
   startDatetime: dateSchema
     .defined()

--- a/src/test-helpers/fixtures.ts
+++ b/src/test-helpers/fixtures.ts
@@ -263,6 +263,7 @@ function createExperimentFullNew(fieldOverrides: Partial<ExperimentFullNew> = {}
   const endDatetime = new Date(new Date(new Date().setMonth(now.getMonth() + 4)).setUTCHours(0, 0, 0, 0))
   return {
     name: 'experiment_1',
+    duration: 2,
     startDatetime,
     endDatetime,
     platform: Platform.Calypso,


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Introduce a 'duration' field to replace the "start date" and "end date" when creating a new experiment.

**Before**
<img width="600" alt="Screenshot 2022-02-01 at 18 59 30" src="https://user-images.githubusercontent.com/14192054/152243234-ed9bab3f-563a-453c-9edd-9eb857a89d61.png">

**After**
<img width="600" alt="Screenshot 2022-02-01 at 18 58 38" src="https://user-images.githubusercontent.com/14192054/152243219-36cd7ebd-10c5-4897-aa6a-f1323d435be2.png">

Related: 406-gh-Automattic/experimentation-platform

## TBD (notes)
- Should we keep the `endDatetime` field when editing the experiment?
- In order to calculate the [Experiment run time](https://github.com/Automattic/experimentation-platform/wiki/Experiment-Health#experiment-run-time) in Metrics table, should the API continue to return `startDatetime`?

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- [ ] Automated tests that cover added/changed functionality
- [ ] Manual testing with production data (locally)
- [ ] Manual testing with mock data (locally or on Vercel)
- [ ] Additional manual testing instructions (please specify):