### PR TITLE
Metrics: display tags in the metrics table

### DIFF
--- a/src/components/explat/metrics/multi-view/MetricsTable.tsx
+++ b/src/components/explat/metrics/multi-view/MetricsTable.tsx
@@ -7,7 +7,7 @@ import React, { forwardRef, useEffect, useMemo } from 'react'
 
 import MetricsApi from 'src/api/explat/MetricsApi'
 import { metricParameterTypeName, stringifyMetricParams } from 'src/lib/explat/metrics'
-import { Metric, MetricParameterType } from 'src/lib/explat/schemas'
+import { Metric, MetricParameterType, TagBare } from 'src/lib/explat/schemas'
 import { useDataLoadingError, useDataSource } from 'src/utils/data-loading'
 import { createIdSlug } from 'src/utils/general'
 import { defaultTableOptions } from 'src/utils/material-table'
@@ -87,6 +87,11 @@ const MetricsTable = ({
       cellStyle: {
         fontFamily: theme.custom.fonts.monospace,
       },
+    },
+    {
+      title: 'Tags',
+      field: 'tags',
+      render: ({ tags }: { tags: TagBare[] }) => tags?.map((tag) => tag.name).join(', '),
     },
     {
       field: 'stringifiedParamsForSearch',

--- a/src/lib/explat/schemas.ts
+++ b/src/lib/explat/schemas.ts
@@ -114,6 +114,29 @@ export const extendedNumberSchema = yup
   // eslint-disable-next-line no-template-curly-in-string
   .test('is-number', '${path} is not a number', (value: unknown) => value === undefined || typeof value === 'number')
 
+export enum TagNamespace {
+  ExclusionGroup = 'exclusion_group',
+}
+
+export const tagBareSchema = yup
+  .object({
+    tagId: idSchema.defined(),
+    namespace: nameSchema.defined(),
+    name: nameSchema.defined(),
+    description: yup.string().defined(),
+  })
+  .defined()
+  .camelCase()
+export interface TagBare extends yup.InferType<typeof tagBareSchema> {}
+// For consistency and openness:
+export const tagFullSchema = tagBareSchema
+export interface TagFull extends yup.InferType<typeof tagFullSchema> {}
+export const tagFullNewSchema = tagFullSchema.shape({
+  tagId: idSchema.nullable(),
+})
+export interface TagFullNew extends yup.InferType<typeof tagFullNewSchema> {}
+export const tagFullNewOutboundSchema = tagFullNewSchema.snakeCase()
+
 export const eventSchema = yup
   .object({
     event: yup.string().defined(),
@@ -209,6 +232,7 @@ const noTestMetricSchema = yup
       then: metricPipeParamsSchema.defined(),
       otherwise: yup.mixed().oneOf([null]),
     }),
+    tags: yup.array(tagBareSchema),
   })
   .defined()
   .camelCase()
@@ -296,29 +320,6 @@ export const metricAssignmentSchema = metricAssignmentNewSchema
   .defined()
   .camelCase()
 export interface MetricAssignment extends yup.InferType<typeof metricAssignmentSchema> {}
-
-export enum TagNamespace {
-  ExclusionGroup = 'exclusion_group',
-}
-
-export const tagBareSchema = yup
-  .object({
-    tagId: idSchema.defined(),
-    namespace: nameSchema.defined(),
-    name: nameSchema.defined(),
-    description: yup.string().defined(),
-  })
-  .defined()
-  .camelCase()
-export interface TagBare extends yup.InferType<typeof tagBareSchema> {}
-// For consistency and openness:
-export const tagFullSchema = tagBareSchema
-export interface TagFull extends yup.InferType<typeof tagFullSchema> {}
-export const tagFullNewSchema = tagFullSchema.shape({
-  tagId: idSchema.nullable(),
-})
-export interface TagFullNew extends yup.InferType<typeof tagFullNewSchema> {}
-export const tagFullNewOutboundSchema = tagFullNewSchema.snakeCase()
 
 export enum SegmentType {
   Country = 'country',


### PR DESCRIPTION
Fixes https://github.com/Automattic/experimentation-platform/issues/868

- adds `tags` to metric schema
- display tags in a raw format (comma separated) in the `MetricsTable`

<!-- Describe your changes in detail. -->
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
- Manual testing with mock data (locally or on Vercel)
- Additional manual testing instructions (please specify):
