### PR TITLE
Experiment directory: separate subsequent data loading

### DIFF
--- a/src/pages/explat/experiments/ExperimentsAgGrid.tsx
+++ b/src/pages/explat/experiments/ExperimentsAgGrid.tsx
@@ -23,22 +23,12 @@ const Experiments = function (): JSX.Element {
 
   const classes = useStyles()
   const { isLoading, data: experiments, error } = useDataSource(() => ExperimentsApi.findAll(), [])
-  const {
-    isLoading: isLoadingAnalyses,
-    data: experimentsWithAnalyses,
-    error: errorLoadingAnalyses,
-  } = useDataSource(() => ExperimentsApi.findAll(true), [])
 
-  useDataLoadingError(error || errorLoadingAnalyses, 'Experiment')
+  useDataLoadingError(error, 'Experiment')
   return (
     <Layout headTitle='Experiments' flexContent>
       <div className={classes.loadingBarContainer}>{isLoading && <LinearProgress />}</div>
-      {!error && (
-        <ExperimentsTableAgGrid
-          isLoadingAnalyses={isLoadingAnalyses}
-          experiments={experimentsWithAnalyses || experiments || []}
-        />
-      )}
+      {!error && <ExperimentsTableAgGrid experiments={experiments || []} />}
     </Layout>
   )
 }


### PR DESCRIPTION
Pausing this until we add the pagination support mentioned in https://github.com/Automattic/experimentation-platform/issues/824#issuecomment-1584251221

Follow-up for https://github.com/Automattic/abacus/pull/881

* Update ag-grid internally with the new `/experiment?include_analyses` response.
* Clean up the parent Experiment directory component and better describe what we're doing.
* This may also prevent the experiment directory cells from flickering when data changes.


<!-- Describe your changes in detail. -->
<!-- Remember to include context: Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- Delete any bullet points that don't apply and add more details if needed. -->

- Automated tests that cover added/changed functionality
- Manual testing with production data (locally)
- Manual testing with mock data (locally or on Vercel)
- Additional manual testing instructions (please specify):
