### PR TITLE
Generalise MetricAssignmentResults

### DIFF
--- a/src/components/explat/experiments/MetricAssignmentForm.tsx
+++ b/src/components/explat/experiments/MetricAssignmentForm.tsx
@@ -110,9 +110,6 @@ function MetricAssignmentForm({
           (formikProps.values.metricAssignment.metricId &&
             indexedMetrics[formikProps.values.metricAssignment.metricId as unknown as number]) ||
           undefined
-        const parameterType =
-          formikProps.values.metricAssignment.metricId &&
-          indexedMetrics[formikProps.values.metricAssignment.metricId as unknown as number].parameterType
         const metricAssignmentsError =
           formikProps.touched.metricAssignment?.metricId && formikProps.errors.metricAssignment?.metricId
         const onMetricChange = (_event: unknown, metric: Metric | null) => {
@@ -214,7 +211,7 @@ function MetricAssignmentForm({
                 </FormControl>
                 <ToggleButton
                   value='check'
-                  disabled={!parameterType}
+                  disabled={!metric}
                   selected={isActiveMinDiffCalculator}
                   onChange={handleMinDiffCalculatorToggle}
                   className={classes.minDifferenceCalculatorToggle}
@@ -225,14 +222,14 @@ function MetricAssignmentForm({
                 </ToggleButton>
               </div>
               <div className={clsx(classes.row, !isActiveMinDiffCalculator && classes.minDiffCalculatorCollapsed)}>
-                {parameterType && (
+                {metric && (
                   <MinDiffCalculator
                     setMinPracticalDiff={(newMinDiff) => handleMinPracticalDiffUpdate(newMinDiff)}
                     {...{
                       samplesPerMonth,
                       setSamplesPerMonth,
                       experiment: experimentToFormData(experiment),
-                      metricParameterType: parameterType,
+                      metric: metric,
                     }}
                   />
                 )}

--- a/src/components/explat/experiments/MinDiffCalculator.tsx
+++ b/src/components/explat/experiments/MinDiffCalculator.tsx
@@ -16,7 +16,8 @@ import React, { useState } from 'react'
 import DebugOutput from 'src/components/general/DebugOutput'
 import PrivateLink from 'src/components/general/PrivateLink'
 import { ExperimentFormData } from 'src/lib/explat/form-data'
-import { MetricParameterType } from 'src/lib/explat/schemas'
+import { getUnitInfo, UnitType } from 'src/lib/explat/metrics'
+import { Metric } from 'src/lib/explat/schemas'
 import { isDebugMode } from 'src/utils/general'
 import {
   defaultStatisticalPower,
@@ -63,16 +64,20 @@ const MinDiffCalculator = ({
   setSamplesPerMonth,
   setMinPracticalDiff,
   experiment,
-  metricParameterType,
+  metric,
 }: {
   samplesPerMonth: number
   setSamplesPerMonth: (n: number) => void
   setMinPracticalDiff: (n: number) => void
   experiment: ExperimentFormData
-  metricParameterType: MetricParameterType
+  metric: Metric
 }): JSX.Element => {
   const classes = useStyles()
-  const isConversion = metricParameterType === MetricParameterType.Conversion
+  const isConversion = getUnitInfo(metric).unitType === UnitType.Ratio
+  // istanbul ignore next; shouldn't occur
+  if (![UnitType.Ratio, UnitType.Usd].includes(getUnitInfo(metric).unitType)) {
+    throw new Error('Unsupported unitType for MinDiffCalculator')
+  }
 
   const onChangeSamplesPerMonth = (event: React.ChangeEvent<{ value: unknown }>) => {
     setSamplesPerMonth(event.target.value as number)

--- a/src/components/explat/experiments/single-view/results/MetricAssignmentResults.tsx
+++ b/src/components/explat/experiments/single-view/results/MetricAssignmentResults.tsx
@@ -24,7 +24,7 @@ import MetricValueInterval from 'src/components/general/MetricValueInterval'
 import PrivateLink from 'src/components/general/PrivateLink'
 import * as Analyses from 'src/lib/explat/analyses'
 import { getChosenVariation, getExperimentRunHours, isOneTimeExperiment } from 'src/lib/explat/experiments'
-import { getUnitInfo, metricParameterTypeName, UnitDerivationType, UnitInfo, UnitType } from 'src/lib/explat/metrics'
+import { getUnitInfo, UnitDerivationType, UnitInfo, UnitType } from 'src/lib/explat/metrics'
 import * as Recommendations from 'src/lib/explat/recommendations'
 import {
   Analysis,
@@ -250,6 +250,7 @@ export default function MetricAssignmentResults({
 
   let estimateTransform: (estimate: number | null) => number | null = identity
   let unitName = ''
+  let countName = ''
   let metricValuePlotTitle = ''
   let metricValueAbsoluteDifferencePlotTitle = ''
   // Some of the information here should eventually be moved to UnitInfo
@@ -257,11 +258,13 @@ export default function MetricAssignmentResults({
     case UnitType.Ratio:
       estimateTransform = (estimate: number | null) => estimate && estimate * 100
       unitName = 'conversion rate'
+      countName = 'Conversions'
       metricValuePlotTitle = `Conversion rate estimates by variation (%)`
       metricValueAbsoluteDifferencePlotTitle = `Conversion rate difference estimates (percentage points)`
       break
     case UnitType.Usd:
       unitName = 'average cash per user (ACPU)'
+      countName = 'Cash Sales'
       metricValuePlotTitle = `Cash sales estimates by variation (USD)`
       metricValueAbsoluteDifferencePlotTitle = `Cash sales difference estimates (USD)`
       break
@@ -698,7 +701,7 @@ export default function MetricAssignmentResults({
                   <TableCell>Variant</TableCell>
                   <TableCell align='right'>Users</TableCell>
                   <TableCell align='right'>
-                    {metricParameterTypeName[metric.parameterType]}
+                    {countName}
                     <WarningAsterisk />
                   </TableCell>
                   <TableCell align='right' className={classes.unitName}>

--- a/src/components/explat/experiments/single-view/results/MetricAssignmentResults.tsx
+++ b/src/components/explat/experiments/single-view/results/MetricAssignmentResults.tsx
@@ -24,7 +24,7 @@ import MetricValueInterval from 'src/components/general/MetricValueInterval'
 import PrivateLink from 'src/components/general/PrivateLink'
 import * as Analyses from 'src/lib/explat/analyses'
 import { getChosenVariation, getExperimentRunHours, isOneTimeExperiment } from 'src/lib/explat/experiments'
-import { getUnitInfo, UnitDerivationType, UnitInfo, UnitType } from 'src/lib/explat/metrics'
+import { getUnitInfo, metricParameterTypeName, UnitDerivationType, UnitInfo, UnitType } from 'src/lib/explat/metrics'
 import * as Recommendations from 'src/lib/explat/recommendations'
 import {
   Analysis,
@@ -33,7 +33,6 @@ import {
   ExperimentFull,
   Metric,
   MetricAssignment,
-  MetricParameterType,
   Variation,
 } from 'src/lib/explat/schemas'
 import * as Visualizations from 'src/lib/explat/visualizations'
@@ -122,6 +121,11 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     warningAsterisk: {
       color: theme.palette.error.main,
+    },
+    unitName: {
+      '&::first-letter': {
+        textTransform: 'capitalize',
+      },
     },
   }),
 )
@@ -244,10 +248,28 @@ export default function MetricAssignmentResults({
     setIsShowAllCredibleIntervals((isShowAllCredibleIntervals) => !isShowAllCredibleIntervals)
   }
 
-  const isConversion = metric.parameterType === MetricParameterType.Conversion
-  const estimateTransform: (estimate: number | null) => number | null = isConversion
-    ? (estimate: number | null) => estimate && estimate * 100
-    : identity
+  let estimateTransform: (estimate: number | null) => number | null = identity
+  let unitName = ''
+  let metricValuePlotTitle = ''
+  let metricValueAbsoluteDifferencePlotTitle = ''
+  // Some of the information here should eventually be moved to UnitInfo
+  switch (getUnitInfo(metric).unitType) {
+    case UnitType.Ratio:
+      estimateTransform = (estimate: number | null) => estimate && estimate * 100
+      unitName = 'conversion rate'
+      metricValuePlotTitle = `Conversion rate estimates by variation (%)`
+      metricValueAbsoluteDifferencePlotTitle = `Conversion rate difference estimates (percentage points)`
+      break
+    case UnitType.Usd:
+      unitName = 'average cash per user (ACPU)'
+      metricValuePlotTitle = `Cash sales estimates by variation (USD)`
+      metricValueAbsoluteDifferencePlotTitle = `Cash sales difference estimates (USD)`
+      break
+    // istanbul ignore next; shouldn't occur
+    default:
+      throw new Error('Unknown unitType')
+  }
+
   const analyses = analysesByStrategyDateAsc[strategy]
   const latestAnalysis = _.last(analyses)
   const latestEstimates = latestAnalysis?.metricEstimates
@@ -479,7 +501,7 @@ export default function MetricAssignmentResults({
             <TableRow>
               <TableCell>
                 <Typography variant='body1' gutterBottom>
-                  The absolute change in the {isConversion ? 'conversion rate' : 'ACPU'} of{' '}
+                  The absolute change in the {unitName} of{' '}
                   <MetricValueInterval
                     intervalName={'the absolute change'}
                     unit={getUnitInfo(metric, [UnitDerivationType.AbsoluteDifference])}
@@ -557,10 +579,8 @@ export default function MetricAssignmentResults({
           <TableHead>
             <TableRow>
               <TableCell>Variant</TableCell>
-              <TableCell align='right'>
-                {metric.parameterType === MetricParameterType.Revenue
-                  ? 'Average cash per user (ACPU) interval'
-                  : 'Conversion rate interval'}
+              <TableCell align='right' className={classes.unitName}>
+                {unitName}
               </TableCell>
               <TableCell align='right'>Absolute change</TableCell>
               <TableCell align='right'>Relative change (lift)</TableCell>
@@ -638,9 +658,7 @@ export default function MetricAssignmentResults({
           <Plot
             layout={{
               ...Visualizations.plotlyLayoutDefault,
-              title: isConversion
-                ? `Conversion rate estimates by variation (%)`
-                : `Cash sales estimates by variation (USD)`,
+              title: metricValuePlotTitle,
             }}
             data={plotlyDataVariationGraph}
             className={classes.metricEstimatePlot}
@@ -648,9 +666,7 @@ export default function MetricAssignmentResults({
           <Plot
             layout={{
               ...Visualizations.plotlyLayoutDefault,
-              title: isConversion
-                ? `Conversion rate difference estimates (percentage points)`
-                : `Cash sales difference estimates (USD)`,
+              title: metricValueAbsoluteDifferencePlotTitle,
             }}
             data={plotlyDataDifferenceGraph}
             className={classes.metricEstimatePlot}
@@ -682,13 +698,11 @@ export default function MetricAssignmentResults({
                   <TableCell>Variant</TableCell>
                   <TableCell align='right'>Users</TableCell>
                   <TableCell align='right'>
-                    {metric.parameterType === MetricParameterType.Revenue ? 'Cash Sales' : 'Conversions'}
+                    {metricParameterTypeName[metric.parameterType]}
                     <WarningAsterisk />
                   </TableCell>
-                  <TableCell align='right'>
-                    {metric.parameterType === MetricParameterType.Revenue
-                      ? 'Average cash per user (ACPU)'
-                      : 'Conversion rate'}
+                  <TableCell align='right' className={classes.unitName}>
+                    {unitName}
                     <WarningAsterisk />
                   </TableCell>
                 </TableRow>

--- a/src/components/explat/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
+++ b/src/components/explat/experiments/single-view/results/__snapshots__/ExperimentResults.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-154"
+    class="makeStyles-root-155"
   >
     <div
       class="MuiPaper-root MuiAlert-root MuiAlert-standardWarning MuiPaper-elevation0"
@@ -35,7 +35,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
     </div>
     <br />
     <div
-      class="MuiPaper-root makeStyles-abnControls-176 MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root makeStyles-abnControls-177 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <h5
         class="MuiTypography-root MuiTypography-h5 MuiTypography-gutterBottom"
@@ -46,7 +46,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
       </h5>
       <br />
       <div
-        class="makeStyles-abnVariationsSelector-177"
+        class="makeStyles-abnVariationsSelector-178"
       >
         <div
           class="MuiFormControl-root"
@@ -145,10 +145,10 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
     </div>
     <br />
     <div
-      class="makeStyles-summary-155"
+      class="makeStyles-summary-156"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-167 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-168 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -157,16 +157,16 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-157"
+        class="makeStyles-summaryColumn-158"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-158 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-159 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-159"
+            class="makeStyles-summaryStatsPart-160"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-161 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-162 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               1,000
             </h3>
@@ -182,10 +182,10 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-159"
+            class="makeStyles-summaryStatsPart-160"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-161 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-162 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Not enough certainty
             </h3>
@@ -193,7 +193,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
               class="MuiTypography-root MuiTypography-subtitle1"
             >
               <span
-                class="makeStyles-tooltipped-186"
+                class="makeStyles-tooltipped-187"
                 title="The recommendation is metric specific and does not consider other metrics. Check the table below to analyze each metric."
               >
                 <strong>
@@ -205,12 +205,12 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-163 makeStyles-indicationSeverityWarning-165 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-164 makeStyles-indicationSeverityWarning-166 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-161 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-162 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Potential issues
             </h3>
@@ -227,7 +227,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-169 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-170 MuiTypography-h3"
     >
       Metric Assignment Results
     </h3>
@@ -236,7 +236,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-191"
+        class="Component-horizontalScrollContainer-192"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -255,26 +255,26 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-192 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-193 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-192 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-193 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric (attribution window)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-192 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-193 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; text-align: center; box-sizing: border-box;"
                     >
                       Estimated difference
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-192 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-193 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; text-align: center; box-sizing: border-box;"
                     >
@@ -282,11 +282,11 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                         Estimated impact
                          
                         <span
-                          class="makeStyles-impactIntervalSelectWrapper-180"
+                          class="makeStyles-impactIntervalSelectWrapper-181"
                         >
                           (per
                           <div
-                            class="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-impactIntervalSelect-181"
+                            class="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-impactIntervalSelect-182"
                           >
                             <div
                               aria-haspopup="listbox"
@@ -320,7 +320,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                       </span>
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-192 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-193 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -371,7 +371,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-175"
+                        class="makeStyles-metricAssignmentNameLine-176"
                       >
                         <span
                           class=""
@@ -413,13 +413,13 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                       </div>
                       <div>
                         <span
-                          class="makeStyles-root-193 makeStyles-metricAssignmentNameSubtitle-178"
+                          class="makeStyles-root-194 makeStyles-metricAssignmentNameSubtitle-179"
                         >
                           primary metric
                         </span>
                       </div>
                       <div
-                        class="makeStyles-baselineMetricInterval-183"
+                        class="makeStyles-baselineMetricInterval-184"
                       >
                         Baseline: 
                           
@@ -428,7 +428,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                           class=""
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-195"
+                            class="makeStyles-metricValueWrapper-196"
                           >
                             50
                           </span>
@@ -436,7 +436,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-195"
+                            class="makeStyles-metricValueWrapper-196"
                           >
                             100
                              
@@ -450,20 +450,20 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; text-align: center; min-width: 180px;"
                     >
                       <div
-                        class="makeStyles-estimatedDifferenceWrapper-179"
+                        class="makeStyles-estimatedDifferenceWrapper-180"
                       >
                         <svg
-                          class="makeStyles-root-196"
+                          class="makeStyles-root-197"
                         >
                           <line
-                            class="makeStyles-minDifference-197"
+                            class="makeStyles-minDifference-198"
                             x1="69.5"
                             x2="69.5"
                             y1="2"
                             y2="17"
                           />
                           <line
-                            class="makeStyles-minDifference-197"
+                            class="makeStyles-minDifference-198"
                             x1="88.5"
                             x2="88.5"
                             y1="2"
@@ -477,7 +477,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                             y2="19"
                           />
                           <g
-                            class="makeStyles-intervalGroup-198"
+                            class="makeStyles-intervalGroup-199"
                           >
                             <rect
                               height="10"
@@ -486,14 +486,14 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                               y="4.5"
                             />
                             <line
-                              class="makeStyles-intervalEdge-200"
+                              class="makeStyles-intervalEdge-201"
                               x1="2"
                               x2="2"
                               y1="2"
                               y2="17"
                             />
                             <line
-                              class="makeStyles-intervalEdge-200"
+                              class="makeStyles-intervalEdge-201"
                               x1="156"
                               x2="156"
                               y1="2"
@@ -503,10 +503,10 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                         </svg>
                         <span
                           aria-label="the absolute change between variations"
-                          class="makeStyles-metricValueIntervalCentered-194 makeStyles-absoluteChangeInterval-184"
+                          class="makeStyles-metricValueIntervalCentered-195 makeStyles-absoluteChangeInterval-185"
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-195"
+                            class="makeStyles-metricValueWrapper-196"
                           >
                             -100
                           </span>
@@ -514,7 +514,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-195"
+                            class="makeStyles-metricValueWrapper-196"
                           >
                             +
                             100
@@ -529,14 +529,14 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 700; min-width: 180px;"
                     >
                       <div
-                        class="makeStyles-estimatedImpactWrapper-182"
+                        class="makeStyles-estimatedImpactWrapper-183"
                       >
                         <span
                           aria-label="the estimated impact of 'treatment1', in hypothetical unchanged conditions, over one year, for the targeted audience,"
-                          class="makeStyles-metricValueIntervalCentered-194"
+                          class="makeStyles-metricValueIntervalCentered-195"
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-195"
+                            class="makeStyles-metricValueWrapper-196"
                           >
                             +
                             355
@@ -545,7 +545,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-195"
+                            class="makeStyles-metricValueWrapper-196"
                           >
                             -355
                              
@@ -554,10 +554,10 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                         </span>
                         <span
                           aria-label="the relative change between variations"
-                          class="makeStyles-metricValueIntervalCentered-194 makeStyles-relativeChangeInterval-185"
+                          class="makeStyles-metricValueIntervalCentered-195 makeStyles-relativeChangeInterval-186"
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-195"
+                            class="makeStyles-metricValueWrapper-196"
                           >
                             -50
                           </span>
@@ -565,7 +565,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-195"
+                            class="makeStyles-metricValueWrapper-196"
                           >
                             +
                             0
@@ -622,7 +622,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-175"
+                        class="makeStyles-metricAssignmentNameLine-176"
                       >
                         <span
                           class=""
@@ -718,7 +718,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-175"
+                        class="makeStyles-metricAssignmentNameLine-176"
                       >
                         <span
                           class=""
@@ -814,7 +814,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-175"
+                        class="makeStyles-metricAssignmentNameLine-176"
                       >
                         <span
                           class=""
@@ -878,7 +878,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-169 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-170 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -960,18 +960,18 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltipped-186"
+                  class="makeStyles-tooltipped-187"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 1.0000
@@ -983,7 +983,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-205 makeStyles-indicationSeverityOk-206 makeStyles-monospace-202 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-206 makeStyles-indicationSeverityOk-207 makeStyles-monospace-203 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span>
@@ -991,13 +991,13 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-203"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-204"
                 scope="row"
               >
                 <p
@@ -1021,18 +1021,18 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltipped-186"
+                  class="makeStyles-tooltipped-187"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 1.0000
@@ -1044,7 +1044,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-205 makeStyles-indicationSeverityOk-206 makeStyles-monospace-202 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-206 makeStyles-indicationSeverityOk-207 makeStyles-monospace-203 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span>
@@ -1052,13 +1052,13 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-203"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-204"
                 scope="row"
               >
                 <p
@@ -1082,18 +1082,18 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltipped-186"
+                  class="makeStyles-tooltipped-187"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 1.0000
@@ -1105,7 +1105,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-205 makeStyles-indicationSeverityOk-206 makeStyles-monospace-202 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-206 makeStyles-indicationSeverityOk-207 makeStyles-monospace-203 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span>
@@ -1113,13 +1113,13 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-203"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-204"
                 scope="row"
               >
                 <p
@@ -1143,7 +1143,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span>
@@ -1151,7 +1151,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 0.0000
@@ -1163,7 +1163,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-205 makeStyles-indicationSeverityOk-206 makeStyles-monospace-202 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-206 makeStyles-indicationSeverityOk-207 makeStyles-monospace-203 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span>
@@ -1171,13 +1171,13 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.01
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-203"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-204"
                 scope="row"
               >
                 <p
@@ -1201,7 +1201,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span>
@@ -1209,7 +1209,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 0.0000
@@ -1221,7 +1221,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-205 makeStyles-indicationSeverityOk-206 makeStyles-monospace-202 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-206 makeStyles-indicationSeverityOk-207 makeStyles-monospace-203 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span>
@@ -1229,13 +1229,13 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-203"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-204"
                 scope="row"
               >
                 <p
@@ -1259,7 +1259,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span>
@@ -1267,7 +1267,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 0.0000
@@ -1281,7 +1281,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-205 makeStyles-indicationSeverityWarning-207 makeStyles-monospace-202 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-206 makeStyles-indicationSeverityWarning-208 makeStyles-monospace-203 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span>
@@ -1289,13 +1289,13 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-203"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-204"
                 scope="row"
               >
                 <p
@@ -1310,7 +1310,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
       </div>
     </div>
     <div
-      class="makeStyles-accordions-170"
+      class="makeStyles-accordions-171"
     >
       <div
         class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -1369,7 +1369,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-171"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-172"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -1529,7 +1529,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-171"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-172"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -1542,7 +1542,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                     This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                   </p>
                   <pre
-                    class="makeStyles-pre-173"
+                    class="makeStyles-pre-174"
                   >
                     <code>
                       with tracks_counts as (
@@ -1576,10 +1576,10 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically significant 2`] = `
 <div
-  class="makeStyles-root-209 analysis-detail-panel"
+  class="makeStyles-root-210 analysis-detail-panel"
 >
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-220 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-221 MuiTypography-body1"
   >
     Summary
   </p>
@@ -1599,7 +1599,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
             class="MuiTableCell-root MuiTableCell-body"
           >
             <h5
-              class="MuiTypography-root makeStyles-recommendation-219 MuiTypography-h5 MuiTypography-gutterBottom"
+              class="MuiTypography-root makeStyles-recommendation-220 MuiTypography-h5 MuiTypography-gutterBottom"
             >
               Inconclusive
             </h5>
@@ -1636,7 +1636,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 class=""
               >
                 <span
-                  class="makeStyles-metricValueWrapper-195"
+                  class="makeStyles-metricValueWrapper-196"
                 >
                   -100
                 </span>
@@ -1644,7 +1644,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 to
                  
                 <span
-                  class="makeStyles-metricValueWrapper-195"
+                  class="makeStyles-metricValueWrapper-196"
                 >
                   +
                   100
@@ -1665,7 +1665,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 class=""
               >
                 <span
-                  class="makeStyles-metricValueWrapper-195"
+                  class="makeStyles-metricValueWrapper-196"
                 >
                   -10
                 </span>
@@ -1673,7 +1673,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 to
                  
                 <span
-                  class="makeStyles-metricValueWrapper-195"
+                  class="makeStyles-metricValueWrapper-196"
                 >
                   +
                   10
@@ -1693,7 +1693,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 class=""
               >
                 <span
-                  class="makeStyles-metricValueWrapper-195"
+                  class="makeStyles-metricValueWrapper-196"
                 >
                   -50
                 </span>
@@ -1701,7 +1701,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 to
                  
                 <span
-                  class="makeStyles-metricValueWrapper-195"
+                  class="makeStyles-metricValueWrapper-196"
                 >
                   +
                   0
@@ -1730,7 +1730,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 class=""
               >
                 <span
-                  class="makeStyles-metricValueWrapper-195"
+                  class="makeStyles-metricValueWrapper-196"
                 >
                   +
                   355
@@ -1739,7 +1739,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 to
                  
                 <span
-                  class="makeStyles-metricValueWrapper-195"
+                  class="makeStyles-metricValueWrapper-196"
                 >
                   -355
                    
@@ -1760,7 +1760,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
             </strong>
              
             <span
-              class="makeStyles-root-225"
+              class="makeStyles-root-227"
               title="09/05/2020, 20:00:00"
             >
               2020-05-10
@@ -1785,7 +1785,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-220 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-221 MuiTypography-body1"
   >
     Analysis
   </p>
@@ -1793,7 +1793,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
     class="MuiPaper-root MuiTableContainer-root MuiPaper-elevation1 MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-coolTable-221"
+      class="MuiTable-root makeStyles-coolTable-222"
     >
       <thead
         class="MuiTableHead-root"
@@ -1808,10 +1808,10 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
             Variant
           </th>
           <th
-            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-unitName-226 MuiTableCell-alignRight"
             scope="col"
           >
-            Conversion rate interval
+            conversion rate
           </th>
           <th
             class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight"
@@ -1834,13 +1834,13 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-215 makeStyles-headerCell-210 makeStyles-credibleIntervalHeader-218"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-216 makeStyles-headerCell-211 makeStyles-credibleIntervalHeader-219"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-211"
+              class="makeStyles-monospace-212"
             >
               control
                
@@ -1848,14 +1848,14 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-211 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-212 MuiTableCell-alignRight"
           >
             <span
               aria-label="the metric value"
-              class="makeStyles-tooltipped-186"
+              class="makeStyles-tooltipped-187"
             >
               <span
-                class="makeStyles-metricValueWrapper-195"
+                class="makeStyles-metricValueWrapper-196"
               >
                 50
               </span>
@@ -1863,7 +1863,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
               to
                
               <span
-                class="makeStyles-metricValueWrapper-195"
+                class="makeStyles-metricValueWrapper-196"
               >
                 100
                  
@@ -1872,12 +1872,12 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-211 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-212 MuiTableCell-alignRight"
           >
             Baseline
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-211 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-212 MuiTableCell-alignRight"
           >
             Baseline
           </td>
@@ -1886,13 +1886,13 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-215 makeStyles-headerCell-210 makeStyles-credibleIntervalHeader-218"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-216 makeStyles-headerCell-211 makeStyles-credibleIntervalHeader-219"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-211"
+              class="makeStyles-monospace-212"
             >
               treatment1
                
@@ -1900,14 +1900,14 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-211 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-212 MuiTableCell-alignRight"
           >
             <span
               aria-label="the metric value"
-              class="makeStyles-tooltipped-186"
+              class="makeStyles-tooltipped-187"
             >
               <span
-                class="makeStyles-metricValueWrapper-195"
+                class="makeStyles-metricValueWrapper-196"
               >
                 50
               </span>
@@ -1915,7 +1915,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
               to
                
               <span
-                class="makeStyles-metricValueWrapper-195"
+                class="makeStyles-metricValueWrapper-196"
               >
                 100
                  
@@ -1924,14 +1924,14 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-211 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-212 MuiTableCell-alignRight"
           >
             <span
               aria-label="the absolute change between variations"
-              class="makeStyles-tooltipped-186"
+              class="makeStyles-tooltipped-187"
             >
               <span
-                class="makeStyles-metricValueWrapper-195"
+                class="makeStyles-metricValueWrapper-196"
               >
                 -100
               </span>
@@ -1939,7 +1939,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
               to
                
               <span
-                class="makeStyles-metricValueWrapper-195"
+                class="makeStyles-metricValueWrapper-196"
               >
                 +
                 100
@@ -1949,14 +1949,14 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-211 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-212 MuiTableCell-alignRight"
           >
             <span
               aria-label="the relative change between variations"
-              class="makeStyles-tooltipped-186"
+              class="makeStyles-tooltipped-187"
             >
               <span
-                class="makeStyles-metricValueWrapper-195"
+                class="makeStyles-metricValueWrapper-196"
               >
                 -50
               </span>
@@ -1964,7 +1964,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
               to
                
               <span
-                class="makeStyles-metricValueWrapper-195"
+                class="makeStyles-metricValueWrapper-196"
               >
                 +
                 0
@@ -1975,16 +1975,16 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
           </td>
         </tr>
         <tr
-          class="MuiTableRow-root makeStyles-rowVariationNotSelected-216"
+          class="MuiTableRow-root makeStyles-rowVariationNotSelected-217"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-215 makeStyles-headerCell-210 makeStyles-credibleIntervalHeader-218"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-216 makeStyles-headerCell-211 makeStyles-credibleIntervalHeader-219"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-211"
+              class="makeStyles-monospace-212"
             >
               treatment2
                
@@ -1992,14 +1992,14 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-211 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-212 MuiTableCell-alignRight"
           >
             <span
               aria-label="the metric value"
-              class="makeStyles-tooltipped-186"
+              class="makeStyles-tooltipped-187"
             >
               <span
-                class="makeStyles-metricValueWrapper-195"
+                class="makeStyles-metricValueWrapper-196"
               >
                 50
               </span>
@@ -2007,7 +2007,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
               to
                
               <span
-                class="makeStyles-metricValueWrapper-195"
+                class="makeStyles-metricValueWrapper-196"
               >
                 100
                  
@@ -2016,14 +2016,14 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-211 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-212 MuiTableCell-alignRight"
           >
             <span
               aria-label="the absolute change between variations"
-              class="makeStyles-tooltipped-186"
+              class="makeStyles-tooltipped-187"
             >
               <span
-                class="makeStyles-metricValueWrapper-195"
+                class="makeStyles-metricValueWrapper-196"
               >
                 -100
               </span>
@@ -2031,7 +2031,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
               to
                
               <span
-                class="makeStyles-metricValueWrapper-195"
+                class="makeStyles-metricValueWrapper-196"
               >
                 +
                 100
@@ -2041,14 +2041,14 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-211 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-212 MuiTableCell-alignRight"
           >
             <span
               aria-label="the relative change between variations"
-              class="makeStyles-tooltipped-186"
+              class="makeStyles-tooltipped-187"
             >
               <span
-                class="makeStyles-metricValueWrapper-195"
+                class="makeStyles-metricValueWrapper-196"
               >
                 -50
               </span>
@@ -2056,7 +2056,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
               to
                
               <span
-                class="makeStyles-metricValueWrapper-195"
+                class="makeStyles-metricValueWrapper-196"
               >
                 +
                 0
@@ -2070,7 +2070,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-analysisFinePrint-217 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-analysisFinePrint-218 MuiTypography-body1"
   >
     95% Credible Intervals (CIs). 
     <strong>
@@ -2080,7 +2080,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
     
     10
     <span
-      class="makeStyles-tooltipped-186"
+      class="makeStyles-tooltipped-187"
       title="Percentage points."
     >
       pp
@@ -2088,17 +2088,17 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
     .
   </p>
   <p
-    class="MuiTypography-root makeStyles-noPlotMessage-214 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-noPlotMessage-215 MuiTypography-body1"
   >
     Past values will be plotted once we have more than one day of results.
   </p>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-220 makeStyles-clickable-222 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-221 makeStyles-clickable-223 MuiTypography-body1"
     role="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-223"
+      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-224"
       focusable="false"
       viewBox="0 0 24 24"
     >
@@ -2109,12 +2109,12 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
     "Observed" data
   </p>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-220 makeStyles-clickable-222 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-221 makeStyles-clickable-223 MuiTypography-body1"
     role="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-223"
+      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-224"
       focusable="false"
       viewBox="0 0 24 24"
     >
@@ -2132,7 +2132,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-168",
+        "className": "makeStyles-participantsPlot-169",
         "data": Array [
           Object {
             "line": Object {
@@ -2214,7 +2214,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-154"
+    class="makeStyles-root-155"
   >
     <div
       class="MuiPaper-root MuiAlert-root MuiAlert-standardWarning MuiPaper-elevation0"
@@ -2244,7 +2244,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
     </div>
     <br />
     <div
-      class="MuiPaper-root makeStyles-abnControls-176 MuiPaper-elevation1 MuiPaper-rounded"
+      class="MuiPaper-root makeStyles-abnControls-177 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <h5
         class="MuiTypography-root MuiTypography-h5 MuiTypography-gutterBottom"
@@ -2255,7 +2255,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
       </h5>
       <br />
       <div
-        class="makeStyles-abnVariationsSelector-177"
+        class="makeStyles-abnVariationsSelector-178"
       >
         <div
           class="MuiFormControl-root"
@@ -2354,10 +2354,10 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
     </div>
     <br />
     <div
-      class="makeStyles-summary-155"
+      class="makeStyles-summary-156"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-167 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-168 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -2366,16 +2366,16 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-157"
+        class="makeStyles-summaryColumn-158"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-158 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-159 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-159"
+            class="makeStyles-summaryStatsPart-160"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-161 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-162 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               1,000
             </h3>
@@ -2391,10 +2391,10 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-159"
+            class="makeStyles-summaryStatsPart-160"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-161 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-162 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Not enough certainty
             </h3>
@@ -2402,7 +2402,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
               class="MuiTypography-root MuiTypography-subtitle1"
             >
               <span
-                class="makeStyles-tooltipped-186"
+                class="makeStyles-tooltipped-187"
                 title="The recommendation is metric specific and does not consider other metrics. Check the table below to analyze each metric."
               >
                 <strong>
@@ -2414,12 +2414,12 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-163 makeStyles-indicationSeverityWarning-165 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-164 makeStyles-indicationSeverityWarning-166 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-161 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-162 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Potential issues
             </h3>
@@ -2436,7 +2436,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-169 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-170 MuiTypography-h3"
     >
       Metric Assignment Results
     </h3>
@@ -2445,7 +2445,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-191"
+        class="Component-horizontalScrollContainer-192"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -2464,26 +2464,26 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-192 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-193 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-192 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-193 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric (attribution window)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-192 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-193 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; text-align: center; box-sizing: border-box;"
                     >
                       Estimated difference
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-192 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-193 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; text-align: center; box-sizing: border-box;"
                     >
@@ -2491,11 +2491,11 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                         Estimated impact
                          
                         <span
-                          class="makeStyles-impactIntervalSelectWrapper-180"
+                          class="makeStyles-impactIntervalSelectWrapper-181"
                         >
                           (per
                           <div
-                            class="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-impactIntervalSelect-181"
+                            class="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-impactIntervalSelect-182"
                           >
                             <div
                               aria-haspopup="listbox"
@@ -2529,7 +2529,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                       </span>
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-192 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-193 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -2580,7 +2580,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-175"
+                        class="makeStyles-metricAssignmentNameLine-176"
                       >
                         <span
                           class=""
@@ -2622,13 +2622,13 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                       </div>
                       <div>
                         <span
-                          class="makeStyles-root-193 makeStyles-metricAssignmentNameSubtitle-178"
+                          class="makeStyles-root-194 makeStyles-metricAssignmentNameSubtitle-179"
                         >
                           primary metric
                         </span>
                       </div>
                       <div
-                        class="makeStyles-baselineMetricInterval-183"
+                        class="makeStyles-baselineMetricInterval-184"
                       >
                         Baseline: 
                           
@@ -2637,7 +2637,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                           class=""
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-195"
+                            class="makeStyles-metricValueWrapper-196"
                           >
                             50
                           </span>
@@ -2645,7 +2645,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-195"
+                            class="makeStyles-metricValueWrapper-196"
                           >
                             100
                              
@@ -2659,20 +2659,20 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; text-align: center; min-width: 180px;"
                     >
                       <div
-                        class="makeStyles-estimatedDifferenceWrapper-179"
+                        class="makeStyles-estimatedDifferenceWrapper-180"
                       >
                         <svg
-                          class="makeStyles-root-196"
+                          class="makeStyles-root-197"
                         >
                           <line
-                            class="makeStyles-minDifference-197"
+                            class="makeStyles-minDifference-198"
                             x1="69.5"
                             x2="69.5"
                             y1="2"
                             y2="17"
                           />
                           <line
-                            class="makeStyles-minDifference-197"
+                            class="makeStyles-minDifference-198"
                             x1="88.5"
                             x2="88.5"
                             y1="2"
@@ -2686,7 +2686,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                             y2="19"
                           />
                           <g
-                            class="makeStyles-intervalGroup-198"
+                            class="makeStyles-intervalGroup-199"
                           >
                             <rect
                               height="10"
@@ -2695,14 +2695,14 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                               y="4.5"
                             />
                             <line
-                              class="makeStyles-intervalEdge-200"
+                              class="makeStyles-intervalEdge-201"
                               x1="2"
                               x2="2"
                               y1="2"
                               y2="17"
                             />
                             <line
-                              class="makeStyles-intervalEdge-200"
+                              class="makeStyles-intervalEdge-201"
                               x1="156"
                               x2="156"
                               y1="2"
@@ -2712,10 +2712,10 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                         </svg>
                         <span
                           aria-label="the absolute change between variations"
-                          class="makeStyles-metricValueIntervalCentered-194 makeStyles-absoluteChangeInterval-184"
+                          class="makeStyles-metricValueIntervalCentered-195 makeStyles-absoluteChangeInterval-185"
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-195"
+                            class="makeStyles-metricValueWrapper-196"
                           >
                             -100
                           </span>
@@ -2723,7 +2723,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-195"
+                            class="makeStyles-metricValueWrapper-196"
                           >
                             +
                             100
@@ -2738,14 +2738,14 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 700; min-width: 180px;"
                     >
                       <div
-                        class="makeStyles-estimatedImpactWrapper-182"
+                        class="makeStyles-estimatedImpactWrapper-183"
                       >
                         <span
                           aria-label="the estimated impact of 'treatment2', in hypothetical unchanged conditions, over one year, for the targeted audience,"
-                          class="makeStyles-metricValueIntervalCentered-194"
+                          class="makeStyles-metricValueIntervalCentered-195"
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-195"
+                            class="makeStyles-metricValueWrapper-196"
                           >
                             +
                             355
@@ -2754,7 +2754,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-195"
+                            class="makeStyles-metricValueWrapper-196"
                           >
                             -355
                              
@@ -2763,10 +2763,10 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                         </span>
                         <span
                           aria-label="the relative change between variations"
-                          class="makeStyles-metricValueIntervalCentered-194 makeStyles-relativeChangeInterval-185"
+                          class="makeStyles-metricValueIntervalCentered-195 makeStyles-relativeChangeInterval-186"
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-195"
+                            class="makeStyles-metricValueWrapper-196"
                           >
                             -50
                           </span>
@@ -2774,7 +2774,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-195"
+                            class="makeStyles-metricValueWrapper-196"
                           >
                             +
                             0
@@ -2831,7 +2831,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-175"
+                        class="makeStyles-metricAssignmentNameLine-176"
                       >
                         <span
                           class=""
@@ -2927,7 +2927,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-175"
+                        class="makeStyles-metricAssignmentNameLine-176"
                       >
                         <span
                           class=""
@@ -3023,7 +3023,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-175"
+                        class="makeStyles-metricAssignmentNameLine-176"
                       >
                         <span
                           class=""
@@ -3087,7 +3087,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                       colspan="5"
                     >
                       <div
-                        class="makeStyles-root-209"
+                        class="makeStyles-root-210"
                       >
                         <h5
                           class="MuiTypography-root MuiTypography-h5 MuiTypography-gutterBottom"
@@ -3122,7 +3122,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-169 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-170 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -3204,18 +3204,18 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltipped-186"
+                  class="makeStyles-tooltipped-187"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 1.0000
@@ -3227,7 +3227,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-205 makeStyles-indicationSeverityOk-206 makeStyles-monospace-202 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-206 makeStyles-indicationSeverityOk-207 makeStyles-monospace-203 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span>
@@ -3235,13 +3235,13 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-203"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-204"
                 scope="row"
               >
                 <p
@@ -3265,18 +3265,18 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltipped-186"
+                  class="makeStyles-tooltipped-187"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 1.0000
@@ -3288,7 +3288,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-205 makeStyles-indicationSeverityOk-206 makeStyles-monospace-202 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-206 makeStyles-indicationSeverityOk-207 makeStyles-monospace-203 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span>
@@ -3296,13 +3296,13 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-203"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-204"
                 scope="row"
               >
                 <p
@@ -3326,18 +3326,18 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltipped-186"
+                  class="makeStyles-tooltipped-187"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 1.0000
@@ -3349,7 +3349,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-205 makeStyles-indicationSeverityOk-206 makeStyles-monospace-202 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-206 makeStyles-indicationSeverityOk-207 makeStyles-monospace-203 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span>
@@ -3357,13 +3357,13 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-203"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-204"
                 scope="row"
               >
                 <p
@@ -3387,7 +3387,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span>
@@ -3395,7 +3395,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 0.0000
@@ -3407,7 +3407,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-205 makeStyles-indicationSeverityOk-206 makeStyles-monospace-202 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-206 makeStyles-indicationSeverityOk-207 makeStyles-monospace-203 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span>
@@ -3415,13 +3415,13 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.01
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-203"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-204"
                 scope="row"
               >
                 <p
@@ -3445,7 +3445,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span>
@@ -3453,7 +3453,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 0.0000
@@ -3465,7 +3465,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-205 makeStyles-indicationSeverityOk-206 makeStyles-monospace-202 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-206 makeStyles-indicationSeverityOk-207 makeStyles-monospace-203 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span>
@@ -3473,13 +3473,13 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-203"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-204"
                 scope="row"
               >
                 <p
@@ -3503,7 +3503,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span>
@@ -3511,7 +3511,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 0.0000
@@ -3525,7 +3525,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-205 makeStyles-indicationSeverityWarning-207 makeStyles-monospace-202 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-206 makeStyles-indicationSeverityWarning-208 makeStyles-monospace-203 makeStyles-nowrap-205"
                 scope="row"
               >
                 <span>
@@ -3533,13 +3533,13 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-202 makeStyles-deemphasized-203 makeStyles-nowrap-204"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-203 makeStyles-deemphasized-204 makeStyles-nowrap-205"
                 scope="row"
               >
                 −∞ &lt; x ≤ 3
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-203"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-204"
                 scope="row"
               >
                 <p
@@ -3554,7 +3554,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
       </div>
     </div>
     <div
-      class="makeStyles-accordions-170"
+      class="makeStyles-accordions-171"
     >
       <div
         class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -3613,7 +3613,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-171"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-172"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -3773,7 +3773,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-171"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-172"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -3786,7 +3786,7 @@ exports[`A/B/n: renders correctly for 1 analysis datapoint, not statistically si
                     This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                   </p>
                   <pre
-                    class="makeStyles-pre-173"
+                    class="makeStyles-pre-174"
                   >
                     <code>
                       with tracks_counts as (
@@ -3824,13 +3824,13 @@ exports[`allows you to change analysis strategy 1`] = `
     class="analysis-latest-results"
   >
     <div
-      class="makeStyles-root-509"
+      class="makeStyles-root-515"
     >
       <div
-        class="makeStyles-summary-510"
+        class="makeStyles-summary-516"
       >
         <div
-          class="MuiPaper-root makeStyles-participantsPlotPaper-522 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-participantsPlotPaper-528 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <h3
             class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -3839,16 +3839,16 @@ exports[`allows you to change analysis strategy 1`] = `
           </h3>
         </div>
         <div
-          class="makeStyles-summaryColumn-512"
+          class="makeStyles-summaryColumn-518"
         >
           <div
-            class="MuiPaper-root makeStyles-summaryStatsPaper-513 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-summaryStatsPaper-519 MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="makeStyles-summaryStatsPart-514"
+              class="makeStyles-summaryStatsPart-520"
             >
               <h3
-                class="MuiTypography-root makeStyles-summaryStatsStat-516 MuiTypography-h3 MuiTypography-colorPrimary"
+                class="MuiTypography-root makeStyles-summaryStatsStat-522 MuiTypography-h3 MuiTypography-colorPrimary"
               >
                 1,000
               </h3>
@@ -3864,10 +3864,10 @@ exports[`allows you to change analysis strategy 1`] = `
               </h6>
             </div>
             <div
-              class="makeStyles-summaryStatsPart-514"
+              class="makeStyles-summaryStatsPart-520"
             >
               <h3
-                class="MuiTypography-root makeStyles-summaryStatsStat-516 MuiTypography-h3 MuiTypography-colorPrimary"
+                class="MuiTypography-root makeStyles-summaryStatsStat-522 MuiTypography-h3 MuiTypography-colorPrimary"
               >
                 Deploy either variation
               </h3>
@@ -3875,7 +3875,7 @@ exports[`allows you to change analysis strategy 1`] = `
                 class="MuiTypography-root MuiTypography-subtitle1"
               >
                 <span
-                  class="makeStyles-tooltipped-541"
+                  class="makeStyles-tooltipped-547"
                   title="The recommendation is metric specific and does not consider other metrics. Check the table below to analyze each metric."
                 >
                   <strong>
@@ -3887,12 +3887,12 @@ exports[`allows you to change analysis strategy 1`] = `
             </div>
           </div>
           <a
-            class="MuiPaper-root makeStyles-summaryHealthPaper-518 makeStyles-indicationSeverityOk-519 MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root makeStyles-summaryHealthPaper-524 makeStyles-indicationSeverityOk-525 MuiPaper-elevation1 MuiPaper-rounded"
             href="#health-report"
           >
             <div>
               <h3
-                class="MuiTypography-root makeStyles-summaryStatsStat-516 MuiTypography-h3 MuiTypography-colorPrimary"
+                class="MuiTypography-root makeStyles-summaryStatsStat-522 MuiTypography-h3 MuiTypography-colorPrimary"
               >
                 No issues detected
               </h3>
@@ -3909,7 +3909,7 @@ exports[`allows you to change analysis strategy 1`] = `
         </div>
       </div>
       <h3
-        class="MuiTypography-root makeStyles-tableTitle-524 MuiTypography-h3"
+        class="MuiTypography-root makeStyles-tableTitle-530 MuiTypography-h3"
       >
         Metric Assignment Results
       </h3>
@@ -3918,7 +3918,7 @@ exports[`allows you to change analysis strategy 1`] = `
         style="position: relative;"
       >
         <div
-          class="Component-horizontalScrollContainer-546"
+          class="Component-horizontalScrollContainer-552"
           style="overflow-x: auto; position: relative;"
         >
           <div>
@@ -3937,26 +3937,26 @@ exports[`allows you to change analysis strategy 1`] = `
                       class="MuiTableRow-root MuiTableRow-head"
                     >
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-547 MuiTableCell-paddingNone"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-553 MuiTableCell-paddingNone"
                         scope="col"
                         style="font-weight: 700;"
                       />
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-547 MuiTableCell-alignLeft"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-553 MuiTableCell-alignLeft"
                         scope="col"
                         style="font-weight: 700; box-sizing: border-box;"
                       >
                         Metric (attribution window)
                       </th>
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-547 MuiTableCell-alignLeft"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-553 MuiTableCell-alignLeft"
                         scope="col"
                         style="font-weight: 700; text-align: center; box-sizing: border-box;"
                       >
                         Estimated difference
                       </th>
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-547 MuiTableCell-alignLeft"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-553 MuiTableCell-alignLeft"
                         scope="col"
                         style="font-weight: 700; text-align: center; box-sizing: border-box;"
                       >
@@ -3964,11 +3964,11 @@ exports[`allows you to change analysis strategy 1`] = `
                           Estimated impact
                            
                           <span
-                            class="makeStyles-impactIntervalSelectWrapper-535"
+                            class="makeStyles-impactIntervalSelectWrapper-541"
                           >
                             (per
                             <div
-                              class="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-impactIntervalSelect-536"
+                              class="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-impactIntervalSelect-542"
                             >
                               <div
                                 aria-haspopup="listbox"
@@ -4002,7 +4002,7 @@ exports[`allows you to change analysis strategy 1`] = `
                         </span>
                       </th>
                       <th
-                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-547 MuiTableCell-alignLeft"
+                        class="MuiTableCell-root MuiTableCell-head MTableHeader-header-553 MuiTableCell-alignLeft"
                         scope="col"
                         style="font-weight: 700; box-sizing: border-box;"
                       >
@@ -4053,7 +4053,7 @@ exports[`allows you to change analysis strategy 1`] = `
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                       >
                         <div
-                          class="makeStyles-metricAssignmentNameLine-530"
+                          class="makeStyles-metricAssignmentNameLine-536"
                         >
                           <span
                             class=""
@@ -4095,13 +4095,13 @@ exports[`allows you to change analysis strategy 1`] = `
                         </div>
                         <div>
                           <span
-                            class="makeStyles-root-548 makeStyles-metricAssignmentNameSubtitle-533"
+                            class="makeStyles-root-554 makeStyles-metricAssignmentNameSubtitle-539"
                           >
                             primary metric
                           </span>
                         </div>
                         <div
-                          class="makeStyles-baselineMetricInterval-538"
+                          class="makeStyles-baselineMetricInterval-544"
                         >
                           Baseline: 
                             
@@ -4110,7 +4110,7 @@ exports[`allows you to change analysis strategy 1`] = `
                             class=""
                           >
                             <span
-                              class="makeStyles-metricValueWrapper-550"
+                              class="makeStyles-metricValueWrapper-556"
                             >
                               0
                             </span>
@@ -4118,7 +4118,7 @@ exports[`allows you to change analysis strategy 1`] = `
                             to
                              
                             <span
-                              class="makeStyles-metricValueWrapper-550"
+                              class="makeStyles-metricValueWrapper-556"
                             >
                               0
                                
@@ -4132,20 +4132,20 @@ exports[`allows you to change analysis strategy 1`] = `
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; text-align: center; min-width: 180px;"
                       >
                         <div
-                          class="makeStyles-estimatedDifferenceWrapper-534"
+                          class="makeStyles-estimatedDifferenceWrapper-540"
                         >
                           <svg
-                            class="makeStyles-root-551"
+                            class="makeStyles-root-557"
                           >
                             <line
-                              class="makeStyles-minDifference-552"
+                              class="makeStyles-minDifference-558"
                               x1="2"
                               x2="2"
                               y1="2"
                               y2="17"
                             />
                             <line
-                              class="makeStyles-minDifference-552"
+                              class="makeStyles-minDifference-558"
                               x1="156"
                               x2="156"
                               y1="2"
@@ -4159,7 +4159,7 @@ exports[`allows you to change analysis strategy 1`] = `
                               y2="19"
                             />
                             <g
-                              class="makeStyles-intervalGroup-553 makeStyles-intervalWithEnoughData-554"
+                              class="makeStyles-intervalGroup-559 makeStyles-intervalWithEnoughData-560"
                             >
                               <rect
                                 height="10"
@@ -4168,14 +4168,14 @@ exports[`allows you to change analysis strategy 1`] = `
                                 y="4.5"
                               />
                               <line
-                                class="makeStyles-intervalEdge-555"
+                                class="makeStyles-intervalEdge-561"
                                 x1="79"
                                 x2="79"
                                 y1="2"
                                 y2="17"
                               />
                               <line
-                                class="makeStyles-intervalEdge-555"
+                                class="makeStyles-intervalEdge-561"
                                 x1="79"
                                 x2="79"
                                 y1="2"
@@ -4185,10 +4185,10 @@ exports[`allows you to change analysis strategy 1`] = `
                           </svg>
                           <span
                             aria-label="the absolute change between variations"
-                            class="makeStyles-metricValueIntervalCentered-549 makeStyles-absoluteChangeInterval-539"
+                            class="makeStyles-metricValueIntervalCentered-555 makeStyles-absoluteChangeInterval-545"
                           >
                             <span
-                              class="makeStyles-metricValueWrapper-550"
+                              class="makeStyles-metricValueWrapper-556"
                             >
                               +
                               0
@@ -4197,7 +4197,7 @@ exports[`allows you to change analysis strategy 1`] = `
                             to
                              
                             <span
-                              class="makeStyles-metricValueWrapper-550"
+                              class="makeStyles-metricValueWrapper-556"
                             >
                               +
                               0
@@ -4212,14 +4212,14 @@ exports[`allows you to change analysis strategy 1`] = `
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 700; min-width: 180px;"
                       >
                         <div
-                          class="makeStyles-estimatedImpactWrapper-537"
+                          class="makeStyles-estimatedImpactWrapper-543"
                         >
                           <span
                             aria-label="the estimated impact of 'test', in hypothetical unchanged conditions, over one year, for the targeted audience,"
-                            class="makeStyles-metricValueIntervalCentered-549"
+                            class="makeStyles-metricValueIntervalCentered-555"
                           >
                             <span
-                              class="makeStyles-metricValueWrapper-550"
+                              class="makeStyles-metricValueWrapper-556"
                             >
                               +
                               -0
@@ -4228,7 +4228,7 @@ exports[`allows you to change analysis strategy 1`] = `
                             to
                              
                             <span
-                              class="makeStyles-metricValueWrapper-550"
+                              class="makeStyles-metricValueWrapper-556"
                             >
                               +
                               -0
@@ -4238,10 +4238,10 @@ exports[`allows you to change analysis strategy 1`] = `
                           </span>
                           <span
                             aria-label="the relative change between variations"
-                            class="makeStyles-metricValueIntervalCentered-549 makeStyles-relativeChangeInterval-540"
+                            class="makeStyles-metricValueIntervalCentered-555 makeStyles-relativeChangeInterval-546"
                           >
                             <span
-                              class="makeStyles-metricValueWrapper-550"
+                              class="makeStyles-metricValueWrapper-556"
                             >
                               -100
                             </span>
@@ -4249,7 +4249,7 @@ exports[`allows you to change analysis strategy 1`] = `
                             to
                              
                             <span
-                              class="makeStyles-metricValueWrapper-550"
+                              class="makeStyles-metricValueWrapper-556"
                             >
                               -100
                                
@@ -4305,7 +4305,7 @@ exports[`allows you to change analysis strategy 1`] = `
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                       >
                         <div
-                          class="makeStyles-metricAssignmentNameLine-530"
+                          class="makeStyles-metricAssignmentNameLine-536"
                         >
                           <span
                             class=""
@@ -4401,7 +4401,7 @@ exports[`allows you to change analysis strategy 1`] = `
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                       >
                         <div
-                          class="makeStyles-metricAssignmentNameLine-530"
+                          class="makeStyles-metricAssignmentNameLine-536"
                         >
                           <span
                             class=""
@@ -4497,7 +4497,7 @@ exports[`allows you to change analysis strategy 1`] = `
                         style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                       >
                         <div
-                          class="makeStyles-metricAssignmentNameLine-530"
+                          class="makeStyles-metricAssignmentNameLine-536"
                         >
                           <span
                             class=""
@@ -4561,7 +4561,7 @@ exports[`allows you to change analysis strategy 1`] = `
         </div>
       </div>
       <h3
-        class="MuiTypography-root makeStyles-tableTitle-524 MuiTypography-h3"
+        class="MuiTypography-root makeStyles-tableTitle-530 MuiTypography-h3"
       >
         Health Report
       </h3>
@@ -4643,18 +4643,18 @@ exports[`allows you to change analysis strategy 1`] = `
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-557 makeStyles-deemphasized-558 makeStyles-nowrap-559"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-563 makeStyles-deemphasized-564 makeStyles-nowrap-565"
                   scope="row"
                 >
                   <span
-                    class="makeStyles-tooltipped-541"
+                    class="makeStyles-tooltipped-547"
                     title="The smaller the p-value the more likely there is an issue."
                   >
                     p-value
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-557 makeStyles-deemphasized-558 makeStyles-nowrap-559"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-563 makeStyles-deemphasized-564 makeStyles-nowrap-565"
                   scope="row"
                 >
                   1.0000
@@ -4666,7 +4666,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   <span />
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-560 makeStyles-indicationSeverityOk-561 makeStyles-monospace-557 makeStyles-nowrap-559"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-566 makeStyles-indicationSeverityOk-567 makeStyles-monospace-563 makeStyles-nowrap-565"
                   scope="row"
                 >
                   <span>
@@ -4674,13 +4674,13 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-557 makeStyles-deemphasized-558 makeStyles-nowrap-559"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-563 makeStyles-deemphasized-564 makeStyles-nowrap-565"
                   scope="row"
                 >
                   0.05 &lt; x ≤ 1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-558"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-564"
                   scope="row"
                 >
                   <p
@@ -4704,18 +4704,18 @@ exports[`allows you to change analysis strategy 1`] = `
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-557 makeStyles-deemphasized-558 makeStyles-nowrap-559"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-563 makeStyles-deemphasized-564 makeStyles-nowrap-565"
                   scope="row"
                 >
                   <span
-                    class="makeStyles-tooltipped-541"
+                    class="makeStyles-tooltipped-547"
                     title="The smaller the p-value the more likely there is an issue."
                   >
                     p-value
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-557 makeStyles-deemphasized-558 makeStyles-nowrap-559"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-563 makeStyles-deemphasized-564 makeStyles-nowrap-565"
                   scope="row"
                 >
                   1.0000
@@ -4727,7 +4727,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   <span />
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-560 makeStyles-indicationSeverityOk-561 makeStyles-monospace-557 makeStyles-nowrap-559"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-566 makeStyles-indicationSeverityOk-567 makeStyles-monospace-563 makeStyles-nowrap-565"
                   scope="row"
                 >
                   <span>
@@ -4735,13 +4735,13 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-557 makeStyles-deemphasized-558 makeStyles-nowrap-559"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-563 makeStyles-deemphasized-564 makeStyles-nowrap-565"
                   scope="row"
                 >
                   0.05 &lt; x ≤ 1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-558"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-564"
                   scope="row"
                 >
                   <p
@@ -4765,7 +4765,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-557 makeStyles-deemphasized-558 makeStyles-nowrap-559"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-563 makeStyles-deemphasized-564 makeStyles-nowrap-565"
                   scope="row"
                 >
                   <span>
@@ -4773,7 +4773,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-557 makeStyles-deemphasized-558 makeStyles-nowrap-559"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-563 makeStyles-deemphasized-564 makeStyles-nowrap-565"
                   scope="row"
                 >
                   0.0000
@@ -4785,7 +4785,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   <span />
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-560 makeStyles-indicationSeverityOk-561 makeStyles-monospace-557 makeStyles-nowrap-559"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-566 makeStyles-indicationSeverityOk-567 makeStyles-monospace-563 makeStyles-nowrap-565"
                   scope="row"
                 >
                   <span>
@@ -4793,13 +4793,13 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-557 makeStyles-deemphasized-558 makeStyles-nowrap-559"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-563 makeStyles-deemphasized-564 makeStyles-nowrap-565"
                   scope="row"
                 >
                   −∞ &lt; x ≤ 0.01
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-558"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-564"
                   scope="row"
                 >
                   <p
@@ -4823,7 +4823,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-557 makeStyles-deemphasized-558 makeStyles-nowrap-559"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-563 makeStyles-deemphasized-564 makeStyles-nowrap-565"
                   scope="row"
                 >
                   <span>
@@ -4831,7 +4831,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-557 makeStyles-deemphasized-558 makeStyles-nowrap-559"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-563 makeStyles-deemphasized-564 makeStyles-nowrap-565"
                   scope="row"
                 >
                   0.0000
@@ -4843,7 +4843,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   <span />
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-560 makeStyles-indicationSeverityOk-561 makeStyles-monospace-557 makeStyles-nowrap-559"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-566 makeStyles-indicationSeverityOk-567 makeStyles-monospace-563 makeStyles-nowrap-565"
                   scope="row"
                 >
                   <span>
@@ -4851,13 +4851,13 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-557 makeStyles-deemphasized-558 makeStyles-nowrap-559"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-563 makeStyles-deemphasized-564 makeStyles-nowrap-565"
                   scope="row"
                 >
                   −∞ &lt; x ≤ 0.1
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-558"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-564"
                   scope="row"
                 >
                   <p
@@ -4881,7 +4881,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-557 makeStyles-deemphasized-558 makeStyles-nowrap-559"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-563 makeStyles-deemphasized-564 makeStyles-nowrap-565"
                   scope="row"
                 >
                   <span>
@@ -4889,7 +4889,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-557 makeStyles-deemphasized-558 makeStyles-nowrap-559"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-563 makeStyles-deemphasized-564 makeStyles-nowrap-565"
                   scope="row"
                 >
                   10.0000
@@ -4901,7 +4901,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   <span />
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-560 makeStyles-indicationSeverityOk-561 makeStyles-monospace-557 makeStyles-nowrap-559"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-indication-566 makeStyles-indicationSeverityOk-567 makeStyles-monospace-563 makeStyles-nowrap-565"
                   scope="row"
                 >
                   <span>
@@ -4909,13 +4909,13 @@ exports[`allows you to change analysis strategy 1`] = `
                   </span>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-557 makeStyles-deemphasized-558 makeStyles-nowrap-559"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-563 makeStyles-deemphasized-564 makeStyles-nowrap-565"
                   scope="row"
                 >
                   7 &lt; x ≤ 28
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-558"
+                  class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-564"
                   scope="row"
                 >
                   <p
@@ -4928,7 +4928,7 @@ exports[`allows you to change analysis strategy 1`] = `
         </div>
       </div>
       <div
-        class="makeStyles-accordions-525"
+        class="makeStyles-accordions-531"
       >
         <div
           class="MuiPaper-root MuiAccordion-root Mui-expanded MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -4987,7 +4987,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   role="region"
                 >
                   <div
-                    class="MuiAccordionDetails-root makeStyles-accordionDetails-526"
+                    class="MuiAccordionDetails-root makeStyles-accordionDetails-532"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -5146,7 +5146,7 @@ exports[`allows you to change analysis strategy 1`] = `
                   role="region"
                 >
                   <div
-                    class="MuiAccordionDetails-root makeStyles-accordionDetails-526"
+                    class="MuiAccordionDetails-root makeStyles-accordionDetails-532"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -5159,7 +5159,7 @@ exports[`allows you to change analysis strategy 1`] = `
                       This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                     </p>
                     <pre
-                      class="makeStyles-pre-528"
+                      class="makeStyles-pre-534"
                     >
                       <code>
                         with tracks_counts as (
@@ -8254,7 +8254,7 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
             </strong>
              
             <span
-              class="makeStyles-root-153"
+              class="makeStyles-root-154"
               title="09/05/2020, 20:00:00"
             >
               2020-05-10
@@ -8302,10 +8302,10 @@ exports[`renders correctly for 1 analysis datapoint, not statistically significa
             Variant
           </th>
           <th
-            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-unitName-153 MuiTableCell-alignRight"
             scope="col"
           >
-            Conversion rate interval
+            conversion rate
           </th>
           <th
             class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight"
@@ -8598,13 +8598,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-226"
+    class="makeStyles-root-228"
   >
     <div
-      class="makeStyles-summary-227"
+      class="makeStyles-summary-229"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-239 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-241 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -8613,16 +8613,16 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-229"
+        class="makeStyles-summaryColumn-231"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-230 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-232 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-231"
+            class="makeStyles-summaryStatsPart-233"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-233 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-235 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               1,000
             </h3>
@@ -8638,10 +8638,10 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-231"
+            class="makeStyles-summaryStatsPart-233"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-233 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-235 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Deploy 
               control
@@ -8651,7 +8651,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
               class="MuiTypography-root MuiTypography-subtitle1"
             >
               <span
-                class="makeStyles-tooltipped-258"
+                class="makeStyles-tooltipped-260"
                 title="The recommendation is metric specific and does not consider other metrics. Check the table below to analyze each metric."
               >
                 <strong>
@@ -8663,12 +8663,12 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-235 makeStyles-indicationSeverityOk-236 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-237 makeStyles-indicationSeverityOk-238 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-233 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-235 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               No issues detected
             </h3>
@@ -8685,7 +8685,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-241 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-243 MuiTypography-h3"
     >
       Metric Assignment Results
     </h3>
@@ -8694,7 +8694,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-263"
+        class="Component-horizontalScrollContainer-265"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -8713,26 +8713,26 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-264 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-266 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-264 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-266 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric (attribution window)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-264 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-266 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; text-align: center; box-sizing: border-box;"
                     >
                       Estimated difference
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-264 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-266 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; text-align: center; box-sizing: border-box;"
                     >
@@ -8740,11 +8740,11 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                         Estimated impact
                          
                         <span
-                          class="makeStyles-impactIntervalSelectWrapper-252"
+                          class="makeStyles-impactIntervalSelectWrapper-254"
                         >
                           (per
                           <div
-                            class="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-impactIntervalSelect-253"
+                            class="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-impactIntervalSelect-255"
                           >
                             <div
                               aria-haspopup="listbox"
@@ -8778,7 +8778,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       </span>
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-264 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-266 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -8829,7 +8829,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-247"
+                        class="makeStyles-metricAssignmentNameLine-249"
                       >
                         <span
                           class=""
@@ -8871,13 +8871,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       </div>
                       <div>
                         <span
-                          class="makeStyles-root-265 makeStyles-metricAssignmentNameSubtitle-250"
+                          class="makeStyles-root-267 makeStyles-metricAssignmentNameSubtitle-252"
                         >
                           primary metric
                         </span>
                       </div>
                       <div
-                        class="makeStyles-baselineMetricInterval-255"
+                        class="makeStyles-baselineMetricInterval-257"
                       >
                         Baseline: 
                           
@@ -8886,7 +8886,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                           class=""
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-267"
+                            class="makeStyles-metricValueWrapper-269"
                           >
                             100
                           </span>
@@ -8894,7 +8894,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-267"
+                            class="makeStyles-metricValueWrapper-269"
                           >
                             200
                              
@@ -8908,20 +8908,20 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; text-align: center; min-width: 180px;"
                     >
                       <div
-                        class="makeStyles-estimatedDifferenceWrapper-251"
+                        class="makeStyles-estimatedDifferenceWrapper-253"
                       >
                         <svg
-                          class="makeStyles-root-268"
+                          class="makeStyles-root-270"
                         >
                           <line
-                            class="makeStyles-minDifference-269"
+                            class="makeStyles-minDifference-271"
                             x1="69.5"
                             x2="69.5"
                             y1="2"
                             y2="17"
                           />
                           <line
-                            class="makeStyles-minDifference-269"
+                            class="makeStyles-minDifference-271"
                             x1="88.5"
                             x2="88.5"
                             y1="2"
@@ -8935,7 +8935,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                             y2="19"
                           />
                           <g
-                            class="makeStyles-intervalGroup-270 makeStyles-intervalWithEnoughData-271"
+                            class="makeStyles-intervalGroup-272 makeStyles-intervalWithEnoughData-273"
                           >
                             <rect
                               height="10"
@@ -8944,14 +8944,14 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                               y="4.5"
                             />
                             <line
-                              class="makeStyles-intervalEdge-272"
+                              class="makeStyles-intervalEdge-274"
                               x1="118.5"
                               x2="118.5"
                               y1="2"
                               y2="17"
                             />
                             <line
-                              class="makeStyles-intervalEdge-272"
+                              class="makeStyles-intervalEdge-274"
                               x1="156"
                               x2="156"
                               y1="2"
@@ -8961,10 +8961,10 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                         </svg>
                         <span
                           aria-label="the absolute change between variations"
-                          class="makeStyles-metricValueIntervalCentered-266 makeStyles-absoluteChangeInterval-256"
+                          class="makeStyles-metricValueIntervalCentered-268 makeStyles-absoluteChangeInterval-258"
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-267"
+                            class="makeStyles-metricValueWrapper-269"
                           >
                             +
                             50
@@ -8973,7 +8973,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-267"
+                            class="makeStyles-metricValueWrapper-269"
                           >
                             +
                             100
@@ -8988,14 +8988,14 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 700; min-width: 180px;"
                     >
                       <div
-                        class="makeStyles-estimatedImpactWrapper-254"
+                        class="makeStyles-estimatedImpactWrapper-256"
                       >
                         <span
                           aria-label="the estimated impact of 'test', in hypothetical unchanged conditions, over one year, for the targeted audience,"
-                          class="makeStyles-metricValueIntervalCentered-266"
+                          class="makeStyles-metricValueIntervalCentered-268"
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-267"
+                            class="makeStyles-metricValueWrapper-269"
                           >
                             -554
                           </span>
@@ -9003,7 +9003,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-267"
+                            class="makeStyles-metricValueWrapper-269"
                           >
                             -1.11K
                              
@@ -9012,10 +9012,10 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                         </span>
                         <span
                           aria-label="the relative change between variations"
-                          class="makeStyles-metricValueIntervalCentered-266 makeStyles-relativeChangeInterval-257"
+                          class="makeStyles-metricValueIntervalCentered-268 makeStyles-relativeChangeInterval-259"
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-267"
+                            class="makeStyles-metricValueWrapper-269"
                           >
                             -50
                           </span>
@@ -9023,7 +9023,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-267"
+                            class="makeStyles-metricValueWrapper-269"
                           >
                             +
                             0
@@ -9081,7 +9081,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-247"
+                        class="makeStyles-metricAssignmentNameLine-249"
                       >
                         <span
                           class=""
@@ -9177,7 +9177,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-247"
+                        class="makeStyles-metricAssignmentNameLine-249"
                       >
                         <span
                           class=""
@@ -9273,7 +9273,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-247"
+                        class="makeStyles-metricAssignmentNameLine-249"
                       >
                         <span
                           class=""
@@ -9337,7 +9337,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-241 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-243 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -9419,18 +9419,18 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-274 makeStyles-deemphasized-275 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-276 makeStyles-deemphasized-277 makeStyles-nowrap-278"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltipped-258"
+                  class="makeStyles-tooltipped-260"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-274 makeStyles-deemphasized-275 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-276 makeStyles-deemphasized-277 makeStyles-nowrap-278"
                 scope="row"
               >
                 1.0000
@@ -9442,7 +9442,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-277 makeStyles-indicationSeverityOk-278 makeStyles-monospace-274 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-279 makeStyles-indicationSeverityOk-280 makeStyles-monospace-276 makeStyles-nowrap-278"
                 scope="row"
               >
                 <span>
@@ -9450,13 +9450,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-274 makeStyles-deemphasized-275 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-276 makeStyles-deemphasized-277 makeStyles-nowrap-278"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-275"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-277"
                 scope="row"
               >
                 <p
@@ -9480,18 +9480,18 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-274 makeStyles-deemphasized-275 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-276 makeStyles-deemphasized-277 makeStyles-nowrap-278"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltipped-258"
+                  class="makeStyles-tooltipped-260"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-274 makeStyles-deemphasized-275 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-276 makeStyles-deemphasized-277 makeStyles-nowrap-278"
                 scope="row"
               >
                 1.0000
@@ -9503,7 +9503,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-277 makeStyles-indicationSeverityOk-278 makeStyles-monospace-274 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-279 makeStyles-indicationSeverityOk-280 makeStyles-monospace-276 makeStyles-nowrap-278"
                 scope="row"
               >
                 <span>
@@ -9511,13 +9511,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-274 makeStyles-deemphasized-275 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-276 makeStyles-deemphasized-277 makeStyles-nowrap-278"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-275"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-277"
                 scope="row"
               >
                 <p
@@ -9541,18 +9541,18 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-274 makeStyles-deemphasized-275 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-276 makeStyles-deemphasized-277 makeStyles-nowrap-278"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltipped-258"
+                  class="makeStyles-tooltipped-260"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-274 makeStyles-deemphasized-275 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-276 makeStyles-deemphasized-277 makeStyles-nowrap-278"
                 scope="row"
               >
                 1.0000
@@ -9564,7 +9564,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-277 makeStyles-indicationSeverityOk-278 makeStyles-monospace-274 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-279 makeStyles-indicationSeverityOk-280 makeStyles-monospace-276 makeStyles-nowrap-278"
                 scope="row"
               >
                 <span>
@@ -9572,13 +9572,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-274 makeStyles-deemphasized-275 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-276 makeStyles-deemphasized-277 makeStyles-nowrap-278"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-275"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-277"
                 scope="row"
               >
                 <p
@@ -9602,7 +9602,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-274 makeStyles-deemphasized-275 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-276 makeStyles-deemphasized-277 makeStyles-nowrap-278"
                 scope="row"
               >
                 <span>
@@ -9610,7 +9610,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-274 makeStyles-deemphasized-275 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-276 makeStyles-deemphasized-277 makeStyles-nowrap-278"
                 scope="row"
               >
                 0.0000
@@ -9622,7 +9622,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-277 makeStyles-indicationSeverityOk-278 makeStyles-monospace-274 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-279 makeStyles-indicationSeverityOk-280 makeStyles-monospace-276 makeStyles-nowrap-278"
                 scope="row"
               >
                 <span>
@@ -9630,13 +9630,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-274 makeStyles-deemphasized-275 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-276 makeStyles-deemphasized-277 makeStyles-nowrap-278"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.01
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-275"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-277"
                 scope="row"
               >
                 <p
@@ -9660,7 +9660,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-274 makeStyles-deemphasized-275 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-276 makeStyles-deemphasized-277 makeStyles-nowrap-278"
                 scope="row"
               >
                 <span>
@@ -9668,7 +9668,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-274 makeStyles-deemphasized-275 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-276 makeStyles-deemphasized-277 makeStyles-nowrap-278"
                 scope="row"
               >
                 0.0000
@@ -9680,7 +9680,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-277 makeStyles-indicationSeverityOk-278 makeStyles-monospace-274 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-279 makeStyles-indicationSeverityOk-280 makeStyles-monospace-276 makeStyles-nowrap-278"
                 scope="row"
               >
                 <span>
@@ -9688,13 +9688,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-274 makeStyles-deemphasized-275 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-276 makeStyles-deemphasized-277 makeStyles-nowrap-278"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-275"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-277"
                 scope="row"
               >
                 <p
@@ -9718,7 +9718,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-274 makeStyles-deemphasized-275 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-276 makeStyles-deemphasized-277 makeStyles-nowrap-278"
                 scope="row"
               >
                 <span>
@@ -9726,7 +9726,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-274 makeStyles-deemphasized-275 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-276 makeStyles-deemphasized-277 makeStyles-nowrap-278"
                 scope="row"
               >
                 10.0000
@@ -9738,7 +9738,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-277 makeStyles-indicationSeverityOk-278 makeStyles-monospace-274 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-279 makeStyles-indicationSeverityOk-280 makeStyles-monospace-276 makeStyles-nowrap-278"
                 scope="row"
               >
                 <span>
@@ -9746,13 +9746,13 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-274 makeStyles-deemphasized-275 makeStyles-nowrap-276"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-276 makeStyles-deemphasized-277 makeStyles-nowrap-278"
                 scope="row"
               >
                 7 &lt; x ≤ 28
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-275"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-277"
                 scope="row"
               >
                 <p
@@ -9765,7 +9765,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
       </div>
     </div>
     <div
-      class="makeStyles-accordions-242"
+      class="makeStyles-accordions-244"
     >
       <div
         class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -9824,7 +9824,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-243"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-245"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -9984,7 +9984,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-243"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-245"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -9997,7 +9997,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 1
                     This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                   </p>
                   <pre
-                    class="makeStyles-pre-245"
+                    class="makeStyles-pre-247"
                   >
                     <code>
                       with tracks_counts as (
@@ -10031,10 +10031,10 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders correctly for 1 analysis datapoint, statistically significant 2`] = `
 <div
-  class="makeStyles-root-281 analysis-detail-panel"
+  class="makeStyles-root-283 analysis-detail-panel"
 >
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-292 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-294 MuiTypography-body1"
   >
     Summary
   </p>
@@ -10054,7 +10054,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
             class="MuiTableCell-root MuiTableCell-body"
           >
             <h5
-              class="MuiTypography-root makeStyles-recommendation-291 MuiTypography-h5 MuiTypography-gutterBottom"
+              class="MuiTypography-root makeStyles-recommendation-293 MuiTypography-h5 MuiTypography-gutterBottom"
             >
               Control
                winning
@@ -10092,7 +10092,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
                 class=""
               >
                 <span
-                  class="makeStyles-metricValueWrapper-267"
+                  class="makeStyles-metricValueWrapper-269"
                 >
                   +
                   50
@@ -10101,7 +10101,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
                 to
                  
                 <span
-                  class="makeStyles-metricValueWrapper-267"
+                  class="makeStyles-metricValueWrapper-269"
                 >
                   +
                   100
@@ -10122,7 +10122,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
                 class=""
               >
                 <span
-                  class="makeStyles-metricValueWrapper-267"
+                  class="makeStyles-metricValueWrapper-269"
                 >
                   -10
                 </span>
@@ -10130,7 +10130,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
                 to
                  
                 <span
-                  class="makeStyles-metricValueWrapper-267"
+                  class="makeStyles-metricValueWrapper-269"
                 >
                   +
                   10
@@ -10150,7 +10150,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
                 class=""
               >
                 <span
-                  class="makeStyles-metricValueWrapper-267"
+                  class="makeStyles-metricValueWrapper-269"
                 >
                   -50
                 </span>
@@ -10158,7 +10158,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
                 to
                  
                 <span
-                  class="makeStyles-metricValueWrapper-267"
+                  class="makeStyles-metricValueWrapper-269"
                 >
                   +
                   0
@@ -10187,7 +10187,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
                 class=""
               >
                 <span
-                  class="makeStyles-metricValueWrapper-267"
+                  class="makeStyles-metricValueWrapper-269"
                 >
                   -554
                 </span>
@@ -10195,7 +10195,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
                 to
                  
                 <span
-                  class="makeStyles-metricValueWrapper-267"
+                  class="makeStyles-metricValueWrapper-269"
                 >
                   -1.11K
                    
@@ -10216,7 +10216,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
             </strong>
              
             <span
-              class="makeStyles-root-297"
+              class="makeStyles-root-300"
               title="09/05/2020, 20:00:00"
             >
               2020-05-10
@@ -10241,7 +10241,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-292 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-294 MuiTypography-body1"
   >
     Analysis
   </p>
@@ -10249,7 +10249,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
     class="MuiPaper-root MuiTableContainer-root MuiPaper-elevation1 MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-coolTable-293"
+      class="MuiTable-root makeStyles-coolTable-295"
     >
       <thead
         class="MuiTableHead-root"
@@ -10264,10 +10264,10 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
             Variant
           </th>
           <th
-            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-unitName-299 MuiTableCell-alignRight"
             scope="col"
           >
-            Conversion rate interval
+            conversion rate
           </th>
           <th
             class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight"
@@ -10290,26 +10290,26 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-287 makeStyles-headerCell-282 makeStyles-credibleIntervalHeader-290"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-289 makeStyles-headerCell-284 makeStyles-credibleIntervalHeader-292"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-283"
+              class="makeStyles-monospace-285"
             >
               test
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-283 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-285 MuiTableCell-alignRight"
           >
             <span
               aria-label="the metric value"
-              class="makeStyles-tooltipped-258"
+              class="makeStyles-tooltipped-260"
             >
               <span
-                class="makeStyles-metricValueWrapper-267"
+                class="makeStyles-metricValueWrapper-269"
               >
                 50
               </span>
@@ -10317,7 +10317,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
               to
                
               <span
-                class="makeStyles-metricValueWrapper-267"
+                class="makeStyles-metricValueWrapper-269"
               >
                 100
                  
@@ -10326,14 +10326,14 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-283 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-285 MuiTableCell-alignRight"
           >
             <span
               aria-label="the absolute change between variations"
-              class="makeStyles-tooltipped-258"
+              class="makeStyles-tooltipped-260"
             >
               <span
-                class="makeStyles-metricValueWrapper-267"
+                class="makeStyles-metricValueWrapper-269"
               >
                 +
                 50
@@ -10342,7 +10342,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
               to
                
               <span
-                class="makeStyles-metricValueWrapper-267"
+                class="makeStyles-metricValueWrapper-269"
               >
                 +
                 100
@@ -10352,14 +10352,14 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-283 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-285 MuiTableCell-alignRight"
           >
             <span
               aria-label="the relative change between variations"
-              class="makeStyles-tooltipped-258"
+              class="makeStyles-tooltipped-260"
             >
               <span
-                class="makeStyles-metricValueWrapper-267"
+                class="makeStyles-metricValueWrapper-269"
               >
                 -50
               </span>
@@ -10367,7 +10367,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
               to
                
               <span
-                class="makeStyles-metricValueWrapper-267"
+                class="makeStyles-metricValueWrapper-269"
               >
                 +
                 0
@@ -10381,26 +10381,26 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-287 makeStyles-headerCell-282 makeStyles-credibleIntervalHeader-290"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-289 makeStyles-headerCell-284 makeStyles-credibleIntervalHeader-292"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-283"
+              class="makeStyles-monospace-285"
             >
               control
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-283 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-285 MuiTableCell-alignRight"
           >
             <span
               aria-label="the metric value"
-              class="makeStyles-tooltipped-258"
+              class="makeStyles-tooltipped-260"
             >
               <span
-                class="makeStyles-metricValueWrapper-267"
+                class="makeStyles-metricValueWrapper-269"
               >
                 100
               </span>
@@ -10408,7 +10408,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
               to
                
               <span
-                class="makeStyles-metricValueWrapper-267"
+                class="makeStyles-metricValueWrapper-269"
               >
                 200
                  
@@ -10417,12 +10417,12 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-283 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-285 MuiTableCell-alignRight"
           >
             Baseline
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-283 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-285 MuiTableCell-alignRight"
           >
             Baseline
           </td>
@@ -10431,7 +10431,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-analysisFinePrint-289 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-analysisFinePrint-291 MuiTypography-body1"
   >
     95% Credible Intervals (CIs). 
     <strong>
@@ -10441,7 +10441,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
     
     10
     <span
-      class="makeStyles-tooltipped-258"
+      class="makeStyles-tooltipped-260"
       title="Percentage points."
     >
       pp
@@ -10449,17 +10449,17 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
     .
   </p>
   <p
-    class="MuiTypography-root makeStyles-noPlotMessage-286 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-noPlotMessage-288 MuiTypography-body1"
   >
     Past values will be plotted once we have more than one day of results.
   </p>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-292 makeStyles-clickable-294 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-294 makeStyles-clickable-296 MuiTypography-body1"
     role="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-295"
+      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-297"
       focusable="false"
       viewBox="0 0 24 24"
     >
@@ -10470,12 +10470,12 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 2
     "Observed" data
   </p>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-292 makeStyles-clickable-294 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-294 makeStyles-clickable-296 MuiTypography-body1"
     role="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-295"
+      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-297"
       focusable="false"
       viewBox="0 0 24 24"
     >
@@ -10493,7 +10493,7 @@ exports[`renders correctly for 1 analysis datapoint, statistically significant 3
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-240",
+        "className": "makeStyles-participantsPlot-242",
         "data": Array [
           Object {
             "line": Object {
@@ -10561,13 +10561,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-298"
+    class="makeStyles-root-301"
   >
     <div
-      class="makeStyles-summary-299"
+      class="makeStyles-summary-302"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-311 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-314 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -10576,16 +10576,16 @@ exports[`renders correctly for conflicting analysis data 1`] = `
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-301"
+        class="makeStyles-summaryColumn-304"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-302 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-305 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-303"
+            class="makeStyles-summaryStatsPart-306"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-305 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-308 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               1,000
             </h3>
@@ -10601,13 +10601,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-303"
+            class="makeStyles-summaryStatsPart-306"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-305 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-308 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               <span
-                class="makeStyles-tooltipped-330"
+                class="makeStyles-tooltipped-333"
                 title="Contact @experimentation-review on #a8c-experiments"
               >
                 Manual analysis required
@@ -10617,7 +10617,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
               class="MuiTypography-root MuiTypography-subtitle1"
             >
               <span
-                class="makeStyles-tooltipped-330"
+                class="makeStyles-tooltipped-333"
                 title="The recommendation is metric specific and does not consider other metrics. Check the table below to analyze each metric."
               >
                 <strong>
@@ -10629,12 +10629,12 @@ exports[`renders correctly for conflicting analysis data 1`] = `
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-307 makeStyles-indicationSeverityOk-308 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-310 makeStyles-indicationSeverityOk-311 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-305 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-308 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               No issues detected
             </h3>
@@ -10651,7 +10651,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-313 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-316 MuiTypography-h3"
     >
       Metric Assignment Results
     </h3>
@@ -10660,7 +10660,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-335"
+        class="Component-horizontalScrollContainer-338"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -10679,26 +10679,26 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-336 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-339 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-336 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-339 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric (attribution window)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-336 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-339 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; text-align: center; box-sizing: border-box;"
                     >
                       Estimated difference
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-336 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-339 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; text-align: center; box-sizing: border-box;"
                     >
@@ -10706,11 +10706,11 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                         Estimated impact
                          
                         <span
-                          class="makeStyles-impactIntervalSelectWrapper-324"
+                          class="makeStyles-impactIntervalSelectWrapper-327"
                         >
                           (per
                           <div
-                            class="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-impactIntervalSelect-325"
+                            class="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-impactIntervalSelect-328"
                           >
                             <div
                               aria-haspopup="listbox"
@@ -10744,7 +10744,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       </span>
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-336 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-339 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -10795,7 +10795,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-319"
+                        class="makeStyles-metricAssignmentNameLine-322"
                       >
                         <span
                           class=""
@@ -10837,13 +10837,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       </div>
                       <div>
                         <span
-                          class="makeStyles-root-337 makeStyles-metricAssignmentNameSubtitle-322"
+                          class="makeStyles-root-340 makeStyles-metricAssignmentNameSubtitle-325"
                         >
                           primary metric
                         </span>
                       </div>
                       <div
-                        class="makeStyles-baselineMetricInterval-327"
+                        class="makeStyles-baselineMetricInterval-330"
                       >
                         Baseline: 
                           
@@ -10852,7 +10852,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                           class=""
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-339"
+                            class="makeStyles-metricValueWrapper-342"
                           >
                             100
                           </span>
@@ -10860,7 +10860,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-339"
+                            class="makeStyles-metricValueWrapper-342"
                           >
                             200
                              
@@ -10882,7 +10882,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 700;"
                     >
                       <span
-                        class="makeStyles-tooltipped-330"
+                        class="makeStyles-tooltipped-333"
                         title="Contact @experimentation-review on #a8c-experiments"
                       >
                         Manual analysis required
@@ -10929,7 +10929,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-319"
+                        class="makeStyles-metricAssignmentNameLine-322"
                       >
                         <span
                           class=""
@@ -11025,7 +11025,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-319"
+                        class="makeStyles-metricAssignmentNameLine-322"
                       >
                         <span
                           class=""
@@ -11121,7 +11121,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-319"
+                        class="makeStyles-metricAssignmentNameLine-322"
                       >
                         <span
                           class=""
@@ -11185,7 +11185,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-313 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-316 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -11267,18 +11267,18 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-341 makeStyles-deemphasized-342 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-344 makeStyles-deemphasized-345 makeStyles-nowrap-346"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltipped-330"
+                  class="makeStyles-tooltipped-333"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-341 makeStyles-deemphasized-342 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-344 makeStyles-deemphasized-345 makeStyles-nowrap-346"
                 scope="row"
               >
                 1.0000
@@ -11290,7 +11290,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-344 makeStyles-indicationSeverityOk-345 makeStyles-monospace-341 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-347 makeStyles-indicationSeverityOk-348 makeStyles-monospace-344 makeStyles-nowrap-346"
                 scope="row"
               >
                 <span>
@@ -11298,13 +11298,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-341 makeStyles-deemphasized-342 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-344 makeStyles-deemphasized-345 makeStyles-nowrap-346"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-342"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-345"
                 scope="row"
               >
                 <p
@@ -11328,18 +11328,18 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-341 makeStyles-deemphasized-342 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-344 makeStyles-deemphasized-345 makeStyles-nowrap-346"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltipped-330"
+                  class="makeStyles-tooltipped-333"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-341 makeStyles-deemphasized-342 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-344 makeStyles-deemphasized-345 makeStyles-nowrap-346"
                 scope="row"
               >
                 1.0000
@@ -11351,7 +11351,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-344 makeStyles-indicationSeverityOk-345 makeStyles-monospace-341 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-347 makeStyles-indicationSeverityOk-348 makeStyles-monospace-344 makeStyles-nowrap-346"
                 scope="row"
               >
                 <span>
@@ -11359,13 +11359,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-341 makeStyles-deemphasized-342 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-344 makeStyles-deemphasized-345 makeStyles-nowrap-346"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-342"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-345"
                 scope="row"
               >
                 <p
@@ -11389,18 +11389,18 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-341 makeStyles-deemphasized-342 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-344 makeStyles-deemphasized-345 makeStyles-nowrap-346"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltipped-330"
+                  class="makeStyles-tooltipped-333"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-341 makeStyles-deemphasized-342 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-344 makeStyles-deemphasized-345 makeStyles-nowrap-346"
                 scope="row"
               >
                 1.0000
@@ -11412,7 +11412,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-344 makeStyles-indicationSeverityOk-345 makeStyles-monospace-341 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-347 makeStyles-indicationSeverityOk-348 makeStyles-monospace-344 makeStyles-nowrap-346"
                 scope="row"
               >
                 <span>
@@ -11420,13 +11420,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-341 makeStyles-deemphasized-342 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-344 makeStyles-deemphasized-345 makeStyles-nowrap-346"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-342"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-345"
                 scope="row"
               >
                 <p
@@ -11450,7 +11450,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-341 makeStyles-deemphasized-342 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-344 makeStyles-deemphasized-345 makeStyles-nowrap-346"
                 scope="row"
               >
                 <span>
@@ -11458,7 +11458,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-341 makeStyles-deemphasized-342 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-344 makeStyles-deemphasized-345 makeStyles-nowrap-346"
                 scope="row"
               >
                 0.0000
@@ -11470,7 +11470,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-344 makeStyles-indicationSeverityOk-345 makeStyles-monospace-341 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-347 makeStyles-indicationSeverityOk-348 makeStyles-monospace-344 makeStyles-nowrap-346"
                 scope="row"
               >
                 <span>
@@ -11478,13 +11478,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-341 makeStyles-deemphasized-342 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-344 makeStyles-deemphasized-345 makeStyles-nowrap-346"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.01
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-342"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-345"
                 scope="row"
               >
                 <p
@@ -11508,7 +11508,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-341 makeStyles-deemphasized-342 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-344 makeStyles-deemphasized-345 makeStyles-nowrap-346"
                 scope="row"
               >
                 <span>
@@ -11516,7 +11516,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-341 makeStyles-deemphasized-342 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-344 makeStyles-deemphasized-345 makeStyles-nowrap-346"
                 scope="row"
               >
                 0.0000
@@ -11528,7 +11528,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-344 makeStyles-indicationSeverityOk-345 makeStyles-monospace-341 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-347 makeStyles-indicationSeverityOk-348 makeStyles-monospace-344 makeStyles-nowrap-346"
                 scope="row"
               >
                 <span>
@@ -11536,13 +11536,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-341 makeStyles-deemphasized-342 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-344 makeStyles-deemphasized-345 makeStyles-nowrap-346"
                 scope="row"
               >
                 −∞ &lt; x ≤ 0.1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-342"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-345"
                 scope="row"
               >
                 <p
@@ -11566,7 +11566,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-341 makeStyles-deemphasized-342 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-344 makeStyles-deemphasized-345 makeStyles-nowrap-346"
                 scope="row"
               >
                 <span>
@@ -11574,7 +11574,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-341 makeStyles-deemphasized-342 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-344 makeStyles-deemphasized-345 makeStyles-nowrap-346"
                 scope="row"
               >
                 10.0000
@@ -11586,7 +11586,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-344 makeStyles-indicationSeverityOk-345 makeStyles-monospace-341 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-347 makeStyles-indicationSeverityOk-348 makeStyles-monospace-344 makeStyles-nowrap-346"
                 scope="row"
               >
                 <span>
@@ -11594,13 +11594,13 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-341 makeStyles-deemphasized-342 makeStyles-nowrap-343"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-344 makeStyles-deemphasized-345 makeStyles-nowrap-346"
                 scope="row"
               >
                 7 &lt; x ≤ 28
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-342"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-345"
                 scope="row"
               >
                 <p
@@ -11613,7 +11613,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
       </div>
     </div>
     <div
-      class="makeStyles-accordions-314"
+      class="makeStyles-accordions-317"
     >
       <div
         class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -11672,7 +11672,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-315"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-318"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -11832,7 +11832,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-315"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-318"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -11845,7 +11845,7 @@ exports[`renders correctly for conflicting analysis data 1`] = `
                     This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                   </p>
                   <pre
-                    class="makeStyles-pre-317"
+                    class="makeStyles-pre-320"
                   >
                     <code>
                       with tracks_counts as (
@@ -11879,10 +11879,10 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders correctly for conflicting analysis data 2`] = `
 <div
-  class="makeStyles-root-348 analysis-detail-panel"
+  class="makeStyles-root-351 analysis-detail-panel"
 >
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-359 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-362 MuiTypography-body1"
   >
     Summary
   </p>
@@ -11902,10 +11902,10 @@ exports[`renders correctly for conflicting analysis data 2`] = `
             class="MuiTableCell-root MuiTableCell-body"
           >
             <h5
-              class="MuiTypography-root makeStyles-recommendation-358 MuiTypography-h5 MuiTypography-gutterBottom"
+              class="MuiTypography-root makeStyles-recommendation-361 MuiTypography-h5 MuiTypography-gutterBottom"
             >
               <span
-                class="makeStyles-tooltipped-330"
+                class="makeStyles-tooltipped-333"
                 title="Contact @experimentation-review on #a8c-experiments"
               >
                 Manual analysis required
@@ -11951,7 +11951,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
                 class=""
               >
                 <span
-                  class="makeStyles-metricValueWrapper-339"
+                  class="makeStyles-metricValueWrapper-342"
                 >
                   +
                   50
@@ -11960,7 +11960,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
                 to
                  
                 <span
-                  class="makeStyles-metricValueWrapper-339"
+                  class="makeStyles-metricValueWrapper-342"
                 >
                   +
                   100
@@ -11981,7 +11981,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
                 class=""
               >
                 <span
-                  class="makeStyles-metricValueWrapper-339"
+                  class="makeStyles-metricValueWrapper-342"
                 >
                   -10
                 </span>
@@ -11989,7 +11989,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
                 to
                  
                 <span
-                  class="makeStyles-metricValueWrapper-339"
+                  class="makeStyles-metricValueWrapper-342"
                 >
                   +
                   10
@@ -12009,7 +12009,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
                 class=""
               >
                 <span
-                  class="makeStyles-metricValueWrapper-339"
+                  class="makeStyles-metricValueWrapper-342"
                 >
                   -50
                 </span>
@@ -12017,7 +12017,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
                 to
                  
                 <span
-                  class="makeStyles-metricValueWrapper-339"
+                  class="makeStyles-metricValueWrapper-342"
                 >
                   +
                   0
@@ -12046,7 +12046,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
                 class=""
               >
                 <span
-                  class="makeStyles-metricValueWrapper-339"
+                  class="makeStyles-metricValueWrapper-342"
                 >
                   -554
                 </span>
@@ -12054,7 +12054,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
                 to
                  
                 <span
-                  class="makeStyles-metricValueWrapper-339"
+                  class="makeStyles-metricValueWrapper-342"
                 >
                   -1.11K
                    
@@ -12075,7 +12075,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
             </strong>
              
             <span
-              class="makeStyles-root-364"
+              class="makeStyles-root-368"
               title="09/05/2020, 20:00:00"
             >
               2020-05-10
@@ -12100,7 +12100,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-359 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-362 MuiTypography-body1"
   >
     Analysis
   </p>
@@ -12108,7 +12108,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
     class="MuiPaper-root MuiTableContainer-root MuiPaper-elevation1 MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-coolTable-360"
+      class="MuiTable-root makeStyles-coolTable-363"
     >
       <thead
         class="MuiTableHead-root"
@@ -12123,10 +12123,10 @@ exports[`renders correctly for conflicting analysis data 2`] = `
             Variant
           </th>
           <th
-            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-unitName-367 MuiTableCell-alignRight"
             scope="col"
           >
-            Conversion rate interval
+            conversion rate
           </th>
           <th
             class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight"
@@ -12149,26 +12149,26 @@ exports[`renders correctly for conflicting analysis data 2`] = `
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-354 makeStyles-headerCell-349 makeStyles-credibleIntervalHeader-357"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-357 makeStyles-headerCell-352 makeStyles-credibleIntervalHeader-360"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-350"
+              class="makeStyles-monospace-353"
             >
               test
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-350 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 MuiTableCell-alignRight"
           >
             <span
               aria-label="the metric value"
-              class="makeStyles-tooltipped-330"
+              class="makeStyles-tooltipped-333"
             >
               <span
-                class="makeStyles-metricValueWrapper-339"
+                class="makeStyles-metricValueWrapper-342"
               >
                 50
               </span>
@@ -12176,7 +12176,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
               to
                
               <span
-                class="makeStyles-metricValueWrapper-339"
+                class="makeStyles-metricValueWrapper-342"
               >
                 100
                  
@@ -12185,14 +12185,14 @@ exports[`renders correctly for conflicting analysis data 2`] = `
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-350 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 MuiTableCell-alignRight"
           >
             <span
               aria-label="the absolute change between variations"
-              class="makeStyles-tooltipped-330"
+              class="makeStyles-tooltipped-333"
             >
               <span
-                class="makeStyles-metricValueWrapper-339"
+                class="makeStyles-metricValueWrapper-342"
               >
                 +
                 50
@@ -12201,7 +12201,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
               to
                
               <span
-                class="makeStyles-metricValueWrapper-339"
+                class="makeStyles-metricValueWrapper-342"
               >
                 +
                 100
@@ -12211,14 +12211,14 @@ exports[`renders correctly for conflicting analysis data 2`] = `
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-350 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 MuiTableCell-alignRight"
           >
             <span
               aria-label="the relative change between variations"
-              class="makeStyles-tooltipped-330"
+              class="makeStyles-tooltipped-333"
             >
               <span
-                class="makeStyles-metricValueWrapper-339"
+                class="makeStyles-metricValueWrapper-342"
               >
                 -50
               </span>
@@ -12226,7 +12226,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
               to
                
               <span
-                class="makeStyles-metricValueWrapper-339"
+                class="makeStyles-metricValueWrapper-342"
               >
                 +
                 0
@@ -12240,26 +12240,26 @@ exports[`renders correctly for conflicting analysis data 2`] = `
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-354 makeStyles-headerCell-349 makeStyles-credibleIntervalHeader-357"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-357 makeStyles-headerCell-352 makeStyles-credibleIntervalHeader-360"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-350"
+              class="makeStyles-monospace-353"
             >
               control
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-350 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 MuiTableCell-alignRight"
           >
             <span
               aria-label="the metric value"
-              class="makeStyles-tooltipped-330"
+              class="makeStyles-tooltipped-333"
             >
               <span
-                class="makeStyles-metricValueWrapper-339"
+                class="makeStyles-metricValueWrapper-342"
               >
                 100
               </span>
@@ -12267,7 +12267,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
               to
                
               <span
-                class="makeStyles-metricValueWrapper-339"
+                class="makeStyles-metricValueWrapper-342"
               >
                 200
                  
@@ -12276,12 +12276,12 @@ exports[`renders correctly for conflicting analysis data 2`] = `
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-350 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 MuiTableCell-alignRight"
           >
             Baseline
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-350 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-353 MuiTableCell-alignRight"
           >
             Baseline
           </td>
@@ -12290,7 +12290,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-analysisFinePrint-356 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-analysisFinePrint-359 MuiTypography-body1"
   >
     95% Credible Intervals (CIs). 
     <strong>
@@ -12300,7 +12300,7 @@ exports[`renders correctly for conflicting analysis data 2`] = `
     
     10
     <span
-      class="makeStyles-tooltipped-330"
+      class="makeStyles-tooltipped-333"
       title="Percentage points."
     >
       pp
@@ -12308,17 +12308,17 @@ exports[`renders correctly for conflicting analysis data 2`] = `
     .
   </p>
   <p
-    class="MuiTypography-root makeStyles-noPlotMessage-353 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-noPlotMessage-356 MuiTypography-body1"
   >
     Past values will be plotted once we have more than one day of results.
   </p>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-359 makeStyles-clickable-361 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-362 makeStyles-clickable-364 MuiTypography-body1"
     role="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-362"
+      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-365"
       focusable="false"
       viewBox="0 0 24 24"
     >
@@ -12329,12 +12329,12 @@ exports[`renders correctly for conflicting analysis data 2`] = `
     "Observed" data
   </p>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-359 makeStyles-clickable-361 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-362 makeStyles-clickable-364 MuiTypography-body1"
     role="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-362"
+      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-365"
       focusable="false"
       viewBox="0 0 24 24"
     >
@@ -12352,7 +12352,7 @@ exports[`renders correctly for conflicting analysis data 3`] = `
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-312",
+        "className": "makeStyles-participantsPlot-315",
         "data": Array [
           Object {
             "line": Object {
@@ -12420,13 +12420,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-365"
+    class="makeStyles-root-369"
   >
     <div
-      class="makeStyles-summary-366"
+      class="makeStyles-summary-370"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-378 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-382 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -12435,16 +12435,16 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-368"
+        class="makeStyles-summaryColumn-372"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-369 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-373 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-370"
+            class="makeStyles-summaryStatsPart-374"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-372 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-376 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               700
             </h3>
@@ -12460,10 +12460,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-370"
+            class="makeStyles-summaryStatsPart-374"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-372 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-376 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Deploy either variation
             </h3>
@@ -12471,7 +12471,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               class="MuiTypography-root MuiTypography-subtitle1"
             >
               <span
-                class="makeStyles-tooltipped-397"
+                class="makeStyles-tooltipped-401"
                 title="The recommendation is metric specific and does not consider other metrics. Check the table below to analyze each metric."
               >
                 <strong>
@@ -12483,12 +12483,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-374 makeStyles-indicationSeverityError-377 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-378 makeStyles-indicationSeverityError-381 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-372 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-376 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Serious issues
             </h3>
@@ -12505,7 +12505,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-380 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-384 MuiTypography-h3"
     >
       Metric Assignment Results
     </h3>
@@ -12514,7 +12514,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-402"
+        class="Component-horizontalScrollContainer-406"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -12533,26 +12533,26 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-403 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-407 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-403 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-407 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric (attribution window)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-403 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-407 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; text-align: center; box-sizing: border-box;"
                     >
                       Estimated difference
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-403 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-407 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; text-align: center; box-sizing: border-box;"
                     >
@@ -12560,11 +12560,11 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                         Estimated impact
                          
                         <span
-                          class="makeStyles-impactIntervalSelectWrapper-391"
+                          class="makeStyles-impactIntervalSelectWrapper-395"
                         >
                           (per
                           <div
-                            class="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-impactIntervalSelect-392"
+                            class="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-impactIntervalSelect-396"
                           >
                             <div
                               aria-haspopup="listbox"
@@ -12598,7 +12598,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       </span>
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-403 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-407 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -12649,7 +12649,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-386"
+                        class="makeStyles-metricAssignmentNameLine-390"
                       >
                         <span
                           class=""
@@ -12691,13 +12691,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       </div>
                       <div>
                         <span
-                          class="makeStyles-root-404 makeStyles-metricAssignmentNameSubtitle-389"
+                          class="makeStyles-root-408 makeStyles-metricAssignmentNameSubtitle-393"
                         >
                           primary metric
                         </span>
                       </div>
                       <div
-                        class="makeStyles-baselineMetricInterval-394"
+                        class="makeStyles-baselineMetricInterval-398"
                       >
                         Baseline: 
                           
@@ -12706,7 +12706,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                           class=""
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-406"
+                            class="makeStyles-metricValueWrapper-410"
                           >
                             0
                           </span>
@@ -12714,7 +12714,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-406"
+                            class="makeStyles-metricValueWrapper-410"
                           >
                             0
                              
@@ -12728,20 +12728,20 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; text-align: center; min-width: 180px;"
                     >
                       <div
-                        class="makeStyles-estimatedDifferenceWrapper-390"
+                        class="makeStyles-estimatedDifferenceWrapper-394"
                       >
                         <svg
-                          class="makeStyles-root-407"
+                          class="makeStyles-root-411"
                         >
                           <line
-                            class="makeStyles-minDifference-408"
+                            class="makeStyles-minDifference-412"
                             x1="2"
                             x2="2"
                             y1="2"
                             y2="17"
                           />
                           <line
-                            class="makeStyles-minDifference-408"
+                            class="makeStyles-minDifference-412"
                             x1="156"
                             x2="156"
                             y1="2"
@@ -12755,7 +12755,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                             y2="19"
                           />
                           <g
-                            class="makeStyles-intervalGroup-409 makeStyles-intervalWithEnoughData-410"
+                            class="makeStyles-intervalGroup-413 makeStyles-intervalWithEnoughData-414"
                           >
                             <rect
                               height="10"
@@ -12764,14 +12764,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                               y="4.5"
                             />
                             <line
-                              class="makeStyles-intervalEdge-411"
+                              class="makeStyles-intervalEdge-415"
                               x1="79"
                               x2="79"
                               y1="2"
                               y2="17"
                             />
                             <line
-                              class="makeStyles-intervalEdge-411"
+                              class="makeStyles-intervalEdge-415"
                               x1="79"
                               x2="79"
                               y1="2"
@@ -12781,10 +12781,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                         </svg>
                         <span
                           aria-label="the absolute change between variations"
-                          class="makeStyles-metricValueIntervalCentered-405 makeStyles-absoluteChangeInterval-395"
+                          class="makeStyles-metricValueIntervalCentered-409 makeStyles-absoluteChangeInterval-399"
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-406"
+                            class="makeStyles-metricValueWrapper-410"
                           >
                             +
                             0
@@ -12793,7 +12793,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-406"
+                            class="makeStyles-metricValueWrapper-410"
                           >
                             +
                             0
@@ -12808,14 +12808,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 700; min-width: 180px;"
                     >
                       <div
-                        class="makeStyles-estimatedImpactWrapper-393"
+                        class="makeStyles-estimatedImpactWrapper-397"
                       >
                         <span
                           aria-label="the estimated impact of 'test', in hypothetical unchanged conditions, over one year, for the targeted audience,"
-                          class="makeStyles-metricValueIntervalCentered-405"
+                          class="makeStyles-metricValueIntervalCentered-409"
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-406"
+                            class="makeStyles-metricValueWrapper-410"
                           >
                             +
                             -0
@@ -12824,7 +12824,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-406"
+                            class="makeStyles-metricValueWrapper-410"
                           >
                             +
                             -0
@@ -12834,10 +12834,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                         </span>
                         <span
                           aria-label="the relative change between variations"
-                          class="makeStyles-metricValueIntervalCentered-405 makeStyles-relativeChangeInterval-396"
+                          class="makeStyles-metricValueIntervalCentered-409 makeStyles-relativeChangeInterval-400"
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-406"
+                            class="makeStyles-metricValueWrapper-410"
                           >
                             -100
                           </span>
@@ -12845,7 +12845,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-406"
+                            class="makeStyles-metricValueWrapper-410"
                           >
                             -100
                              
@@ -12901,7 +12901,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-386"
+                        class="makeStyles-metricAssignmentNameLine-390"
                       >
                         <span
                           class=""
@@ -12997,7 +12997,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-386"
+                        class="makeStyles-metricAssignmentNameLine-390"
                       >
                         <span
                           class=""
@@ -13093,7 +13093,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-386"
+                        class="makeStyles-metricAssignmentNameLine-390"
                       >
                         <span
                           class=""
@@ -13134,7 +13134,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                         </a>
                       </div>
                       <div
-                        class="makeStyles-baselineMetricInterval-394"
+                        class="makeStyles-baselineMetricInterval-398"
                       >
                         Baseline: 
                           
@@ -13143,7 +13143,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                           class=""
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-406"
+                            class="makeStyles-metricValueWrapper-410"
                           >
                             0
                           </span>
@@ -13151,7 +13151,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-406"
+                            class="makeStyles-metricValueWrapper-410"
                           >
                             0
                              
@@ -13165,20 +13165,20 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; text-align: center; min-width: 180px;"
                     >
                       <div
-                        class="makeStyles-estimatedDifferenceWrapper-390"
+                        class="makeStyles-estimatedDifferenceWrapper-394"
                       >
                         <svg
-                          class="makeStyles-root-407"
+                          class="makeStyles-root-411"
                         >
                           <line
-                            class="makeStyles-minDifference-408"
+                            class="makeStyles-minDifference-412"
                             x1="2"
                             x2="2"
                             y1="2"
                             y2="17"
                           />
                           <line
-                            class="makeStyles-minDifference-408"
+                            class="makeStyles-minDifference-412"
                             x1="156"
                             x2="156"
                             y1="2"
@@ -13192,7 +13192,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                             y2="19"
                           />
                           <g
-                            class="makeStyles-intervalGroup-409 makeStyles-intervalWithEnoughData-410"
+                            class="makeStyles-intervalGroup-413 makeStyles-intervalWithEnoughData-414"
                           >
                             <rect
                               height="10"
@@ -13201,14 +13201,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                               y="4.5"
                             />
                             <line
-                              class="makeStyles-intervalEdge-411"
+                              class="makeStyles-intervalEdge-415"
                               x1="79"
                               x2="79"
                               y1="2"
                               y2="17"
                             />
                             <line
-                              class="makeStyles-intervalEdge-411"
+                              class="makeStyles-intervalEdge-415"
                               x1="79"
                               x2="79"
                               y1="2"
@@ -13218,10 +13218,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                         </svg>
                         <span
                           aria-label="the absolute change between variations"
-                          class="makeStyles-metricValueIntervalCentered-405 makeStyles-absoluteChangeInterval-395"
+                          class="makeStyles-metricValueIntervalCentered-409 makeStyles-absoluteChangeInterval-399"
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-406"
+                            class="makeStyles-metricValueWrapper-410"
                           >
                             +
                             0
@@ -13230,7 +13230,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-406"
+                            class="makeStyles-metricValueWrapper-410"
                           >
                             +
                             0
@@ -13245,14 +13245,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 700; min-width: 180px;"
                     >
                       <div
-                        class="makeStyles-estimatedImpactWrapper-393"
+                        class="makeStyles-estimatedImpactWrapper-397"
                       >
                         <span
                           aria-label="the estimated impact of 'test', in hypothetical unchanged conditions, over one year, for the targeted audience,"
-                          class="makeStyles-metricValueIntervalCentered-405"
+                          class="makeStyles-metricValueIntervalCentered-409"
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-406"
+                            class="makeStyles-metricValueWrapper-410"
                           >
                             +
                             -0
@@ -13261,7 +13261,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-406"
+                            class="makeStyles-metricValueWrapper-410"
                           >
                             +
                             -0
@@ -13271,10 +13271,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                         </span>
                         <span
                           aria-label="the relative change between variations"
-                          class="makeStyles-metricValueIntervalCentered-405 makeStyles-relativeChangeInterval-396"
+                          class="makeStyles-metricValueIntervalCentered-409 makeStyles-relativeChangeInterval-400"
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-406"
+                            class="makeStyles-metricValueWrapper-410"
                           >
                             -100
                           </span>
@@ -13282,7 +13282,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-406"
+                            class="makeStyles-metricValueWrapper-410"
                           >
                             -100
                              
@@ -13306,7 +13306,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-380 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-384 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -13388,18 +13388,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-413 makeStyles-deemphasized-414 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-417 makeStyles-deemphasized-418 makeStyles-nowrap-419"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltipped-397"
+                  class="makeStyles-tooltipped-401"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-413 makeStyles-deemphasized-414 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-417 makeStyles-deemphasized-418 makeStyles-nowrap-419"
                 scope="row"
               >
                 1.0000
@@ -13411,7 +13411,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-416 makeStyles-indicationSeverityOk-417 makeStyles-monospace-413 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-420 makeStyles-indicationSeverityOk-421 makeStyles-monospace-417 makeStyles-nowrap-419"
                 scope="row"
               >
                 <span>
@@ -13419,13 +13419,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-413 makeStyles-deemphasized-414 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-417 makeStyles-deemphasized-418 makeStyles-nowrap-419"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-414"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-418"
                 scope="row"
               >
                 <p
@@ -13449,18 +13449,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-413 makeStyles-deemphasized-414 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-417 makeStyles-deemphasized-418 makeStyles-nowrap-419"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltipped-397"
+                  class="makeStyles-tooltipped-401"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-413 makeStyles-deemphasized-414 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-417 makeStyles-deemphasized-418 makeStyles-nowrap-419"
                 scope="row"
               >
                 1.0000
@@ -13472,7 +13472,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-416 makeStyles-indicationSeverityOk-417 makeStyles-monospace-413 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-420 makeStyles-indicationSeverityOk-421 makeStyles-monospace-417 makeStyles-nowrap-419"
                 scope="row"
               >
                 <span>
@@ -13480,13 +13480,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-413 makeStyles-deemphasized-414 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-417 makeStyles-deemphasized-418 makeStyles-nowrap-419"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-414"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-418"
                 scope="row"
               >
                 <p
@@ -13510,18 +13510,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-413 makeStyles-deemphasized-414 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-417 makeStyles-deemphasized-418 makeStyles-nowrap-419"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltipped-397"
+                  class="makeStyles-tooltipped-401"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-413 makeStyles-deemphasized-414 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-417 makeStyles-deemphasized-418 makeStyles-nowrap-419"
                 scope="row"
               >
                 1.0000
@@ -13533,7 +13533,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-416 makeStyles-indicationSeverityOk-417 makeStyles-monospace-413 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-420 makeStyles-indicationSeverityOk-421 makeStyles-monospace-417 makeStyles-nowrap-419"
                 scope="row"
               >
                 <span>
@@ -13541,13 +13541,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-413 makeStyles-deemphasized-414 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-417 makeStyles-deemphasized-418 makeStyles-nowrap-419"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-414"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-418"
                 scope="row"
               >
                 <p
@@ -13571,7 +13571,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-413 makeStyles-deemphasized-414 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-417 makeStyles-deemphasized-418 makeStyles-nowrap-419"
                 scope="row"
               >
                 <span>
@@ -13579,7 +13579,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-413 makeStyles-deemphasized-414 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-417 makeStyles-deemphasized-418 makeStyles-nowrap-419"
                 scope="row"
               >
                 0.1000
@@ -13593,7 +13593,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-416 makeStyles-indicationSeverityError-419 makeStyles-monospace-413 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-420 makeStyles-indicationSeverityError-423 makeStyles-monospace-417 makeStyles-nowrap-419"
                 scope="row"
               >
                 <span>
@@ -13601,13 +13601,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-413 makeStyles-deemphasized-414 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-417 makeStyles-deemphasized-418 makeStyles-nowrap-419"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-414"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-418"
                 scope="row"
               >
                 <p
@@ -13633,7 +13633,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-413 makeStyles-deemphasized-414 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-417 makeStyles-deemphasized-418 makeStyles-nowrap-419"
                 scope="row"
               >
                 <span>
@@ -13641,7 +13641,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-413 makeStyles-deemphasized-414 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-417 makeStyles-deemphasized-418 makeStyles-nowrap-419"
                 scope="row"
               >
                 0.1500
@@ -13655,7 +13655,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-416 makeStyles-indicationSeverityWarning-418 makeStyles-monospace-413 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-420 makeStyles-indicationSeverityWarning-422 makeStyles-monospace-417 makeStyles-nowrap-419"
                 scope="row"
               >
                 <span>
@@ -13663,13 +13663,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-413 makeStyles-deemphasized-414 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-417 makeStyles-deemphasized-418 makeStyles-nowrap-419"
                 scope="row"
               >
                 0.1 &lt; x ≤ 0.4
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-414"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-418"
                 scope="row"
               >
                 <p
@@ -13695,7 +13695,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-413 makeStyles-deemphasized-414 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-417 makeStyles-deemphasized-418 makeStyles-nowrap-419"
                 scope="row"
               >
                 <span>
@@ -13703,7 +13703,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-413 makeStyles-deemphasized-414 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-417 makeStyles-deemphasized-418 makeStyles-nowrap-419"
                 scope="row"
               >
                 10.0000
@@ -13715,7 +13715,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-416 makeStyles-indicationSeverityOk-417 makeStyles-monospace-413 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-420 makeStyles-indicationSeverityOk-421 makeStyles-monospace-417 makeStyles-nowrap-419"
                 scope="row"
               >
                 <span>
@@ -13723,13 +13723,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-413 makeStyles-deemphasized-414 makeStyles-nowrap-415"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-417 makeStyles-deemphasized-418 makeStyles-nowrap-419"
                 scope="row"
               >
                 7 &lt; x ≤ 28
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-414"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-418"
                 scope="row"
               >
                 <p
@@ -13742,7 +13742,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <div
-      class="makeStyles-accordions-381"
+      class="makeStyles-accordions-385"
     >
       <div
         class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -13801,7 +13801,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-382"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-386"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -13961,7 +13961,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-382"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-386"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -13974,7 +13974,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                   </p>
                   <pre
-                    class="makeStyles-pre-384"
+                    class="makeStyles-pre-388"
                   >
                     <code>
                       with tracks_counts as (
@@ -14008,10 +14008,10 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders the condensed table with some analyses in non-debug mode for a Conversion Metric 2`] = `
 <div
-  class="makeStyles-root-420 analysis-detail-panel"
+  class="makeStyles-root-424 analysis-detail-panel"
 >
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-431 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-435 MuiTypography-body1"
   >
     Summary
   </p>
@@ -14031,7 +14031,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableCell-root MuiTableCell-body"
           >
             <h5
-              class="MuiTypography-root makeStyles-recommendation-430 MuiTypography-h5 MuiTypography-gutterBottom"
+              class="MuiTypography-root makeStyles-recommendation-434 MuiTypography-h5 MuiTypography-gutterBottom"
             >
               No difference
             </h5>
@@ -14068,7 +14068,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 class=""
               >
                 <span
-                  class="makeStyles-metricValueWrapper-406"
+                  class="makeStyles-metricValueWrapper-410"
                 >
                   +
                   0
@@ -14077,7 +14077,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 to
                  
                 <span
-                  class="makeStyles-metricValueWrapper-406"
+                  class="makeStyles-metricValueWrapper-410"
                 >
                   +
                   0
@@ -14098,7 +14098,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 class=""
               >
                 <span
-                  class="makeStyles-metricValueWrapper-406"
+                  class="makeStyles-metricValueWrapper-410"
                 >
                   -10
                 </span>
@@ -14106,7 +14106,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 to
                  
                 <span
-                  class="makeStyles-metricValueWrapper-406"
+                  class="makeStyles-metricValueWrapper-410"
                 >
                   +
                   10
@@ -14126,7 +14126,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 class=""
               >
                 <span
-                  class="makeStyles-metricValueWrapper-406"
+                  class="makeStyles-metricValueWrapper-410"
                 >
                   -100
                 </span>
@@ -14134,7 +14134,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 to
                  
                 <span
-                  class="makeStyles-metricValueWrapper-406"
+                  class="makeStyles-metricValueWrapper-410"
                 >
                   -100
                    
@@ -14162,7 +14162,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 class=""
               >
                 <span
-                  class="makeStyles-metricValueWrapper-406"
+                  class="makeStyles-metricValueWrapper-410"
                 >
                   +
                   -0
@@ -14171,7 +14171,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 to
                  
                 <span
-                  class="makeStyles-metricValueWrapper-406"
+                  class="makeStyles-metricValueWrapper-410"
                 >
                   +
                   -0
@@ -14193,7 +14193,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </strong>
              
             <span
-              class="makeStyles-root-436"
+              class="makeStyles-root-441"
               title="09/05/2020, 20:00:00"
             >
               2020-05-10
@@ -14218,7 +14218,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-431 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-435 MuiTypography-body1"
   >
     Analysis
   </p>
@@ -14226,7 +14226,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     class="MuiPaper-root MuiTableContainer-root MuiPaper-elevation1 MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-coolTable-432"
+      class="MuiTable-root makeStyles-coolTable-436"
     >
       <thead
         class="MuiTableHead-root"
@@ -14241,10 +14241,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             Variant
           </th>
           <th
-            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-unitName-440 MuiTableCell-alignRight"
             scope="col"
           >
-            Conversion rate interval
+            conversion rate
           </th>
           <th
             class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight"
@@ -14267,26 +14267,26 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-426 makeStyles-headerCell-421 makeStyles-credibleIntervalHeader-429"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-430 makeStyles-headerCell-425 makeStyles-credibleIntervalHeader-433"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-422"
+              class="makeStyles-monospace-426"
             >
               test
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-422 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-426 MuiTableCell-alignRight"
           >
             <span
               aria-label="the metric value"
-              class="makeStyles-tooltipped-397"
+              class="makeStyles-tooltipped-401"
             >
               <span
-                class="makeStyles-metricValueWrapper-406"
+                class="makeStyles-metricValueWrapper-410"
               >
                 0
               </span>
@@ -14294,7 +14294,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               to
                
               <span
-                class="makeStyles-metricValueWrapper-406"
+                class="makeStyles-metricValueWrapper-410"
               >
                 0
                  
@@ -14303,14 +14303,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-422 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-426 MuiTableCell-alignRight"
           >
             <span
               aria-label="the absolute change between variations"
-              class="makeStyles-tooltipped-397"
+              class="makeStyles-tooltipped-401"
             >
               <span
-                class="makeStyles-metricValueWrapper-406"
+                class="makeStyles-metricValueWrapper-410"
               >
                 +
                 0
@@ -14319,7 +14319,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               to
                
               <span
-                class="makeStyles-metricValueWrapper-406"
+                class="makeStyles-metricValueWrapper-410"
               >
                 +
                 0
@@ -14329,14 +14329,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-422 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-426 MuiTableCell-alignRight"
           >
             <span
               aria-label="the relative change between variations"
-              class="makeStyles-tooltipped-397"
+              class="makeStyles-tooltipped-401"
             >
               <span
-                class="makeStyles-metricValueWrapper-406"
+                class="makeStyles-metricValueWrapper-410"
               >
                 -100
               </span>
@@ -14344,7 +14344,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               to
                
               <span
-                class="makeStyles-metricValueWrapper-406"
+                class="makeStyles-metricValueWrapper-410"
               >
                 -100
                  
@@ -14357,26 +14357,26 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-426 makeStyles-headerCell-421 makeStyles-credibleIntervalHeader-429"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-430 makeStyles-headerCell-425 makeStyles-credibleIntervalHeader-433"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-422"
+              class="makeStyles-monospace-426"
             >
               control
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-422 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-426 MuiTableCell-alignRight"
           >
             <span
               aria-label="the metric value"
-              class="makeStyles-tooltipped-397"
+              class="makeStyles-tooltipped-401"
             >
               <span
-                class="makeStyles-metricValueWrapper-406"
+                class="makeStyles-metricValueWrapper-410"
               >
                 0
               </span>
@@ -14384,7 +14384,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               to
                
               <span
-                class="makeStyles-metricValueWrapper-406"
+                class="makeStyles-metricValueWrapper-410"
               >
                 0
                  
@@ -14393,12 +14393,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-422 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-426 MuiTableCell-alignRight"
           >
             Baseline
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-422 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-426 MuiTableCell-alignRight"
           >
             Baseline
           </td>
@@ -14407,7 +14407,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-analysisFinePrint-428 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-analysisFinePrint-432 MuiTypography-body1"
   >
     95% Credible Intervals (CIs). 
     <strong>
@@ -14417,7 +14417,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     
     10
     <span
-      class="makeStyles-tooltipped-397"
+      class="makeStyles-tooltipped-401"
       title="Percentage points."
     >
       pp
@@ -14425,15 +14425,15 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     .
   </p>
   <div
-    class="makeStyles-metricEstimatePlots-423"
+    class="makeStyles-metricEstimatePlots-427"
   />
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-431 makeStyles-clickable-433 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-435 makeStyles-clickable-437 MuiTypography-body1"
     role="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-434"
+      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-438"
       focusable="false"
       viewBox="0 0 24 24"
     >
@@ -14444,12 +14444,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     "Observed" data
   </p>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-431 makeStyles-clickable-433 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-435 makeStyles-clickable-437 MuiTypography-body1"
     role="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-434"
+      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-438"
       focusable="false"
       viewBox="0 0 24 24"
     >
@@ -14467,7 +14467,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-379",
+        "className": "makeStyles-participantsPlot-383",
         "data": Array [
           Object {
             "line": Object {
@@ -14526,7 +14526,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-424",
+        "className": "makeStyles-metricEstimatePlot-428",
         "data": Array [
           Object {
             "line": Object {
@@ -14622,7 +14622,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-424",
+        "className": "makeStyles-metricEstimatePlot-428",
         "data": Array [
           Object {
             "line": Object {
@@ -14804,7 +14804,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-424",
+        "className": "makeStyles-metricEstimatePlot-428",
         "data": Array [
           Object {
             "line": Object {
@@ -14900,7 +14900,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-424",
+        "className": "makeStyles-metricEstimatePlot-428",
         "data": Array [
           Object {
             "line": Object {
@@ -15111,13 +15111,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   class="analysis-latest-results"
 >
   <div
-    class="makeStyles-root-437"
+    class="makeStyles-root-442"
   >
     <div
-      class="makeStyles-summary-438"
+      class="makeStyles-summary-443"
     >
       <div
-        class="MuiPaper-root makeStyles-participantsPlotPaper-450 MuiPaper-elevation1 MuiPaper-rounded"
+        class="MuiPaper-root makeStyles-participantsPlotPaper-455 MuiPaper-elevation1 MuiPaper-rounded"
       >
         <h3
           class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom"
@@ -15126,16 +15126,16 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
         </h3>
       </div>
       <div
-        class="makeStyles-summaryColumn-440"
+        class="makeStyles-summaryColumn-445"
       >
         <div
-          class="MuiPaper-root makeStyles-summaryStatsPaper-441 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryStatsPaper-446 MuiPaper-elevation1 MuiPaper-rounded"
         >
           <div
-            class="makeStyles-summaryStatsPart-442"
+            class="makeStyles-summaryStatsPart-447"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-444 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-449 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               700
             </h3>
@@ -15151,10 +15151,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </h6>
           </div>
           <div
-            class="makeStyles-summaryStatsPart-442"
+            class="makeStyles-summaryStatsPart-447"
           >
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-444 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-449 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Deploy either variation
             </h3>
@@ -15162,7 +15162,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               class="MuiTypography-root MuiTypography-subtitle1"
             >
               <span
-                class="makeStyles-tooltipped-469"
+                class="makeStyles-tooltipped-474"
                 title="The recommendation is metric specific and does not consider other metrics. Check the table below to analyze each metric."
               >
                 <strong>
@@ -15174,12 +15174,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           </div>
         </div>
         <a
-          class="MuiPaper-root makeStyles-summaryHealthPaper-446 makeStyles-indicationSeverityError-449 MuiPaper-elevation1 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-summaryHealthPaper-451 makeStyles-indicationSeverityError-454 MuiPaper-elevation1 MuiPaper-rounded"
           href="#health-report"
         >
           <div>
             <h3
-              class="MuiTypography-root makeStyles-summaryStatsStat-444 MuiTypography-h3 MuiTypography-colorPrimary"
+              class="MuiTypography-root makeStyles-summaryStatsStat-449 MuiTypography-h3 MuiTypography-colorPrimary"
             >
               Serious issues
             </h3>
@@ -15196,7 +15196,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-452 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-457 MuiTypography-h3"
     >
       Metric Assignment Results
     </h3>
@@ -15205,7 +15205,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       style="position: relative;"
     >
       <div
-        class="Component-horizontalScrollContainer-474"
+        class="Component-horizontalScrollContainer-479"
         style="overflow-x: auto; position: relative;"
       >
         <div>
@@ -15224,26 +15224,26 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-475 MuiTableCell-paddingNone"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-480 MuiTableCell-paddingNone"
                       scope="col"
                       style="font-weight: 700;"
                     />
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-475 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-480 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
                       Metric (attribution window)
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-475 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-480 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; text-align: center; box-sizing: border-box;"
                     >
                       Estimated difference
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-475 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-480 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; text-align: center; box-sizing: border-box;"
                     >
@@ -15251,11 +15251,11 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                         Estimated impact
                          
                         <span
-                          class="makeStyles-impactIntervalSelectWrapper-463"
+                          class="makeStyles-impactIntervalSelectWrapper-468"
                         >
                           (per
                           <div
-                            class="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-impactIntervalSelect-464"
+                            class="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-impactIntervalSelect-469"
                           >
                             <div
                               aria-haspopup="listbox"
@@ -15289,7 +15289,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       </span>
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-475 MuiTableCell-alignLeft"
+                      class="MuiTableCell-root MuiTableCell-head MTableHeader-header-480 MuiTableCell-alignLeft"
                       scope="col"
                       style="font-weight: 700; box-sizing: border-box;"
                     >
@@ -15340,7 +15340,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-458"
+                        class="makeStyles-metricAssignmentNameLine-463"
                       >
                         <span
                           class=""
@@ -15382,13 +15382,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       </div>
                       <div>
                         <span
-                          class="makeStyles-root-476 makeStyles-metricAssignmentNameSubtitle-461"
+                          class="makeStyles-root-481 makeStyles-metricAssignmentNameSubtitle-466"
                         >
                           primary metric
                         </span>
                       </div>
                       <div
-                        class="makeStyles-baselineMetricInterval-466"
+                        class="makeStyles-baselineMetricInterval-471"
                       >
                         Baseline: 
                           
@@ -15397,7 +15397,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                           class=""
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-478"
+                            class="makeStyles-metricValueWrapper-483"
                           >
                             0.00
                           </span>
@@ -15405,7 +15405,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-478"
+                            class="makeStyles-metricValueWrapper-483"
                           >
                             0.00
                              
@@ -15419,20 +15419,20 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; text-align: center; min-width: 180px;"
                     >
                       <div
-                        class="makeStyles-estimatedDifferenceWrapper-462"
+                        class="makeStyles-estimatedDifferenceWrapper-467"
                       >
                         <svg
-                          class="makeStyles-root-479"
+                          class="makeStyles-root-484"
                         >
                           <line
-                            class="makeStyles-minDifference-480"
+                            class="makeStyles-minDifference-485"
                             x1="2"
                             x2="2"
                             y1="2"
                             y2="17"
                           />
                           <line
-                            class="makeStyles-minDifference-480"
+                            class="makeStyles-minDifference-485"
                             x1="156"
                             x2="156"
                             y1="2"
@@ -15446,7 +15446,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                             y2="19"
                           />
                           <g
-                            class="makeStyles-intervalGroup-481 makeStyles-intervalWithEnoughData-482"
+                            class="makeStyles-intervalGroup-486 makeStyles-intervalWithEnoughData-487"
                           >
                             <rect
                               height="10"
@@ -15455,14 +15455,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                               y="4.5"
                             />
                             <line
-                              class="makeStyles-intervalEdge-483"
+                              class="makeStyles-intervalEdge-488"
                               x1="79"
                               x2="79"
                               y1="2"
                               y2="17"
                             />
                             <line
-                              class="makeStyles-intervalEdge-483"
+                              class="makeStyles-intervalEdge-488"
                               x1="79"
                               x2="79"
                               y1="2"
@@ -15472,10 +15472,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                         </svg>
                         <span
                           aria-label="the absolute change between variations"
-                          class="makeStyles-metricValueIntervalCentered-477 makeStyles-absoluteChangeInterval-467"
+                          class="makeStyles-metricValueIntervalCentered-482 makeStyles-absoluteChangeInterval-472"
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-478"
+                            class="makeStyles-metricValueWrapper-483"
                           >
                             +
                             0.00
@@ -15484,7 +15484,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-478"
+                            class="makeStyles-metricValueWrapper-483"
                           >
                             +
                             0.00
@@ -15499,14 +15499,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 700; min-width: 180px;"
                     >
                       <div
-                        class="makeStyles-estimatedImpactWrapper-465"
+                        class="makeStyles-estimatedImpactWrapper-470"
                       >
                         <span
                           aria-label="the estimated impact of 'test', in hypothetical unchanged conditions, over one year, for the targeted audience,"
-                          class="makeStyles-metricValueIntervalCentered-477"
+                          class="makeStyles-metricValueIntervalCentered-482"
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-478"
+                            class="makeStyles-metricValueWrapper-483"
                           >
                             +
                             -0
@@ -15515,7 +15515,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-478"
+                            class="makeStyles-metricValueWrapper-483"
                           >
                             +
                             -0
@@ -15525,10 +15525,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                         </span>
                         <span
                           aria-label="the relative change between variations"
-                          class="makeStyles-metricValueIntervalCentered-477 makeStyles-relativeChangeInterval-468"
+                          class="makeStyles-metricValueIntervalCentered-482 makeStyles-relativeChangeInterval-473"
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-478"
+                            class="makeStyles-metricValueWrapper-483"
                           >
                             -100
                           </span>
@@ -15536,7 +15536,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-478"
+                            class="makeStyles-metricValueWrapper-483"
                           >
                             -100
                              
@@ -15592,7 +15592,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-458"
+                        class="makeStyles-metricAssignmentNameLine-463"
                       >
                         <span
                           class=""
@@ -15688,7 +15688,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-458"
+                        class="makeStyles-metricAssignmentNameLine-463"
                       >
                         <span
                           class=""
@@ -15784,7 +15784,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; min-width: 450px;"
                     >
                       <div
-                        class="makeStyles-metricAssignmentNameLine-458"
+                        class="makeStyles-metricAssignmentNameLine-463"
                       >
                         <span
                           class=""
@@ -15825,7 +15825,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                         </a>
                       </div>
                       <div
-                        class="makeStyles-baselineMetricInterval-466"
+                        class="makeStyles-baselineMetricInterval-471"
                       >
                         Baseline: 
                           
@@ -15834,7 +15834,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                           class=""
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-478"
+                            class="makeStyles-metricValueWrapper-483"
                           >
                             0.00
                           </span>
@@ -15842,7 +15842,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-478"
+                            class="makeStyles-metricValueWrapper-483"
                           >
                             0.00
                              
@@ -15856,20 +15856,20 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; text-align: center; min-width: 180px;"
                     >
                       <div
-                        class="makeStyles-estimatedDifferenceWrapper-462"
+                        class="makeStyles-estimatedDifferenceWrapper-467"
                       >
                         <svg
-                          class="makeStyles-root-479"
+                          class="makeStyles-root-484"
                         >
                           <line
-                            class="makeStyles-minDifference-480"
+                            class="makeStyles-minDifference-485"
                             x1="2"
                             x2="2"
                             y1="2"
                             y2="17"
                           />
                           <line
-                            class="makeStyles-minDifference-480"
+                            class="makeStyles-minDifference-485"
                             x1="156"
                             x2="156"
                             y1="2"
@@ -15883,7 +15883,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                             y2="19"
                           />
                           <g
-                            class="makeStyles-intervalGroup-481 makeStyles-intervalWithEnoughData-482"
+                            class="makeStyles-intervalGroup-486 makeStyles-intervalWithEnoughData-487"
                           >
                             <rect
                               height="10"
@@ -15892,14 +15892,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                               y="4.5"
                             />
                             <line
-                              class="makeStyles-intervalEdge-483"
+                              class="makeStyles-intervalEdge-488"
                               x1="79"
                               x2="79"
                               y1="2"
                               y2="17"
                             />
                             <line
-                              class="makeStyles-intervalEdge-483"
+                              class="makeStyles-intervalEdge-488"
                               x1="79"
                               x2="79"
                               y1="2"
@@ -15909,10 +15909,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                         </svg>
                         <span
                           aria-label="the absolute change between variations"
-                          class="makeStyles-metricValueIntervalCentered-477 makeStyles-absoluteChangeInterval-467"
+                          class="makeStyles-metricValueIntervalCentered-482 makeStyles-absoluteChangeInterval-472"
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-478"
+                            class="makeStyles-metricValueWrapper-483"
                           >
                             +
                             0.00
@@ -15921,7 +15921,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-478"
+                            class="makeStyles-metricValueWrapper-483"
                           >
                             +
                             0.00
@@ -15936,14 +15936,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                       style="box-sizing: border-box; font-family: 'Roboto Mono', monospace; font-weight: 700; min-width: 180px;"
                     >
                       <div
-                        class="makeStyles-estimatedImpactWrapper-465"
+                        class="makeStyles-estimatedImpactWrapper-470"
                       >
                         <span
                           aria-label="the estimated impact of 'test', in hypothetical unchanged conditions, over one year, for the targeted audience,"
-                          class="makeStyles-metricValueIntervalCentered-477"
+                          class="makeStyles-metricValueIntervalCentered-482"
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-478"
+                            class="makeStyles-metricValueWrapper-483"
                           >
                             +
                             -0
@@ -15952,7 +15952,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-478"
+                            class="makeStyles-metricValueWrapper-483"
                           >
                             +
                             -0
@@ -15962,10 +15962,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                         </span>
                         <span
                           aria-label="the relative change between variations"
-                          class="makeStyles-metricValueIntervalCentered-477 makeStyles-relativeChangeInterval-468"
+                          class="makeStyles-metricValueIntervalCentered-482 makeStyles-relativeChangeInterval-473"
                         >
                           <span
-                            class="makeStyles-metricValueWrapper-478"
+                            class="makeStyles-metricValueWrapper-483"
                           >
                             -100
                           </span>
@@ -15973,7 +15973,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                           to
                            
                           <span
-                            class="makeStyles-metricValueWrapper-478"
+                            class="makeStyles-metricValueWrapper-483"
                           >
                             -100
                              
@@ -15997,7 +15997,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <h3
-      class="MuiTypography-root makeStyles-tableTitle-452 MuiTypography-h3"
+      class="MuiTypography-root makeStyles-tableTitle-457 MuiTypography-h3"
     >
       Health Report
     </h3>
@@ -16079,18 +16079,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-485 makeStyles-deemphasized-486 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-490 makeStyles-deemphasized-491 makeStyles-nowrap-492"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltipped-469"
+                  class="makeStyles-tooltipped-474"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-485 makeStyles-deemphasized-486 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-490 makeStyles-deemphasized-491 makeStyles-nowrap-492"
                 scope="row"
               >
                 1.0000
@@ -16102,7 +16102,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-488 makeStyles-indicationSeverityOk-489 makeStyles-monospace-485 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-493 makeStyles-indicationSeverityOk-494 makeStyles-monospace-490 makeStyles-nowrap-492"
                 scope="row"
               >
                 <span>
@@ -16110,13 +16110,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-485 makeStyles-deemphasized-486 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-490 makeStyles-deemphasized-491 makeStyles-nowrap-492"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-486"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-491"
                 scope="row"
               >
                 <p
@@ -16140,18 +16140,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-485 makeStyles-deemphasized-486 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-490 makeStyles-deemphasized-491 makeStyles-nowrap-492"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltipped-469"
+                  class="makeStyles-tooltipped-474"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-485 makeStyles-deemphasized-486 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-490 makeStyles-deemphasized-491 makeStyles-nowrap-492"
                 scope="row"
               >
                 1.0000
@@ -16163,7 +16163,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-488 makeStyles-indicationSeverityOk-489 makeStyles-monospace-485 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-493 makeStyles-indicationSeverityOk-494 makeStyles-monospace-490 makeStyles-nowrap-492"
                 scope="row"
               >
                 <span>
@@ -16171,13 +16171,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-485 makeStyles-deemphasized-486 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-490 makeStyles-deemphasized-491 makeStyles-nowrap-492"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-486"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-491"
                 scope="row"
               >
                 <p
@@ -16201,18 +16201,18 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-485 makeStyles-deemphasized-486 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-490 makeStyles-deemphasized-491 makeStyles-nowrap-492"
                 scope="row"
               >
                 <span
-                  class="makeStyles-tooltipped-469"
+                  class="makeStyles-tooltipped-474"
                   title="The smaller the p-value the more likely there is an issue."
                 >
                   p-value
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-485 makeStyles-deemphasized-486 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-490 makeStyles-deemphasized-491 makeStyles-nowrap-492"
                 scope="row"
               >
                 1.0000
@@ -16224,7 +16224,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-488 makeStyles-indicationSeverityOk-489 makeStyles-monospace-485 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-493 makeStyles-indicationSeverityOk-494 makeStyles-monospace-490 makeStyles-nowrap-492"
                 scope="row"
               >
                 <span>
@@ -16232,13 +16232,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-485 makeStyles-deemphasized-486 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-490 makeStyles-deemphasized-491 makeStyles-nowrap-492"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-486"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-491"
                 scope="row"
               >
                 <p
@@ -16262,7 +16262,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-485 makeStyles-deemphasized-486 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-490 makeStyles-deemphasized-491 makeStyles-nowrap-492"
                 scope="row"
               >
                 <span>
@@ -16270,7 +16270,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-485 makeStyles-deemphasized-486 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-490 makeStyles-deemphasized-491 makeStyles-nowrap-492"
                 scope="row"
               >
                 0.1000
@@ -16284,7 +16284,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-488 makeStyles-indicationSeverityError-491 makeStyles-monospace-485 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-493 makeStyles-indicationSeverityError-496 makeStyles-monospace-490 makeStyles-nowrap-492"
                 scope="row"
               >
                 <span>
@@ -16292,13 +16292,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-485 makeStyles-deemphasized-486 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-490 makeStyles-deemphasized-491 makeStyles-nowrap-492"
                 scope="row"
               >
                 0.05 &lt; x ≤ 1
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-486"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-491"
                 scope="row"
               >
                 <p
@@ -16324,7 +16324,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-485 makeStyles-deemphasized-486 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-490 makeStyles-deemphasized-491 makeStyles-nowrap-492"
                 scope="row"
               >
                 <span>
@@ -16332,7 +16332,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-485 makeStyles-deemphasized-486 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-490 makeStyles-deemphasized-491 makeStyles-nowrap-492"
                 scope="row"
               >
                 0.1500
@@ -16346,7 +16346,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-488 makeStyles-indicationSeverityWarning-490 makeStyles-monospace-485 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-493 makeStyles-indicationSeverityWarning-495 makeStyles-monospace-490 makeStyles-nowrap-492"
                 scope="row"
               >
                 <span>
@@ -16354,13 +16354,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-485 makeStyles-deemphasized-486 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-490 makeStyles-deemphasized-491 makeStyles-nowrap-492"
                 scope="row"
               >
                 0.1 &lt; x ≤ 0.4
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-486"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-491"
                 scope="row"
               >
                 <p
@@ -16386,7 +16386,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </a>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-485 makeStyles-deemphasized-486 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-490 makeStyles-deemphasized-491 makeStyles-nowrap-492"
                 scope="row"
               >
                 <span>
@@ -16394,7 +16394,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-485 makeStyles-deemphasized-486 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-490 makeStyles-deemphasized-491 makeStyles-nowrap-492"
                 scope="row"
               >
                 10.0000
@@ -16406,7 +16406,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 <span />
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-488 makeStyles-indicationSeverityOk-489 makeStyles-monospace-485 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-indication-493 makeStyles-indicationSeverityOk-494 makeStyles-monospace-490 makeStyles-nowrap-492"
                 scope="row"
               >
                 <span>
@@ -16414,13 +16414,13 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 </span>
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-485 makeStyles-deemphasized-486 makeStyles-nowrap-487"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-490 makeStyles-deemphasized-491 makeStyles-nowrap-492"
                 scope="row"
               >
                 7 &lt; x ≤ 28
               </td>
               <td
-                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-486"
+                class="MuiTableCell-root MuiTableCell-body makeStyles-deemphasized-491"
                 scope="row"
               >
                 <p
@@ -16433,7 +16433,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
       </div>
     </div>
     <div
-      class="makeStyles-accordions-453"
+      class="makeStyles-accordions-458"
     >
       <div
         class="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -16492,7 +16492,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-454"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-459"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -16652,7 +16652,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 role="region"
               >
                 <div
-                  class="MuiAccordionDetails-root makeStyles-accordionDetails-454"
+                  class="MuiAccordionDetails-root makeStyles-accordionDetails-459"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1"
@@ -16665,7 +16665,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                     This query should only be used to monitor event flow. The best way to use it is to run it multiple times and ensure that counts go up and are roughly distributed as expected. Counts may also go down as events are moved to prod_events every day.
                   </p>
                   <pre
-                    class="makeStyles-pre-456"
+                    class="makeStyles-pre-461"
                   >
                     <code>
                       with tracks_counts as (
@@ -16699,10 +16699,10 @@ inner join wpcom.experiment_variations using (experiment_variation_id)
 
 exports[`renders the condensed table with some analyses in non-debug mode for a Revenue Metric 2`] = `
 <div
-  class="makeStyles-root-492 analysis-detail-panel"
+  class="makeStyles-root-497 analysis-detail-panel"
 >
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-503 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-508 MuiTypography-body1"
   >
     Summary
   </p>
@@ -16722,7 +16722,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             class="MuiTableCell-root MuiTableCell-body"
           >
             <h5
-              class="MuiTypography-root makeStyles-recommendation-502 MuiTypography-h5 MuiTypography-gutterBottom"
+              class="MuiTypography-root makeStyles-recommendation-507 MuiTypography-h5 MuiTypography-gutterBottom"
             >
               No difference
             </h5>
@@ -16751,7 +16751,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom"
             >
               The absolute change in the 
-              ACPU
+              average cash per user (ACPU)
                of
                
               <span
@@ -16759,7 +16759,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 class=""
               >
                 <span
-                  class="makeStyles-metricValueWrapper-478"
+                  class="makeStyles-metricValueWrapper-483"
                 >
                   +
                   0.00
@@ -16768,7 +16768,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 to
                  
                 <span
-                  class="makeStyles-metricValueWrapper-478"
+                  class="makeStyles-metricValueWrapper-483"
                 >
                   +
                   0.00
@@ -16789,7 +16789,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 class=""
               >
                 <span
-                  class="makeStyles-metricValueWrapper-478"
+                  class="makeStyles-metricValueWrapper-483"
                 >
                   -0.10
                 </span>
@@ -16797,7 +16797,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 to
                  
                 <span
-                  class="makeStyles-metricValueWrapper-478"
+                  class="makeStyles-metricValueWrapper-483"
                 >
                   +
                   0.10
@@ -16817,7 +16817,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 class=""
               >
                 <span
-                  class="makeStyles-metricValueWrapper-478"
+                  class="makeStyles-metricValueWrapper-483"
                 >
                   -100
                 </span>
@@ -16825,7 +16825,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 to
                  
                 <span
-                  class="makeStyles-metricValueWrapper-478"
+                  class="makeStyles-metricValueWrapper-483"
                 >
                   -100
                    
@@ -16853,7 +16853,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 class=""
               >
                 <span
-                  class="makeStyles-metricValueWrapper-478"
+                  class="makeStyles-metricValueWrapper-483"
                 >
                   +
                   -0
@@ -16862,7 +16862,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
                 to
                  
                 <span
-                  class="makeStyles-metricValueWrapper-478"
+                  class="makeStyles-metricValueWrapper-483"
                 >
                   +
                   -0
@@ -16884,7 +16884,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </strong>
              
             <span
-              class="makeStyles-root-508"
+              class="makeStyles-root-514"
               title="09/05/2020, 20:00:00"
             >
               2020-05-10
@@ -16909,7 +16909,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-503 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-508 MuiTypography-body1"
   >
     Analysis
   </p>
@@ -16917,7 +16917,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     class="MuiPaper-root MuiTableContainer-root MuiPaper-elevation1 MuiPaper-rounded"
   >
     <table
-      class="MuiTable-root makeStyles-coolTable-504"
+      class="MuiTable-root makeStyles-coolTable-509"
     >
       <thead
         class="MuiTableHead-root"
@@ -16932,10 +16932,10 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             Variant
           </th>
           <th
-            class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-unitName-513 MuiTableCell-alignRight"
             scope="col"
           >
-            Average cash per user (ACPU) interval
+            average cash per user (ACPU)
           </th>
           <th
             class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight"
@@ -16958,26 +16958,26 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-498 makeStyles-headerCell-493 makeStyles-credibleIntervalHeader-501"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-503 makeStyles-headerCell-498 makeStyles-credibleIntervalHeader-506"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-494"
+              class="makeStyles-monospace-499"
             >
               test
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-494 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-499 MuiTableCell-alignRight"
           >
             <span
               aria-label="the metric value"
-              class="makeStyles-tooltipped-469"
+              class="makeStyles-tooltipped-474"
             >
               <span
-                class="makeStyles-metricValueWrapper-478"
+                class="makeStyles-metricValueWrapper-483"
               >
                 0.00
               </span>
@@ -16985,7 +16985,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               to
                
               <span
-                class="makeStyles-metricValueWrapper-478"
+                class="makeStyles-metricValueWrapper-483"
               >
                 0.00
                  
@@ -16994,14 +16994,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-494 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-499 MuiTableCell-alignRight"
           >
             <span
               aria-label="the absolute change between variations"
-              class="makeStyles-tooltipped-469"
+              class="makeStyles-tooltipped-474"
             >
               <span
-                class="makeStyles-metricValueWrapper-478"
+                class="makeStyles-metricValueWrapper-483"
               >
                 +
                 0.00
@@ -17010,7 +17010,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               to
                
               <span
-                class="makeStyles-metricValueWrapper-478"
+                class="makeStyles-metricValueWrapper-483"
               >
                 +
                 0.00
@@ -17020,14 +17020,14 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-494 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-499 MuiTableCell-alignRight"
           >
             <span
               aria-label="the relative change between variations"
-              class="makeStyles-tooltipped-469"
+              class="makeStyles-tooltipped-474"
             >
               <span
-                class="makeStyles-metricValueWrapper-478"
+                class="makeStyles-metricValueWrapper-483"
               >
                 -100
               </span>
@@ -17035,7 +17035,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               to
                
               <span
-                class="makeStyles-metricValueWrapper-478"
+                class="makeStyles-metricValueWrapper-483"
               >
                 -100
                  
@@ -17048,26 +17048,26 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
           class="MuiTableRow-root"
         >
           <th
-            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-498 makeStyles-headerCell-493 makeStyles-credibleIntervalHeader-501"
+            class="MuiTableCell-root MuiTableCell-head makeStyles-rowHeader-503 makeStyles-headerCell-498 makeStyles-credibleIntervalHeader-506"
             role="cell"
             scope="row"
             valign="top"
           >
             <span
-              class="makeStyles-monospace-494"
+              class="makeStyles-monospace-499"
             >
               control
             </span>
           </th>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-494 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-499 MuiTableCell-alignRight"
           >
             <span
               aria-label="the metric value"
-              class="makeStyles-tooltipped-469"
+              class="makeStyles-tooltipped-474"
             >
               <span
-                class="makeStyles-metricValueWrapper-478"
+                class="makeStyles-metricValueWrapper-483"
               >
                 0.00
               </span>
@@ -17075,7 +17075,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
               to
                
               <span
-                class="makeStyles-metricValueWrapper-478"
+                class="makeStyles-metricValueWrapper-483"
               >
                 0.00
                  
@@ -17084,12 +17084,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
             </span>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-494 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-499 MuiTableCell-alignRight"
           >
             Baseline
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-494 MuiTableCell-alignRight"
+            class="MuiTableCell-root MuiTableCell-body makeStyles-monospace-499 MuiTableCell-alignRight"
           >
             Baseline
           </td>
@@ -17098,7 +17098,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     </table>
   </div>
   <p
-    class="MuiTypography-root makeStyles-analysisFinePrint-500 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-analysisFinePrint-505 MuiTypography-body1"
   >
     95% Credible Intervals (CIs). 
     <strong>
@@ -17111,15 +17111,15 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     .
   </p>
   <div
-    class="makeStyles-metricEstimatePlots-495"
+    class="makeStyles-metricEstimatePlots-500"
   />
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-503 makeStyles-clickable-505 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-508 makeStyles-clickable-510 MuiTypography-body1"
     role="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-506"
+      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-511"
       focusable="false"
       viewBox="0 0 24 24"
     >
@@ -17130,12 +17130,12 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     "Observed" data
   </p>
   <p
-    class="MuiTypography-root makeStyles-dataTableHeader-503 makeStyles-clickable-505 MuiTypography-body1"
+    class="MuiTypography-root makeStyles-dataTableHeader-508 makeStyles-clickable-510 MuiTypography-body1"
     role="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-506"
+      class="MuiSvgIcon-root makeStyles-expandCollapseIcon-511"
       focusable="false"
       viewBox="0 0 24 24"
     >
@@ -17153,7 +17153,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
   "calls": Array [
     Array [
       Object {
-        "className": "makeStyles-participantsPlot-451",
+        "className": "makeStyles-participantsPlot-456",
         "data": Array [
           Object {
             "line": Object {
@@ -17212,7 +17212,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-496",
+        "className": "makeStyles-metricEstimatePlot-501",
         "data": Array [
           Object {
             "line": Object {
@@ -17308,7 +17308,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-496",
+        "className": "makeStyles-metricEstimatePlot-501",
         "data": Array [
           Object {
             "line": Object {
@@ -17490,7 +17490,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-496",
+        "className": "makeStyles-metricEstimatePlot-501",
         "data": Array [
           Object {
             "line": Object {
@@ -17586,7 +17586,7 @@ exports[`renders the condensed table with some analyses in non-debug mode for a 
     ],
     Array [
       Object {
-        "className": "makeStyles-metricEstimatePlot-496",
+        "className": "makeStyles-metricEstimatePlot-501",
         "data": Array [
           Object {
             "line": Object {

--- a/src/components/explat/experiments/single-view/results/__snapshots__/MetricAssignmentResults.test.tsx.snap
+++ b/src/components/explat/experiments/single-view/results/__snapshots__/MetricAssignmentResults.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`MetricAssignmentResults renders an appropriate message with no analyses 1`] = `
 <div>
   <div
-    class="makeStyles-root-21"
+    class="makeStyles-root-22"
   >
     <h5
       class="MuiTypography-root MuiTypography-h5 MuiTypography-gutterBottom"

--- a/src/components/explat/experiments/wizard/Metrics.tsx
+++ b/src/components/explat/experiments/wizard/Metrics.tsx
@@ -567,7 +567,7 @@ const Metrics = ({
                                   samplesPerMonth,
                                   setSamplesPerMonth,
                                   experiment: formikProps.values.experiment,
-                                  metricParameterType: indexedMetrics[metricAssignment.metricId].parameterType,
+                                  metric: indexedMetrics[metricAssignment.metricId],
                                 }}
                               />
                             </TableCell>


### PR DESCRIPTION
<!-- Describe your changes in detail. -->
**This PR generalises MetricAssignmentResults so that we aren't using metricParameterType.**

This is the last in this series of PRs and resolves the front-end portion of https://github.com/Automattic/experimentation-platform/issues/781

<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)

